### PR TITLE
[FEAT] 기본 공통 컴포넌트 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "@types/react": "~19.1.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
-    "jest": "^30.4.2",
+    "jest": "~29.7.0",
     "react-test-renderer": "^19.2.6",
     "ts-jest": "^29.4.9",
     "typescript": "~5.9.2"

--- a/frontend/src/features/notices/components/CategoryBadge.tsx
+++ b/frontend/src/features/notices/components/CategoryBadge.tsx
@@ -1,0 +1,43 @@
+/**
+ * CategoryBadge — 카테고리 뱃지 컴포넌트
+ * 시안: Primary 10% 배경 (#00288C1A) + Primary 텍스트
+ * cornerRadius 4, padding [4, 10], fontSize 10, fontWeight 700
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import type { NoticeCategory } from '@/src/types/api';
+
+interface CategoryBadgeProps {
+  category: NoticeCategory;
+}
+
+function CategoryBadgeComponent({ category }: CategoryBadgeProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{category}</Text>
+    </View>
+  );
+}
+
+export const CategoryBadge = React.memo(CategoryBadgeComponent);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.categoryBadgeBg,
+    borderRadius: 4,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    alignSelf: 'flex-start',
+  },
+  text: {
+    fontFamily: 'Pretendard',
+    fontSize: 10,
+    fontWeight: '700',
+    color: Colors.categoryBadgeText,
+    letterSpacing: -0.25,
+    lineHeight: 15,
+  },
+});

--- a/frontend/src/features/notices/components/CategoryTab.tsx
+++ b/frontend/src/features/notices/components/CategoryTab.tsx
@@ -1,0 +1,115 @@
+/**
+ * CategoryTab — 대분류 태그 탭 컴포넌트
+ * pencil.dev 시안: pill 버튼, 수평 배치, gap 8
+ * 미선택: #EEEEEE 배경 + #44465299 텍스트
+ * 선택: #00288C 배경 + #FFFFFF 텍스트
+ * padding [8, 20], borderRadius 9999, fontSize 14, fontWeight 600
+ */
+
+import React, { useCallback } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import type { NoticeCategory } from '@/src/types/api';
+
+interface CategoryTabProps {
+  /** 대분류 카테고리 목록 */
+  categories: NoticeCategory[];
+  /** 현재 선택된 카테고리 */
+  selectedCategory: NoticeCategory;
+  /** 카테고리 변경 콜백 */
+  onSelect: (category: NoticeCategory) => void;
+}
+
+function CategoryTabComponent({
+  categories,
+  selectedCategory,
+  onSelect,
+}: CategoryTabProps) {
+  return (
+    <View style={styles.wrapper}>
+      <ScrollView
+        horizontal // 가로 방향 스크롤
+        showsHorizontalScrollIndicator={false} // 스크롤 바 숨기기
+        contentContainerStyle={styles.container}
+      >
+        {categories.map((category) => {
+          const isSelected = category === selectedCategory;
+          return (
+            <TabButton
+              key={category}
+              label={category}
+              isSelected={isSelected}
+              onPress={() => onSelect(category)}
+            />
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+export const CategoryTab = React.memo(CategoryTabComponent);
+
+// ─── 개별 탭 버튼 ────────────────────────────────────────────────────
+
+interface TabButtonProps {
+  label: string;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+function TabButtonComponent({ label, isSelected, onPress }: TabButtonProps) {
+  const handlePress = useCallback(() => {
+    onPress();
+  }, [onPress]);
+
+  return (
+    <TouchableOpacity // 투명도가 변하는 커스텀 버튼
+      style={[styles.button, isSelected && styles.buttonSelected]}
+      onPress={handlePress}
+      activeOpacity={0.7}
+    >
+      <Text style={[styles.buttonText, isSelected && styles.buttonTextSelected]}>
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+// 스크롤 내, 개별 탭 별로 메모이제이션 적용
+const TabButton = React.memo(TabButtonComponent);
+
+const styles = StyleSheet.create({
+  wrapper: {
+    paddingTop: 16,
+  },
+  container: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 24,
+    paddingBottom: 4,
+  },
+  button: {
+    backgroundColor: Colors.tabBg,
+    borderRadius: 9999,
+    paddingVertical: 8,
+    paddingHorizontal: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonSelected: {
+    backgroundColor: Colors.primary,
+  },
+  buttonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.tabText,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+  buttonTextSelected: {
+    color: '#FFFFFF',
+  },
+});

--- a/frontend/src/features/notices/components/CategoryTab.tsx
+++ b/frontend/src/features/notices/components/CategoryTab.tsx
@@ -1,6 +1,6 @@
 /**
  * CategoryTab — 대분류 태그 탭 컴포넌트
- * pencil.dev 시안: pill 버튼, 수평 배치, gap 8
+ * 시안: pill 버튼, 수평 배치, gap 8
  * 미선택: #EEEEEE 배경 + #44465299 텍스트
  * 선택: #00288C 배경 + #FFFFFF 텍스트
  * padding [8, 20], borderRadius 9999, fontSize 14, fontWeight 600

--- a/frontend/src/features/notices/components/DeadlineBadge.tsx
+++ b/frontend/src/features/notices/components/DeadlineBadge.tsx
@@ -1,0 +1,85 @@
+/**
+ * DeadlineBadge — D-day 뱃지 컴포넌트
+ * pencil.dev 시안: 임박(D-3 이내) → 노란 배경, 일반 → 회색 배경, 마감 → 회색+텍스트 흐림
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import { calculateDday, formatDday, isDdayUrgent } from '@/src/shared/utils/date';
+
+interface DeadlineBadgeProps {
+  /** ISO 8601 마감일 문자열 */
+  deadlineAt: string;
+}
+
+function DeadlineBadgeComponent({ deadlineAt }: DeadlineBadgeProps) {
+  const dday = calculateDday(deadlineAt);
+  const label = formatDday(dday);
+  const isUrgent = isDdayUrgent(dday);
+  const isExpired = dday < 0;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        isUrgent && styles.urgentBg,
+        isExpired && styles.expiredBg, // 단축 평가 및 스타일 병합 원리
+        !isUrgent && !isExpired && styles.normalBg,
+      ]}
+    >
+      <Text
+        style={[
+          styles.text,
+          isUrgent && styles.urgentText,
+          isExpired && styles.expiredText,
+          !isUrgent && !isExpired && styles.normalText,
+        ]}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+// FlatList renderItem 리렌더 방지
+export const DeadlineBadge = React.memo(DeadlineBadgeComponent);
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 4,
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+    alignSelf: 'flex-start',
+  },
+  // 임박 (D-3 이내, D-day 포함)
+  urgentBg: {
+    backgroundColor: Colors.ddayUrgentBg,
+  },
+  // 일반 (D-4 이상)
+  normalBg: {
+    backgroundColor: Colors.ddayNormalBg,
+  },
+  // 마감 (기한 지남)
+  expiredBg: {
+    backgroundColor: Colors.ddayNormalBg,
+    opacity: 0.6,
+  },
+  text: {
+    fontFamily: 'Pretendard',
+    fontSize: 10,
+    fontWeight: '900',
+    lineHeight: 15,
+  },
+  urgentText: {
+    color: Colors.ddayUrgentText,
+  },
+  normalText: {
+    color: Colors.ddayNormalText,
+  },
+  expiredText: {
+    color: Colors.ddayNormalText,
+    opacity: 0.5,
+  },
+});

--- a/frontend/src/features/notices/components/DeadlineBadge.tsx
+++ b/frontend/src/features/notices/components/DeadlineBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * DeadlineBadge — D-day 뱃지 컴포넌트
- * pencil.dev 시안: 임박(D-3 이내) → 노란 배경, 일반 → 회색 배경, 마감 → 회색+텍스트 흐림
+ * 시안: 임박(D-3 이내) → 노란 배경, 일반 → 회색 배경, 마감 → 회색+텍스트 흐림
  */
 
 import React from 'react';

--- a/frontend/src/features/notices/components/NoticeCard.tsx
+++ b/frontend/src/features/notices/components/NoticeCard.tsx
@@ -1,0 +1,184 @@
+/**
+ * NoticeCard — 공지 카드 컴포넌트 (기본형)
+ * 시안 Card 1, Card 3 기준
+ *
+ * 구조:
+ * ┌─────────────────────────────┐
+ * │ [카테고리뱃지]       [D-day] │
+ * │ 제목 텍스트                  │
+ * │ ┌─ AI 요약 미리보기 ──────┐ │
+ * │ │ • 요약 내용 1줄~2줄       │ │
+ * │ └──────────────────────────┘ │
+ * │ 날짜 · 부서          🔖     │
+ * └─────────────────────────────┘
+ *
+ * padding 20, gap 8, cornerRadius 12, fill #FFFFFF
+ */
+
+import { Feather } from '@expo/vector-icons';
+import { useRouter, type Href } from 'expo-router';
+import React, { useCallback } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import { formatDate } from '@/src/shared/utils/date';
+import type { Notice } from '@/src/types/api';
+
+import { CategoryBadge } from './CategoryBadge';
+import { DeadlineBadge } from './DeadlineBadge';
+
+interface NoticeCardProps {
+  notice: Notice;
+  /** 즐겨찾기 토글 콜백 */
+  onToggleBookmark?: (noticeId: string) => void;
+}
+
+function NoticeCardComponent({ notice, onToggleBookmark }: NoticeCardProps) {
+  const router = useRouter();
+
+  // 카드 탭 → 공지 상세로 이동
+  const handlePress = useCallback(() => {
+    router.push(`/notice/${notice.id}` as Href);
+  }, [router, notice.id]);
+
+  // 즐겨찾기 토글
+  const handleBookmarkPress = useCallback(() => {
+    onToggleBookmark?.(notice.id);
+  }, [onToggleBookmark, notice.id]);
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={handlePress}
+      activeOpacity={0.7}
+    >
+      {/* 상단: 카테고리 뱃지 + D-day 뱃지 */}
+      <View style={styles.badgeRow}>
+        <CategoryBadge category={notice.category} />
+        {notice.deadlineAt != null && (
+          <DeadlineBadge deadlineAt={notice.deadlineAt} />
+        )}
+      </View>
+
+      {/* 제목 */}
+      <View style={styles.titleContainer}>
+        <Text style={styles.title} numberOfLines={2}>
+          {notice.title}
+        </Text>
+      </View>
+
+      {/* AI 요약 미리보기 — DONE 상태일 때만 표시 */}
+      {notice.aiSummaryStatus === 'DONE' && notice.aiSummary != null && (
+        <View style={styles.summaryContainer}>
+          <View style={styles.summaryContent}>
+            <Feather
+              name="file-text"
+              size={10.5}
+              color={Colors.primary}
+              style={styles.summaryIcon}
+            />
+            <Text style={styles.summaryText} numberOfLines={2}>
+              {/* 마크 제거하고 첫 줄만 가져오기 */}
+              {notice.aiSummary.replace(/•\s*/g, '').split('\n')[0]}
+            </Text>
+          </View>
+        </View>
+      )}
+
+      {/* 하단: 날짜 · 부서 + 즐겨찾기 */}
+      <View style={styles.footer}>
+        <View style={styles.meta}>
+          <Text style={styles.metaText}>{formatDate(notice.postedAt)}</Text>
+          <View style={styles.metaDot} />
+          <Text style={styles.metaText}>{notice.department}</Text>
+        </View>
+        <TouchableOpacity onPress={handleBookmarkPress} hitSlop={8}>
+          <Feather
+            name="bookmark"
+            size={18}
+            color={
+              notice.isBookmarked ? Colors.primary : Colors.bookmarkInactive
+            }
+          />
+        </TouchableOpacity>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+// FlatList renderItem 리렌더 방지
+export const NoticeCard = React.memo(NoticeCardComponent);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.cardBg,
+    borderRadius: 12,
+    padding: 20,
+    gap: 8,
+  },
+  // 뱃지 행
+  badgeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  // 제목
+  titleContainer: {
+    paddingTop: 4,
+  },
+  title: {
+    fontFamily: 'Pretendard',
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    lineHeight: 22,
+  },
+  // AI 요약 미리보기
+  summaryContainer: {
+    backgroundColor: Colors.summaryBg,
+    borderRadius: 8,
+    padding: 12,
+  },
+  summaryContent: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  summaryIcon: {
+    marginTop: 5,
+    marginRight: 6,
+  },
+  summaryText: {
+    flex: 1,
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    lineHeight: 22.75,
+  },
+  // 하단 메타
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: 8,
+    opacity: 0.7,
+  },
+  meta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  metaText: {
+    fontFamily: 'Pretendard',
+    fontSize: 11,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    lineHeight: 16.5,
+  },
+  metaDot: {
+    width: 4,
+    height: 4,
+    borderRadius: 9999,
+    backgroundColor: Colors.separator,
+  },
+});

--- a/frontend/src/features/notices/components/TagChipList.tsx
+++ b/frontend/src/features/notices/components/TagChipList.tsx
@@ -1,0 +1,108 @@
+/**
+ * TagChip — 소분류 태그 칩 컴포넌트
+ * 시안: #F5F6FA 배경, #444652B2 텍스트
+ * padding [6, 12], borderRadius 9999, fontSize 12, fontWeight 500
+ * 수평 스크롤 리스트에서 사용
+ */
+
+import React, { useCallback } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+
+interface TagChipListProps {
+  /** 소분류 태그 목록 (예: ['#전체', '#국가장학', ...]) */
+  tags: string[];
+  /** 현재 선택된 태그 */
+  selectedTag: string;
+  /** 태그 변경 콜백 */
+  onSelect: (tag: string) => void;
+}
+
+function TagChipListComponent({ tags, selectedTag, onSelect }: TagChipListProps) {
+  return (
+    <View style={styles.wrapper}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.container}
+      >
+        {tags.map((tag) => {
+          const isSelected = tag === selectedTag;
+          return (
+            <ChipButton
+              key={tag}
+              label={tag}
+              isSelected={isSelected}
+              onPress={() => onSelect(tag)}
+            />
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+export const TagChipList = React.memo(TagChipListComponent);
+
+// ─── 개별 칩 버튼 ────────────────────────────────────────────────────
+
+interface ChipButtonProps {
+  label: string;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+function ChipButtonComponent({ label, isSelected, onPress }: ChipButtonProps) {
+  const handlePress = useCallback(() => {
+    onPress();
+  }, [onPress]);
+
+  return (
+    <TouchableOpacity
+      style={[styles.chip, isSelected && styles.chipSelected]}
+      onPress={handlePress}
+      activeOpacity={0.7}
+    >
+      <Text style={[styles.chipText, isSelected && styles.chipTextSelected]}>
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const ChipButton = React.memo(ChipButtonComponent);
+
+const styles = StyleSheet.create({
+  wrapper: {
+    height: 52,
+    justifyContent: 'center',
+  },
+  container: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 24,
+  },
+  chip: {
+    backgroundColor: Colors.chipBg,
+    borderRadius: 9999,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  chipSelected: {
+    backgroundColor: Colors.primary,
+  },
+  chipText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '500',
+    color: Colors.chipText,
+    lineHeight: 16,
+    textAlign: 'center',
+  },
+  chipTextSelected: {
+    color: '#FFFFFF',
+  },
+});

--- a/frontend/src/features/notices/components/TodayHighlightCard.tsx
+++ b/frontend/src/features/notices/components/TodayHighlightCard.tsx
@@ -1,0 +1,120 @@
+/**
+ * TodayHighlightCard — Today's Highlight 시그니처 카드
+ * 시안: hljQp 노드
+ *
+ * 구조:
+ * ┌───────────────────────────────┐
+ * │ TODAY'S HIGHLIGHT             │
+ * │ 제목 텍스트 (최대 2줄)        │
+ * │                     🏫 아이콘 │
+ * │ 마감일: 2026.04.15 (18:00까지)│
+ * └───────────────────────────────┘
+ *
+ * fill #FFDF9C, cornerRadius 12, 좌우마진 16, width 358
+ * shadow: blur 1.75, offset y:1, color #0000000D
+ */
+
+import { useRouter, type Href } from 'expo-router';
+import React, { useCallback } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import type { Notice } from '@/src/types/api';
+
+interface TodayHighlightCardProps {
+  notice: Notice;
+}
+
+function TodayHighlightCardComponent({ notice }: TodayHighlightCardProps) {
+  const router = useRouter();
+
+  const handlePress = useCallback(() => {
+    router.push(`/notice/${notice.id}` as Href);
+  }, [router, notice.id]);
+
+  // 마감일 포맷 (예: "마감일: 2026.04.15 (18:00까지)")
+  const deadlineLabel = notice.deadlineAt
+    ? `마감일: ${notice.deadlineAt.replace(/-/g, '.')}`
+    : undefined;
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={handlePress}
+      activeOpacity={0.85}
+    >
+      {/* TODAY'S HIGHLIGHT 라벨 */}
+      <View style={styles.labelContainer}>
+        <Text style={styles.label}>TODAY&apos;S HIGHLIGHT</Text>
+      </View>
+
+      {/* 제목 */}
+      <View style={styles.headingContainer}>
+        <Text style={styles.heading} numberOfLines={2}>
+          {notice.title}
+        </Text>
+      </View>
+
+      {/* 마감일 */}
+      {deadlineLabel != null && (
+        <View style={styles.deadlineContainer}>
+          <Text style={styles.deadline}>{deadlineLabel}</Text>
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+export const TodayHighlightCard = React.memo(TodayHighlightCardComponent);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.highlightBg,
+    borderRadius: 12,
+    marginHorizontal: 16,
+    height: 132,
+    overflow: 'hidden',
+    // 시안: shadow
+    // Android only: elevation으로 그림자 대체
+    elevation: 1,
+  },
+  // TODAY'S HIGHLIGHT 라벨
+  labelContainer: {
+    paddingTop: 20,
+    paddingHorizontal: 20,
+    paddingBottom: 4,
+  },
+  label: {
+    fontFamily: 'Pretendard',
+    fontSize: 10,
+    fontWeight: '700',
+    color: Colors.highlightSubText,
+    letterSpacing: 1,
+    lineHeight: 15,
+  },
+  // 제목
+  headingContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 0.75,
+  },
+  heading: {
+    fontFamily: 'Pretendard',
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.highlightText,
+    lineHeight: 22.5,
+  },
+  // 마감일
+  deadlineContainer: {
+    paddingHorizontal: 20,
+    paddingTop: 4,
+    opacity: 0.8,
+  },
+  deadline: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '400',
+    color: Colors.highlightSubText,
+    lineHeight: 16,
+  },
+});

--- a/frontend/src/features/notices/components/index.ts
+++ b/frontend/src/features/notices/components/index.ts
@@ -1,0 +1,10 @@
+/**
+ * notices 컴포넌트 배럴 export
+ */
+
+export { CategoryBadge } from './CategoryBadge';
+export { CategoryTab } from './CategoryTab';
+export { DeadlineBadge } from './DeadlineBadge';
+export { NoticeCard } from './NoticeCard';
+export { TagChipList } from './TagChipList';
+export { TodayHighlightCard } from './TodayHighlightCard';

--- a/frontend/src/features/notices/index.ts
+++ b/frontend/src/features/notices/index.ts
@@ -1,0 +1,5 @@
+/**
+ * notices 피처 배럴 export
+ */
+
+export * from './components';


### PR DESCRIPTION
# 📖 작업 배경

- Phase 0에서 구축한 프로젝트 기반(타입, 상수, Axios, QueryClient) 위에서 Phase 2(메인 피드 화면) 조립에 필요한 재사용 컴포넌트들을 먼저 제작

- 화면을 바로 짜는 것보다 디자인 시스템 단위의 컴포넌트를 먼저 완성해두는 것이 조립 속도와 일관성 모두에 유리하기 때문에 Phase 1을 별도 단계로 분리

- 디자인 스펙은 노드 ID 단위로 직접 추출한 값을 사용

<br>

## 🔧 작업 내용

공지 피드 화면 구성에 필요한 6개 컴포넌트 구현.
전부 `src/features/notices/components/`에 위치하며 중첩 배럴 export로 묶어 사용.

| 컴포넌트 | 역할 |
|---------|------|
| `DeadlineBadge` | D-day 뱃지 — 임박/일반/마감 3단계 색상 분기 |
| `CategoryBadge` | 카테고리 뱃지 — 장학, 학사 등 표시 |
| `CategoryTab` | 대분류 탭 — pill 형태, 선택/미선택 상태 |
| `TagChipList` | 소분류 태그 칩 — 수평 스크롤 |
| `NoticeCard` | 공지 카드 기본형 — 뱃지+제목+AI요약+날짜/부서+즐겨찾기 |
| `TodayHighlightCard` | Today's Highlight 시그니처 카드 |

<br>

## 🔍 동작 방식

```
메인 피드 화면 (Phase 2에서 조립)
  ├─ TodayHighlightCard     ← 최상단 시그니처 카드, 탭 시 notice/[id]로 이동
  ├─ CategoryTab            ← 대분류 선택 → Zustand 필터 상태 변경
  ├─ TagChipList            ← 소분류 선택 → Zustand 필터 상태 변경
  └─ FlatList
       └─ NoticeCard        ← 카드 탭 → notice/[id], 즐겨찾기 탭 → onToggleBookmark 콜백
            ├─ CategoryBadge
            └─ DeadlineBadge (deadlineAt != null인 경우만 렌더)
```

D-day 판단 흐름:
```
deadlineAt → calculateDday() → dday 값
  dday < 0   → '마감' (회색 + opacity 0.6)
  dday 0~3   → 'D-{n}' or 'D-day' (노란 배경)
  dday 4+    → 'D-{n}' (회색 배 )
```

AI 요약 조건부 렌더링:
```
aiSummaryStatus === 'DONE' && aiSummary != null → 요약 영역 표시
그 외 (PENDING / PROCESSING / FAILED)            → 요약 영역 미표시
                                                   (Phase 2에서 스켈레톤 추가 예정)
```

<br>

## 💡 설계 근거

- **`React.memo` 전체 적용** 
  - `FlatList`의 `renderItem`에 사용되는 컴포넌트는 부모 리렌더 시 불필요하게 재렌더되기 쉬움. 
  - 공지 카드가 수십 개 렌더되는 환경에서 성능 저하 방지를 위해 모든 컴포넌트에 적용.

- **`useCallback`으로 콜백 메모이제이션**'
  - `React.memo`는 props가 참조 동일할 때만 리렌더를 막음. 
  - 인라인 함수는 매 렌더마다 새 참조가 생기므로 `onPress`, `onToggleBookmark` 등 콜백은 `useCallback`으로 감쌈.

- **`AiSummaryStatus` 조건 분기** 
  -  `aiSummary: string | null`만 보고 렌더 여부를 결정하면 `PENDING`(요약 생성 전)과 `FAILED`(요약 실패)를 구분할 수 없음.
  - `aiSummaryStatus === 'DONE'` 조건을 추가해서 Phase 2에서 스켈레톤 vs 실패 안내를 각각 처리할 수 있도록 여지를 남김.

- **`as Href` 타입 캐스팅** 
  -  Expo Router typed routes 설정(`typedRoutes: true`)에서 동적 경로 템플릿 리터럴(`/notice/${id}`)은 정적 분석이 불가해 TS 오류 발생. 
  - `router.push`의 파라미터 타입을 `Href`로 캐스팅하여 해결. 
  - 실제 라우트 등록은 `app/_layout.tsx`에서 완료.

- **색상 전부 `Colors.*` 토큰 참조**
  - 하드코딩된 색상은 디자인 변경 시 전수 수정이 필요해짐. 
  - `src/constants/colors.ts`의 토큰을 통해 단일 출처(Single Source of Truth) 유지.

<br>

## ✅ 체크리스트

- [x] `npx tsc --noEmit` 오류 없음
- [x] 모든 컴포넌트 `React.memo` 적용
- [x] 인라인 스타일 객체 없음 (`StyleSheet.create()` 사용)
- [x] `any` 타입 없음
- [x] 색상 하드코딩 없음 (`Colors.*` 토큰만 사용)
- [x] 배럴 export 정리 (`components/index.ts`, `features/notices/index.ts`)

<br>

## 🔗 연관 이슈

- #4
- #12
