### PR TITLE
Feature/20260507 05

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -25,13 +25,15 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-restclient")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("org.postgresql:postgresql")
     annotationProcessor("org.projectlombok:lombok")
+    implementation("org.jsoup:jsoup:1.18.1")
     testImplementation("org.springframework.boot:spring-boot-starter-batch-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-validation-test")

--- a/backend/src/main/java/org/cathori/backend/CathoriApplication.java
+++ b/backend/src/main/java/org/cathori/backend/CathoriApplication.java
@@ -2,8 +2,10 @@ package org.cathori.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CathoriApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/org/cathori/backend/notice/application/AiPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/AiPort.java
@@ -1,0 +1,10 @@
+package org.cathori.backend.notice.application;
+
+
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+
+import java.util.List;
+
+public interface AiPort {
+    AiSummaryResult summarize(String bodyText, List<String> ImgUrl);
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/CrawledNotice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/CrawledNotice.java
@@ -1,0 +1,29 @@
+package org.cathori.backend.notice.application;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+
+/**
+ * 크롤러가 수집한 공지 데이터를 담는 DTO
+ *
+ * JsoupCrawler 학교 사이트에서 파싱한 결과를 담아 반환한다.
+ * NoticeService 에서 Notice 엔티티로 변환된다.
+ */
+@Getter
+@Builder
+public class CrawledNotice {
+
+    private String articleNo;
+    private String category;
+    private String title;
+    private String department;
+    private String postedAt;
+    private String url;
+    private String bodyText;
+    private List<String> imageUrls;
+    private String sourceType;
+    private String sourceId;
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/CrawlerPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/CrawlerPort.java
@@ -1,0 +1,21 @@
+package org.cathori.backend.notice.application;
+
+import java.util.List;
+
+
+/**
+ * 가톨릭대 공지사항 크롤러 인터페이스
+ *
+ * 크롤러 구현체(JsoupCrawler)와 서비스(NoticeService) 사이의 계약을 정의한다.
+ * NoticeService는 이 인터페이스만 바라보기 때문에,
+ * 나중에 크롤러 구현체를 교체하거나 추가해도 NoticeService 코드는 건드리지 않아도 된다.
+ *
+ * @param sourceType 출처 유형 (예: "MAIN")
+ * @param sourceId   학과 공지의 경우 학과 코드, 메인 공지는 null
+ * @param lastArticleNo DB에 저장된 가장 최신 articleNo. 이 값 이하의 공지는 수집하지 않는다.
+ *                      0이면 중단 조건 없이 전체 수집 (최초 실행 시)
+ * @return 새로 수집된 공지 목록 (이미 저장된 공지 제외)
+ */
+public interface CrawlerPort {
+    List<CrawledNotice> crawl(String sourceType, String sourceId, int lastArticleNo);
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeService.java
@@ -1,0 +1,76 @@
+package org.cathori.backend.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cathori.backend.notice.infra.NoticeSummaryUpdater;
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final CrawlerPort crawlerPort;
+    private final AiPort aiPort;
+    private final NoticeRepository noticeRepository;
+    private final NoticeSummaryUpdater noticeSummaryUpdater;
+
+    public List<CrawledNotice> crawl(String sourceType, String sourceId) {
+        int lastArticleNo = noticeRepository.findMaxArticleNo(sourceType, sourceId)
+                .orElse(0);
+
+        return crawlerPort.crawl(sourceType, sourceId, lastArticleNo);
+    }
+
+    @Transactional
+    public List<Long> save(List<CrawledNotice> crawledList) {
+        List<Notice> notices = crawledList.stream()
+                .map(Notice::from)
+                .toList();
+
+        return noticeRepository.saveAll(notices).stream()
+                .map(Notice::getId)
+                .toList();
+    }
+
+    public void summarize(List<Long> noticeIds) {
+        if (noticeIds.isEmpty()) return;
+
+        List<Notice> notices = noticeRepository.findAllById(noticeIds);
+        for (Notice notice : notices) {
+            if (notice.getBodyText() == null) continue;
+            try {
+                AiSummaryResult result = aiPort.summarize(notice.getBodyText(), notice.getImageUrls());
+                noticeSummaryUpdater.applyResult(notice.getId(), result);
+            } catch (Exception e) {
+                log.warn("AI 요약 실패 noticeId={}", notice.getId(), e);
+                noticeSummaryUpdater.applyFailed(notice.getId());
+            }
+        }
+    }
+
+    public void retrySummary() {
+        List<Notice> notices = noticeRepository.findTop15ForSummary(
+                List.of("PENDING", "FAILED"),
+                PageRequest.of(0, 15)
+        );
+
+        for (Notice notice : notices) {
+            if (notice.getBodyText() == null) continue;
+            try {
+                AiSummaryResult result = aiPort.summarize(notice.getBodyText(), notice.getImageUrls());
+                noticeSummaryUpdater.applyResult(notice.getId(), result);
+            } catch (Exception e) {
+                log.warn("AI 요약 실패 noticeId={}", notice.getId(), e);
+                noticeSummaryUpdater.applyFailed(notice.getId());
+            }
+        }
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeSummaryUpdater.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeSummaryUpdater.java
@@ -1,0 +1,27 @@
+package org.cathori.backend.notice.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeSummaryUpdater {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public void applyResult(Long noticeId, AiSummaryResult result) {
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow();
+        notice.applySummary(result);
+    }
+
+    @Transactional
+    public void applyFailed(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow();
+        notice.markSummaryFailed();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/RetryScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/RetryScheduler.java
@@ -1,0 +1,18 @@
+package org.cathori.backend.notice.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.application.NoticeService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RetryScheduler {
+
+    private final NoticeService noticeService;
+
+    @Scheduled(cron = "0 30 * * * *")
+    public void retryFailedSummaries() {
+        noticeService.retrySummary();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/ai/AiSummaryResult.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/ai/AiSummaryResult.java
@@ -1,0 +1,5 @@
+package org.cathori.backend.notice.infra.ai;
+
+import java.util.List;
+
+public record AiSummaryResult(List<String> summary, String deadline) {}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/ai/GeminiAiAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/ai/GeminiAiAdapter.java
@@ -1,0 +1,142 @@
+package org.cathori.backend.notice.infra.ai;
+
+import org.cathori.backend.notice.application.AiPort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GeminiAiAdapter implements AiPort {
+
+    private static final String GEMINI_BASE_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=";
+
+    private static final String PROMPT_TEMPLATE = """
+            다음은 대학교 공지사항 본문입니다. 분석하여 아래 JSON 형식으로 응답하세요.
+            {
+              "summary": ["핵심 내용 1", "핵심 내용 2", "핵심 내용 3"],
+              "deadline": "YYYY-MM-DD 또는 null"
+            }
+            규칙:
+            - summary: 공지의 핵심 내용을 3개 이하 bullet point로 요약 (한국어)
+            - deadline: 마감일/신청마감/접수기간 종료일이 있으면 YYYY-MM-DD, 없으면 null
+
+            본문:
+            """;
+
+    private final RestClient restClient;
+    private final ObjectMapper mapper;
+    private final String apiKey;
+    private final HttpClient httpClient;
+
+    public GeminiAiAdapter(
+            RestClient.Builder builder,
+            ObjectMapper mapper,
+            @Value("${gemini.api.key}") String apiKey
+    ) {
+        this.restClient = builder.build();
+        this.mapper = mapper;
+        this.apiKey = apiKey;
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    @Override
+    public AiSummaryResult summarize(String bodyText, List<String> imageUrls) {
+        Map<String, Object> requestBody = buildRequestBody(bodyText, imageUrls);
+
+        String responseJson = restClient.post()
+                .uri(GEMINI_BASE_URL + apiKey)
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .retrieve()
+                .body(String.class);
+
+        return parseResponse(responseJson);
+    }
+
+    private Map<String, Object> buildRequestBody(String bodyText, List<String> imageUrls) {
+        List<Map<String, Object>> parts = new ArrayList<>();
+
+        Map<String, Object> textPart = new HashMap<>();
+        textPart.put("text", PROMPT_TEMPLATE + bodyText);
+        parts.add(textPart);
+
+        for (String url : imageUrls) {
+            byte[] imageBytes = downloadImage(url); // 실패 시 RuntimeException throw
+            String base64 = Base64.getEncoder().encodeToString(imageBytes);
+
+            Map<String, String> inlineData = new HashMap<>();
+            inlineData.put("mime_type", "image/jpeg");
+            inlineData.put("data", base64);
+
+            Map<String, Object> imagePart = new HashMap<>();
+            imagePart.put("inline_data", inlineData);
+            parts.add(imagePart);
+        }
+
+        Map<String, Object> content = new HashMap<>();
+        content.put("parts", parts);
+
+        Map<String, String> generationConfig = new HashMap<>();
+        generationConfig.put("responseMimeType", "application/json");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("contents", List.of(content));
+        body.put("generationConfig", generationConfig);
+        return body;
+    }
+
+    private AiSummaryResult parseResponse(String responseJson) {
+        try {
+            JsonNode root = mapper.readTree(responseJson);
+            String innerJson = root.path("candidates").get(0)
+                    .path("content").path("parts").get(0)
+                    .path("text").asText();
+
+            JsonNode summaryJson = mapper.readTree(innerJson);
+
+            List<String> summary = mapper.convertValue(
+                    summaryJson.path("summary"), new TypeReference<List<String>>() {});
+
+            JsonNode deadlineNode = summaryJson.path("deadline");
+            String deadline = (deadlineNode.isNull() || deadlineNode.asText().equals("null"))
+                    ? null : deadlineNode.asText();
+
+            return new AiSummaryResult(summary, deadline);
+        } catch (Exception e) {
+            throw new RuntimeException("Gemini 응답 파싱 실패", e);
+        }
+    }
+
+    private byte[] downloadImage(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .GET()
+                    .build();
+            HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("이미지 다운로드 실패: status=" + response.statusCode() + ", url=" + url);
+            }
+            return response.body();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("이미지 다운로드 실패: url=" + url, e);
+        }
+    }
+
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
@@ -1,0 +1,210 @@
+package org.cathori.backend.notice.infra.crawler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.application.CrawlerPort;
+import org.cathori.backend.notice.infra.crawler.format.NoticeDetails;
+import org.cathori.backend.notice.infra.crawler.format.NoticeRow;
+import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
+import org.cathori.backend.notice.infra.crawler.source.MainSource;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Component
+public class CatholicNoticeCrawler implements CrawlerPort {
+
+
+    /**
+     * 가톨릭대 공지사항 목록 페이지를 크롤링해 새 공지를 수집한다.
+     *
+     * @param sourceType    공지 출처 유형 (예: "MAIN")
+     * @param sourceId      학과 공지의 경우 학과 코드, 메인 공지는 null
+     * @param lastArticleNo DB에 저장된 가장 최신 articleNo. 이 값 이하의 공지는 수집하지 않는다.
+     * @return 새로 수집된 공지 목록
+     */
+    @Override
+    public List<CrawledNotice> crawl(String sourceType, String sourceId, int lastArticleNo) {
+        String targetUrl = getCrawlTargetUrl(sourceType, sourceId);
+        List<CrawledNotice> result = new ArrayList<>();
+
+        Document targetPageDoc;
+        try {
+            targetPageDoc = Jsoup.connect(targetUrl).get();
+            log.info("HTML 수신 성공 - sourceType: {}, sourceId: {}, 길이: {}", sourceType, sourceId, targetPageDoc.html().length());
+        } catch (IOException e) {
+            log.warn("크롤링 연결 실패: {}", e.getMessage());
+            return result;
+        }
+
+        Elements rows = targetPageDoc.select("table tbody tr");
+
+        for (Element row : rows) {
+            try {
+                NoticeRow parsed = parseNoticeRow(row, targetUrl);
+                if (parsed == null) continue;
+
+                int articleNo = Integer.parseInt(parsed.articleNo());
+                if (lastArticleNo > 0 && articleNo <= lastArticleNo) break;
+
+                NoticeDetails detail = crawlNoticeDetail(parsed.noticeDetailsUrl());
+                result.add(CrawledNotice.builder()
+                        .articleNo(parsed.articleNo())
+                        .category(parsed.category())
+                        .title(parsed.title())
+                        .department(parsed.department())
+                        .postedAt(parsed.postedAt())
+                        .url(parsed.noticeDetailsUrl())
+                        .bodyText(detail.bodyText())
+                        .imageUrls(detail.imageUrls())
+                        .sourceType(sourceType)
+                        .sourceId(sourceId)
+                        .build());
+
+                log.debug("본문 수집 - articleNo: {}, 본문길이: {}, 이미지수: {}",
+                        parsed.articleNo(), detail.bodyText().length(), detail.imageUrls().size());
+            } catch (Exception e) {
+                log.warn("공지 파싱 실패 (스킵): {}", e.getMessage());
+            }
+        }
+
+        return result;
+    }
+    /**
+     * tr 한 행을 파싱해 NoticeRow로 변환한다.
+     * a.b-title이 없으면 null 반환 (공지 행이 아닌 경우 skip)
+     * articleNo 추출 실패 시 null 반환
+     *
+     * @param row       파싱할 tr 요소
+     * @param targetUrl 공지 목록 페이지 URL (상세 URL 조합에 사용)
+     * @return 파싱된 NoticeRow. 유효하지 않은 행이면 null
+     */
+    private NoticeRow parseNoticeRow(Element row, String targetUrl) {
+        Element titleLink = row.selectFirst("a.b-title");
+        if (titleLink == null) return null;
+
+        String href = titleLink.attr("href");
+        String articleNo = extractQueryParam(href, "articleNo");
+        if (articleNo == null) return null;
+
+        String category = firstNonEmpty(row, "td.b-cate", "span.b-cate");
+        String title = titleLink.text().trim();
+        String department = extractText(row, "span.b-writer");
+        String postedAt = extractText(row, "span.b-date").replace(".", "-");
+        String noticeDetailsUrl = targetUrl + href;
+
+        return new NoticeRow(articleNo, category, title, department, postedAt, noticeDetailsUrl);
+    }
+
+    /**
+     * 공지 상세 페이지에 접근해 본문 텍스트와 이미지 URL을 수집한다.
+     * 접근 실패 시 빈 본문과 빈 이미지 목록을 담은 NoticeDetails 반환.
+     *
+     * @param url 공지 상세 페이지 URL
+     * @return 본문 텍스트와 이미지 URL 목록을 담은 NoticeDetails
+     */
+    private NoticeDetails crawlNoticeDetail(String url) {
+        try {
+            Document doc = Jsoup.connect(url).get();
+
+            String bodyText = doc.select("div.fr-view p").stream()
+                    .map(Element::text)
+                    .filter(t -> !t.isBlank())
+                    .collect(Collectors.joining("\n"));
+
+            List<String> imageUrls = doc.select("div.fr-view img").stream()
+                    .map(img -> img.attr("src"))
+                    .filter(src -> !src.isBlank())
+                    .map(src -> src.startsWith("/") ? "https://www.catholic.ac.kr" + src : src)
+                    .collect(Collectors.toList());
+
+            return new NoticeDetails(bodyText, imageUrls);
+
+        } catch (IOException e) {
+            log.warn("상세 페이지 크롤링 실패 (url={}): {}", url, e.getMessage());
+            return new NoticeDetails("", List.of());
+        }
+    }
+
+    /**
+     * sourceType에 따라 크롤링 대상 URL을 반환한다.
+     * DEPARTMENT면 DepartmentSource에서 해당 학과 URL을 조회하고,
+     * MAIN이면 메인 공지사항 목록 URL을 반환한다.
+     *
+     * @param sourceType 공지 출처 유형 ("MAIN" / "DEPARTMENT")
+     * @param sourceId   학과 공지의 경우 DepartmentSource enum 상수명, 메인 공지는 null
+     * @return 크롤링 대상 URL
+     */
+    private String getCrawlTargetUrl(String sourceType, String sourceId) {
+        if ("DEPARTMENT".equals(sourceType)) {
+            return DepartmentSource.valueOf(sourceId).getUrl();
+        }
+        return MainSource.MAIN.getUrl();
+    }
+
+
+    /**
+     * 공지 href에서 articleNo 값을 추출할 때 사용한다.
+     * 예: "?articleNo=269669&mode=view&articleLimit=10" → "269669"
+     *
+     * 범용 구현이라 articleNo 외 다른 파라미터도 추출 가능하다.
+     *
+     * @param url  쿼리 파라미터가 포함된 URL (공지 href)
+     * @param name 추출할 파라미터 이름 (현재는 "articleNo"만 사용)
+     * @return 파라미터 값. 없으면 null
+     */
+    private String extractQueryParam(String url, String name) {
+        int q = url.indexOf('?');
+        if (q < 0) return null;
+        for (String kv : url.substring(q + 1).split("&")) {
+            String[] parts = kv.split("=", 2);
+            if (parts.length == 2 && name.equals(parts[0])) return parts[1];
+        }
+        return null;
+    }
+
+    /**
+     * 주어진 selector 목록 중 텍스트가 있는 첫 번째 요소의 텍스트를 반환한다.
+     * 모두 비어있으면 빈 문자열 반환.
+     *
+     * @param parent    탐색 기준 요소
+     * @param selectors 순서대로 시도할 CSS selector 목록
+     * @return 찾은 텍스트 또는 빈 문자열
+     */
+    private String firstNonEmpty(Element parent, String... selectors) {
+        for (String sel : selectors) {
+            Element el = parent.selectFirst(sel);
+            if (el != null && !el.text().isBlank()) return el.text().trim();
+        }
+        return "";
+    }
+
+    /**
+     * 들어온 parent 태그 안에서, selector 조건에 맞는 첫 번째 태그를 찾아서, 그 태그의 텍스트를 반환하는 함수
+     * 요소가 없으면 빈 문자열 반환.
+     *<br>
+     * 예시:
+     *   parent = <tr>...<span class="b-writer">교수학습개발원</span>...</tr>
+     *   selector = "span.b-writer"
+     *   반환값 = "교수학습개발원"
+     **<br>
+     * @param parent   탐색 기준 요소
+     * @param selector CSS selector
+     * @return 찾은 텍스트 또는 빈 문자열
+     */
+    private String extractText(Element parent, String selector) {
+        Element el = parent.selectFirst(selector);
+        return el != null ? el.text().trim() : "";
+    }
+    
+
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
@@ -1,0 +1,44 @@
+package org.cathori.backend.notice.infra.crawler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.application.NoticeService;
+import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CrawlingScheduler {
+
+    private final NoticeService noticeService;
+
+    @Scheduled(cron = "0 0 0,12 * * *") // 12시간에 한번
+    public void scheduleCrawling() {
+        log.info("크롤링 시작");
+        int total = 0;
+
+
+        List<CrawledNotice> mainList = noticeService.crawl("MAIN", null);
+        List<Long> mainIds = noticeService.save(mainList);
+        noticeService.summarize(mainIds);
+        total += mainList.size();
+
+        for (DepartmentSource department : DepartmentSource.values()) {
+            try {
+                List<CrawledNotice> deptList = noticeService.crawl("DEPARTMENT", department.name());
+                List<Long> deptIds = noticeService.save(deptList);
+                noticeService.summarize(deptIds);
+                total += deptList.size();
+            } catch (Exception e) {
+                log.warn("학과 크롤링 실패, 스킵: {} - {}", department.getDisplayName(), e.getMessage());
+            }
+        }
+
+        log.info("크롤링 완료. 총 수집 건수: {}", total);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/format/NoticeDetails.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/format/NoticeDetails.java
@@ -1,0 +1,6 @@
+package org.cathori.backend.notice.infra.crawler.format;
+
+import java.util.List;
+
+public record NoticeDetails(String bodyText, List<String> imageUrls) {
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/format/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/format/NoticeRow.java
@@ -1,0 +1,21 @@
+package org.cathori.backend.notice.infra.crawler.format;
+
+/***
+ * 공지 목록 페이지에서
+ *
+ * @param articleNo
+ * @param category
+ * @param title
+ * @param department
+ * @param postedAt
+ * @param noticeDetailsUrl
+ */
+
+public record NoticeRow(
+        String articleNo,
+        String category,
+        String title,
+        String department,
+        String postedAt,
+        String noticeDetailsUrl
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/source/DepartmentSource.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/source/DepartmentSource.java
@@ -1,0 +1,86 @@
+package org.cathori.backend.notice.infra.crawler.source;
+
+public enum DepartmentSource {
+
+    // 기본 패턴: https://{code}.catholic.ac.kr/{code}/community/notice.do
+    BUSINESS("business", "경영학과"),
+    ACCOUNTING("accounting", "회계학과"),
+    GBS("gbs", "국제경영학과"),
+    BIOTECH("biotech", "생명공학"),
+    BMCE("bmce", "바이오메디컬화학공학"),
+    AIBME("aibme", "AI의공학"),
+    MBS("mbs", "의생명과학"),
+    BMSW("bmsw", "바이오메디컬소프트웨어"),
+    CSIE("csie", "컴퓨터정보공학"),
+    MTC("mtc", "미디어기술컨텐츠"),
+    ICE("ice", "정보통신전자공학"),
+    AI("ai", "인공지능"),
+    DATASCIENCE("datascience", "데이터사이언스"),
+    PHARMACY("pharmacy", "약학"),
+    KOREAN("korean", "국어국문"),
+    PHILOSOPHY("philosophy", "철학"),
+    KOREANHISTORY("koreanhistory", "국사"),
+    ENGLISH("english", "영어영문"),
+    CN("cn", "중국언어문화"),
+    FRENCH("french", "프랑스어문화"),
+    SOCIALWELFARE("socialwelfare", "사회복지"),
+    PSYCHOLOGY("psychology", "심리"),
+    SOCIOLOGY("sociology", "사회"),
+    CHILDREN("children", "아동"),
+    SPED("sped", "특수교육"),
+    IS("is", "국제학부"),
+    LAW("law", "법학"),
+    ECONOMICS("economics", "경제"),
+    PA("pa", "행정"),
+    GLOBALBIZ("globalbiz", "글로벌경영"),
+    KLC("klc", "한국어문화"),
+    CHEMISTRY("chemistry", "화학"),
+    MATH("math", "수학"),
+    PHYSICS("physics", "물리"),
+    ENVI("envi", "에너지환경공학"),
+    DESIGN("design", "공간디자인소비자"),
+    CLOTHING("clothing", "의류"),
+    FN("fn", "식품영양"),
+    MUSIC("music", "음악"),
+    VOICE("voice", "성악"),
+    GAMC("gamc", "예술미디어융합"),
+    TEACHING("teaching", "교직"),
+    LIBERAL("liberal", "자유전공"),
+
+    // 예외 패턴: URL 직접 지정
+    JAPANESE("japanese", "일어일본문화",
+            "https://japanese.catholic.ac.kr/japanese/major/notice.do"),
+    CUK_COLLEGE("catholic-college", "CUK 특화 학부대학",
+            "https://catholic-college.catholic.ac.kr/catholic_college/notification/notice.do"),
+    MAJOR_CONVERGENCE("major-convergence", "융합전공",
+            "https://major-convergence.catholic.ac.kr/major_convergence/notice/notice.do");
+
+    private static final String BASE_URL_TEMPLATE =
+            "https://%s.catholic.ac.kr/%s/community/notice.do";
+
+    private final String code;
+    private final String displayName;
+    private final String customUrl;
+
+    DepartmentSource(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+        this.customUrl = null;
+    }
+
+    DepartmentSource(String code, String displayName, String customUrl) {
+        this.code = code;
+        this.displayName = displayName;
+        this.customUrl = customUrl;
+    }
+
+    public String getUrl() {
+        if (customUrl != null) {
+            return customUrl;
+        }
+        return String.format(BASE_URL_TEMPLATE, code, code);
+    }
+
+    public String getCode() { return code; }
+    public String getDisplayName() { return displayName; }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/source/MainSource.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/source/MainSource.java
@@ -1,0 +1,11 @@
+package org.cathori.backend.notice.infra.crawler.source;
+
+public enum MainSource {
+    MAIN("https://www.catholic.ac.kr/ko/campuslife/notice.do");
+
+    private final String url;
+
+    MainSource(String url) { this.url = url; }
+
+    public String getUrl() { return url; }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
@@ -1,0 +1,127 @@
+package org.cathori.backend.notice.model;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@Entity
+@Table(name = "notices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String articleNo;
+
+    @Column(nullable = false, length = 20)
+    private String sourceType;
+
+    @Column(length = 20)
+    private String sourceId;
+
+    @Column(nullable = false, length = 20)
+    private String category;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "text")
+    private String bodyText;
+
+    @Column(columnDefinition = "text")
+    private String imageUrlsJson;
+
+    @Column(columnDefinition = "text")
+    private String aiSummary;
+
+    @Column(nullable = false, length = 20)
+    private String aiSummaryStatus = "PENDING";
+
+    @Column(nullable = false, length = 30)
+    private String department;
+
+    @Column(nullable = false)
+    private LocalDate postedAt;
+
+    @Column
+    private LocalDate deadlineAt;
+
+    @Column(nullable = false, length = 500)
+    private String url;
+
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public List<String> getImageUrls() {
+        if (imageUrlsJson == null || imageUrlsJson.isBlank()) return List.of();
+        try {
+            return List.of(MAPPER.readValue(imageUrlsJson, String[].class));
+        } catch (JacksonException e) {
+            return List.of();
+        }
+    }
+
+    public void applySummary(AiSummaryResult result) {
+        try {
+            this.aiSummary = MAPPER.writeValueAsString(result.summary());
+        } catch (JacksonException e) {
+            this.aiSummary = "[]";
+        }
+        if (result.deadline() != null && !result.deadline().equals("null")) {
+            try {
+                this.deadlineAt = LocalDate.parse(result.deadline());
+            } catch (DateTimeParseException ignored) {}
+        }
+        this.aiSummaryStatus = "SUCCESS";
+    }
+
+    public void markSummaryFailed() {
+        this.aiSummaryStatus = "FAILED";
+    }
+
+    public static Notice from(CrawledNotice crawled) {
+        Notice notice = new Notice();
+        notice.articleNo = crawled.getArticleNo();
+        notice.sourceType = crawled.getSourceType();
+        notice.sourceId = crawled.getSourceId();
+        notice.category = crawled.getCategory();
+        notice.title = crawled.getTitle();
+        notice.department = crawled.getDepartment();
+        notice.postedAt = LocalDate.parse(crawled.getPostedAt());
+        notice.url = crawled.getUrl();
+        notice.bodyText = crawled.getBodyText();
+        try {
+            notice.imageUrlsJson = MAPPER.writeValueAsString(crawled.getImageUrls());
+        } catch (JacksonException e) {
+            notice.imageUrlsJson = "[]";
+        }
+        notice.aiSummaryStatus = "PENDING";
+        notice.viewCount = 0L;
+        return notice;
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
@@ -1,0 +1,22 @@
+package org.cathori.backend.notice.model;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    boolean existsByArticleNo(String articleNo);
+
+    @Query(value = "SELECT MAX(CAST(article_no AS INTEGER)) FROM notices" +
+            " WHERE source_type = :sourceType AND (source_id = :sourceId OR source_id IS NULL)",
+            nativeQuery = true)
+    Optional<Integer> findMaxArticleNo(@Param("sourceType") String sourceType, @Param("sourceId") String sourceId);
+
+    @Query("SELECT n FROM Notice n WHERE n.aiSummaryStatus IN :statuses ORDER BY n.id ASC")
+    List<Notice> findTop15ForSummary(@Param("statuses") List<String> statuses, Pageable pageable);
+}


### PR DESCRIPTION
## 🔧 작업 내용

크롤링 → 저장 → AI 요약 파이프라인 구현

- `CrawlerPort` / `AiPort` — application 레이어 인터페이스 정의
- `CrawledNotice` — 크롤러 결과를 담는 DTO
- `CatholicNoticeCrawler` — Jsoup 기반 크롤러 구현체. 목록 페이지 파싱 + 상세 페이지 본문/이미지 수집
- `GeminiAiAdapter` — Gemini API 호출 구현체. 본문 텍스트 + 이미지(inline_data base64) 멀티모달 요약
- `Notice` 엔티티 + `NoticeRepository` — 공지 저장 및 조회
- `NoticeService` — crawl / save / summarize / retrySummary 흐름 조율
- `CrawlingScheduler` — 12시간 주기 크롤링 스케줄러 (메인 + 전체 학과)
- `RetryScheduler` — 30분 주기 AI 요약 실패 재시도 (PENDING/FAILED 상태 15건 배치)
- `DepartmentSource` / `MainSource` — 크롤링 대상 URL enum 관리

## 🔍 동작 방식

```
CrawlingScheduler (12h)
  → NoticeService.crawl()       // lastArticleNo 조회 후 CrawlerPort에 전달
  → NoticeService.save()        // CrawledNotice → Notice 변환 후 저장
  → NoticeService.summarize()   // Gemini API 호출, 결과 반영

RetryScheduler (30min)
  → NoticeService.retrySummary() // PENDING/FAILED 상태 15건 재시도
```

## 💡 설계 근거

- `CrawlerPort` / `AiPort`를 인터페이스로 분리한 이유 — `NoticeService`가 구현체(Jsoup, Gemini)를 직접 의존하지 않게 해서 레이어 경계 유지. 나중에 크롤러나 AI 구현체를 교체해도 서비스 코드는 건드리지 않아도 됨
- `@Scheduled`를 `NoticeService`가 아닌 `CrawlingScheduler` / `RetryScheduler`에 배치한 이유 — `@Scheduled`는 인프라 관심사. 서비스 레이어에 스케줄링 어노테이션을 두면 레이어 경계가 무너짐
- AI 요약 실패 시 re-crawl 대신 DB 저장 후 재시도로 설계한 이유 — Gemini API 실패는 일시적 오류일 가능성이 높음. 크롤링을 다시 하면 학교 서버 부하 및 차단 리스크가 올라감. 이미 저장된 본문으로 재시도하는 게 더 안전함
- `DepartmentSource`에 URL 예외 패턴(JAPANESE, CUK_COLLEGE, MAJOR_CONVERGENCE) 별도 처리 — 대부분의 학과는 `https://{code}.catholic.ac.kr/{code}/community/notice.do` 패턴을 따르지만 일부 학과는 URL 구조가 다름. enum 생성자 오버로드로 예외 케이스 수용

## ✅ 체크리스트

- [x] CrawlerPort / AiPort 인터페이스와 구현체 분리 확인
- [x] @Scheduled 위치가 infra 레이어(Scheduler)에만 있는지 확인
- [x] AI 요약 실패 시 FAILED 상태로 저장되고 RetryScheduler가 재시도하는 흐름 확인
- [x] DepartmentSource URL 예외 패턴 3개 별도 처리 확인

## 🔗 연관 이슈

closes #