### PR TITLE
[FEAT] 이메일인증/회원가입

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.security:spring-security-crypto")
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("org.postgresql:postgresql")

--- a/backend/src/main/java/org/cathori/backend/config/AppConfig.java
+++ b/backend/src/main/java/org/cathori/backend/config/AppConfig.java
@@ -1,0 +1,15 @@
+package org.cathori.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/UserErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/user/UserErrorCode.java
@@ -23,16 +23,16 @@ public enum UserErrorCode implements ErrorCode {
 
     @Override
     public HttpStatus getStatus() {
-        return null;
+        return status;
     }
 
     @Override
     public String getCode() {
-        return "";
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/backend/src/main/java/org/cathori/backend/user/api/AuthController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/AuthController.java
@@ -1,0 +1,45 @@
+package org.cathori.backend.user.api;
+
+import jakarta.validation.Valid;
+import org.cathori.backend.user.api.dto.*;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.EmailVerificationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final EmailVerificationService emailVerificationService;
+    private final AuthService authService;
+
+    public AuthController(EmailVerificationService emailVerificationService, AuthService authService) {
+        this.emailVerificationService = emailVerificationService;
+        this.authService = authService;
+    }
+
+    @PostMapping("/email/send")
+    public ResponseEntity<EmailSendResponse> sendVerificationEmail(
+            @RequestBody @Valid EmailSendRequest request) {
+        emailVerificationService.sendCode(request.email());
+        return ResponseEntity.ok(new EmailSendResponse(request.email()));
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<EmailSendResponse> verifyCode(
+            @RequestBody @Valid EmailVerifyRequest request) {
+        emailVerificationService.verifyCode(request.email(), request.code());
+        return ResponseEntity.ok(new EmailSendResponse(request.email()));
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(
+            @RequestBody @Valid RegisterRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(authService.register(request));
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/api/UserController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/UserController.java
@@ -1,0 +1,4 @@
+package org.cathori.backend.user.api;
+
+public class UserController {
+}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/EmailSendRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/EmailSendRequest.java
@@ -1,0 +1,10 @@
+package org.cathori.backend.user.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailSendRequest(
+        @NotBlank(message = "이메일을 입력해 주세요")
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        String email
+) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/EmailSendResponse.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/EmailSendResponse.java
@@ -1,0 +1,3 @@
+package org.cathori.backend.user.api.dto;
+
+public record EmailSendResponse(String email) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/EmailVerifyRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/EmailVerifyRequest.java
@@ -1,0 +1,13 @@
+package org.cathori.backend.user.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerifyRequest(
+        @NotBlank(message = "이메일을 입력해 주세요")
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        String email,
+
+        @NotBlank(message = "인증번호를 입력해 주세요")
+        String code
+) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/RegisterRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/RegisterRequest.java
@@ -1,0 +1,24 @@
+package org.cathori.backend.user.api.dto;
+
+import jakarta.validation.constraints.*;
+
+public record RegisterRequest(
+        @NotBlank(message = "이메일을 입력해 주세요")
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해 주세요")
+        String password,
+
+        @NotBlank(message = "전공을 입력해 주세요")
+        String major1,
+
+        String major2,
+
+        @Min(value = 1, message = "학년은 1 이상이어야 합니다")
+        @Max(value = 4, message = "학년은 4 이하이어야 합니다")
+        int grade,
+
+        @NotBlank(message = "재학 상태를 입력해 주세요")
+        String status
+) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/RegisterResponse.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/RegisterResponse.java
@@ -1,0 +1,3 @@
+package org.cathori.backend.user.api.dto;
+
+public record RegisterResponse(Long userId, String email) {}

--- a/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
@@ -1,0 +1,34 @@
+package org.cathori.backend.user.application;
+
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.user.UserErrorCode;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.api.dto.RegisterResponse;
+import org.cathori.backend.user.domain.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final VerifiedEmailStore verifiedEmailStore;
+    private final UserService userService;
+
+    public AuthService(VerifiedEmailStore verifiedEmailStore, UserService userService) {
+        this.verifiedEmailStore = verifiedEmailStore;
+        this.userService = userService;
+    }
+
+    public RegisterResponse register(RegisterRequest request) {
+        if (!verifiedEmailStore.isVerified(request.email())) {
+            throw new BusinessException(UserErrorCode.USER_NOT_VERIFIED);
+        }
+
+        if (userService.existsByEmail(request.email())) {
+            throw new BusinessException(UserErrorCode.USER_EMAIL_DUPLICATE);
+        }
+
+        User saved = userService.save(request);
+        verifiedEmailStore.remove(request.email());
+        return new RegisterResponse(saved.getId(), saved.getEmail());
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/application/EmailVerificationService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/EmailVerificationService.java
@@ -1,0 +1,48 @@
+package org.cathori.backend.user.application;
+
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.user.UserErrorCode;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+
+@Service
+public class EmailVerificationService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final VerificationStore verificationStore;
+    private final VerifiedEmailStore verifiedEmailStore;
+    private final NotificationPort notificationPort;
+
+    public EmailVerificationService(VerificationStore verificationStore,
+                                    VerifiedEmailStore verifiedEmailStore,
+                                    NotificationPort notificationPort) {
+        this.verificationStore = verificationStore;
+        this.verifiedEmailStore = verifiedEmailStore;
+        this.notificationPort = notificationPort;
+    }
+
+    public void sendCode(String email) {
+        String code = String.format("%06d", RANDOM.nextInt(1_000_000));
+        verificationStore.save(email, code);
+        notificationPort.sendVerificationCode(email, code);
+    }
+
+    public void verifyCode(String email, String code) {
+        VerificationStore.Entry entry = verificationStore.find(email)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_VERIFY_CODE_EXPIRED));
+
+        if (entry.expiresAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(UserErrorCode.USER_VERIFY_CODE_EXPIRED);
+        }
+
+        if (!entry.code().equals(code)) {
+            throw new BusinessException(UserErrorCode.USER_INVALID_VERIFY_CODE);
+        }
+
+        verifiedEmailStore.markVerified(email);
+        verificationStore.remove(email);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/application/NotificationPort.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/NotificationPort.java
@@ -1,0 +1,5 @@
+package org.cathori.backend.user.application;
+
+public interface NotificationPort {
+    void sendVerificationCode(String email, String code);
+}

--- a/backend/src/main/java/org/cathori/backend/user/application/UserService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/UserService.java
@@ -1,0 +1,34 @@
+package org.cathori.backend.user.application;
+
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.domain.User;
+import org.cathori.backend.user.domain.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public User save(RegisterRequest request) {
+        String encoded = passwordEncoder.encode(request.password());
+        return userRepository.save(
+                User.create(request.email(), encoded,
+                        request.major1(), request.major2(),
+                        request.grade(), request.status())
+        );
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/application/VerificationStore.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/VerificationStore.java
@@ -1,0 +1,29 @@
+package org.cathori.backend.user.application;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class VerificationStore {
+
+    private static final int TTL_MINUTES = 3;
+
+    record Entry(String code, LocalDateTime expiresAt) {}
+
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+    public void save(String email, String code) {
+        store.put(email, new Entry(code, LocalDateTime.now().plusMinutes(TTL_MINUTES)));
+    }
+
+    public Optional<Entry> find(String email) {
+        return Optional.ofNullable(store.get(email));
+    }
+
+    public void remove(String email) {
+        store.remove(email);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/application/VerifiedEmailStore.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/VerifiedEmailStore.java
@@ -1,0 +1,23 @@
+package org.cathori.backend.user.application;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class VerifiedEmailStore {
+
+    private final ConcurrentHashMap<String, Boolean> store = new ConcurrentHashMap<>();
+
+    public void markVerified(String email) {
+        store.put(email, true);
+    }
+
+    public boolean isVerified(String email) {
+        return store.getOrDefault(email, false);
+    }
+
+    public void remove(String email) {
+        store.remove(email);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/domain/User.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/User.java
@@ -1,0 +1,57 @@
+package org.cathori.backend.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 255, nullable = false)
+    private String password;
+
+    @Column(length = 30, nullable = false)
+    private String major;
+
+    @Column(length = 30)
+    private String secondMajor;
+
+    @Column(nullable = false)
+    private int grade;
+
+    @Column(length = 10, nullable = false)
+    private String enrollmentStatus;
+
+    @Column(length = 255)
+    private String deviceToken;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public static User create(String email, String encodedPassword,
+                              String major, String secondMajor,
+                              int grade, String enrollmentStatus) {
+        User user = new User();
+        user.email = email;
+        user.password = encodedPassword;
+        user.major = major;
+        user.secondMajor = secondMajor;
+        user.grade = grade;
+        user.enrollmentStatus = enrollmentStatus;
+        user.createdAt = LocalDateTime.now();
+        return user;
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
@@ -1,0 +1,6 @@
+package org.cathori.backend.user.domain;
+
+public interface UserRepository {
+    User save(User user);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/SmtpEmailNotifier.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/SmtpEmailNotifier.java
@@ -1,0 +1,25 @@
+package org.cathori.backend.user.infra;
+
+import org.cathori.backend.user.application.NotificationPort;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmtpEmailNotifier implements NotificationPort {
+
+    private final JavaMailSender mailSender;
+
+    public SmtpEmailNotifier(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendVerificationCode(String email, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[Cathori] 이메일 인증번호");
+        message.setText("인증번호: " + code + "\n3분 내에 입력해 주세요.");
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package org.cathori.backend.user.infra;
+
+import org.cathori.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.cathori.backend.user.infra;
+
+import org.cathori.backend.user.domain.User;
+import org.cathori.backend.user.domain.UserRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository jpaRepository;
+
+    public UserRepositoryImpl(UserJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public User save(User user) {
+        return jpaRepository.save(user);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaRepository.existsByEmail(email);
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용

> 구현한 내용을 큰 틀에서 작성

- POST /api/auth/email/send — 6자리 인증번호 생성 후 이메일 발송
- POST /api/auth/email/verify — 인증번호 검증 및 인증 완료 처리
- POST /api/auth/register — 이메일 인증 완료된 사용자만 회원가입 허용
- BCrypt 비밀번호 암호화 적용
- UserErrorCode 반환값 누락 버그 수정 (null → 실제 필드값)

## 🔍 동작 방식

### 이메일 인증번호 발송
<img width="1013" height="475" alt="image" src="https://github.com/user-attachments/assets/66c95244-57e0-4903-a5b2-a3b38db0a30b" />

### 이메일 인증번호 검증
<img width="995" height="788" alt="image" src="https://github.com/user-attachments/assets/f8dbde14-0da4-4c23-b7a8-2decc5e5a6b9" />

### 회원가입
<img width="929" height="907" alt="image" src="https://github.com/user-attachments/assets/f500e9ba-ce12-4bb4-bccb-24c3bc52b768" />


## 💡 설계 근거

> 코드만 봐서는 알 수 없는 판단이 들어간 부분 위주로 작성

### NotificationPort 인터페이스 분리
EmailVerificationService가 SmtpEmailNotifier를 직접 의존하지 않고 NotificationPort 인터페이스를 통해 호출한다. application 레이어가 infra 레이어를 직접 참조하지 않도록 레이어 경계를 유지하기 위함이다.

### VerificationStore / VerifiedEmailStore 인메모리 저장
인증번호와 인증 완료 상태를 DB가 아닌 ConcurrentHashMap으로 관리한다. 인증번호는 TTL 3분의 일회성 데이터라 DB에 저장할 필요가 없다고 판단했다. 단, 현재는 서버 재시작 시 초기화되고 멀티 인스턴스 환경에서 공유가 안 된다는 한계가 있다.

### VerificationStore / VerifiedEmailStore 분리 이유
두 스토어의 데이터 생명주기가 다르기 때문에 분리했다. 인증번호(VerificationStore)는 검증 즉시 삭제되고, 인증 완료 상태(VerifiedEmailStore)는 회원가입 완료 시점까지 유지된다.

### UserRepository 도메인 인터페이스 + UserRepositoryImpl 분리

JPA 의존성이 domain 레이어까지 침투하지 않도록 infra에 구현체를 두는 구조를 유지했다



## **✅ 체크리스트**


> PR 올리기 전 스스로 확인한 항목을 작성

 - 인증번호 발송 → 검증 → 회원가입 전체 흐름 로컬 테스트 완료
 - 미인증 상태로 회원가입 요청 시 예외 처리 확인
 - 이메일 중복 가입 시 예외 처리 확인
 - UserErrorCode 반환값 수정 확인

## 🔗 연관 이슈

---

closes #