### PR TITLE
[feat] #8 글로벌 예외처리 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/common/exception/BusinessException.java
+++ b/backend/src/main/java/org/cathori/backend/common/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package org.cathori.backend.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/org/cathori/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/common/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package org.cathori.backend.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/backend/src/main/java/org/cathori/backend/common/exception/ErrorResponse.java
+++ b/backend/src/main/java/org/cathori/backend/common/exception/ErrorResponse.java
@@ -1,0 +1,8 @@
+package org.cathori.backend.common.exception;
+
+public record ErrorResponse(String code, String message) {
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/cathori/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package org.cathori.backend.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("BusinessException: code={}, message={}", errorCode.getCode(), errorCode.getMessage());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.from(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다");
+        log.warn("Validation failed: {}", message);
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse("INVALID_INPUT", message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity
+                .internalServerError()
+                .body(new ErrorResponse("INTERNAL_ERROR", "서버 내부 오류가 발생했습니다"));
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeErrorCode.java
@@ -1,0 +1,33 @@
+package org.cathori.backend.notice.application;
+
+import org.cathori.backend.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum NoticeErrorCode implements ErrorCode {
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_NOT_FOUND", "존재하지 않는 공지입니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    NoticeErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/tag/TagErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/tag/TagErrorCode.java
@@ -1,0 +1,36 @@
+package org.cathori.backend.tag;
+
+import org.cathori.backend.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum TagErrorCode implements ErrorCode {
+
+    TAG_DUPLICATE(HttpStatus.CONFLICT, "TAG_DUPLICATE", "이미 존재하는 태그입니다"),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG_NOT_FOUND", "태그를 찾을 수 없습니다"),
+    TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TAG_LIMIT_EXCEEDED", "태그 개수 한도를 초과했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    TagErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/UserErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/user/UserErrorCode.java
@@ -1,0 +1,38 @@
+package org.cathori.backend.user;
+
+import org.cathori.backend.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorCode implements ErrorCode {
+    USER_EMAIL_DUPLICATE(HttpStatus.CONFLICT, "USER_EMAIL_DUPLICATE", "이미 사용중인 이메일입니다"),
+    USER_INVALID_VERIFY_CODE(HttpStatus.BAD_REQUEST, "USER_INVALID_VERIFY_CODE", "인증번호가 올바르지 않습니다"),
+    USER_VERIFY_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "USER_VERIFY_CODE_EXPIRED", "인증번호가 만료되었습니다"),
+    USER_NOT_VERIFIED(HttpStatus.FORBIDDEN, "USER_NOT_VERIFIED", "이메일 인증이 완료되지 않았습니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "존재하지 않는 사용자입니다"),
+    USER_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER_INVALID_PASSWORD", "비밀번호가 올바르지 않습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    UserErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용

글로벌 예외처리 구조 구현 및 도메인별 ErrorCode 정의

- `ErrorCode` 인터페이스 — status, code, message 3개 메서드 정의
- `BusinessException` — ErrorCode를 wrapping하는 비즈니스 예외 최상위 클래스
- `ErrorResponse` — 에러 응답 포맷 (code, message 2필드 record)
- `GlobalExceptionHandler` — BusinessException, MethodArgumentNotValidException, Exception 3가지 핸들링
- `NoticeErrorCode` — NOTICE_NOT_FOUND
- `TagErrorCode` — TAG_DUPLICATE, TAG_NOT_FOUND, TAG_LIMIT_EXCEEDED
- `UserErrorCode` — USER_EMAIL_DUPLICATE, USER_INVALID_VERIFY_CODE, USER_VERIFY_CODE_EXPIRED, USER_NOT_VERIFIED, USER_NOT_FOUND, USER_INVALID_PASSWORD

## 🔍 동작 방식

서비스 레이어에서 비즈니스 규칙 위반 시 `BusinessException(ErrorCode)`를 throw
→ `GlobalExceptionHandler`가 catch
→ `ErrorResponse.from(errorCode)`로 변환
→ ErrorCode에 정의된 HTTP status로 응답 반환

## 💡 설계 근거

- `ErrorCode`를 interface로 정의한 이유 — 도메인별로 enum이 각자 구현하게 해서 에러코드를 도메인 단위로 관리. 하나의 enum에 전부 몰아넣으면 도메인 경계가 흐려짐
- 성공 응답에 wrapper 없음 — 불필요한 중첩 구조 제거, 에러 응답만 code + message로 통일
- `MethodArgumentNotValidException` 별도 처리 — `@Valid` 검증 실패는 Spring이 던지는 예외라 BusinessException 흐름을 탈 수 없어서 따로 핸들링

## ✅ 체크리스트

- [x] ErrorCode 인터페이스 구조 설계대로 구현됨
- [x] GlobalExceptionHandler 3가지 케이스 핸들링 확인
- [x] 도메인별 ErrorCode enum 정의 완료
- [ ] TODO: ErrorCode enum getter 빈값 반환 버그 수정 필요 (`return null`, `return ""` 하드코딩 — 다음 PR에서 수정)

## 🔗 연관 이슈

closes #