### PR TITLE
태그생성/삭제기능 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/tag/TagErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/tag/TagErrorCode.java
@@ -9,6 +9,7 @@ public enum TagErrorCode implements ErrorCode {
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG_NOT_FOUND", "태그를 찾을 수 없습니다"),
     TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "TAG_LIMIT_EXCEEDED", "태그 개수 한도를 초과했습니다");
 
+
     private final HttpStatus status;
     private final String code;
     private final String message;
@@ -21,16 +22,16 @@ public enum TagErrorCode implements ErrorCode {
 
     @Override
     public HttpStatus getStatus() {
-        return null;
+        return status;
     }
 
     @Override
     public String getCode() {
-        return "";
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/backend/src/main/java/org/cathori/backend/tag/api/TagController.java
+++ b/backend/src/main/java/org/cathori/backend/tag/api/TagController.java
@@ -1,0 +1,38 @@
+package org.cathori.backend.tag.api;
+
+import jakarta.validation.Valid;
+import org.cathori.backend.security.CustomUserDetails;
+import org.cathori.backend.tag.api.dto.CreateTagRequest;
+import org.cathori.backend.tag.application.TagService;
+import org.cathori.backend.tag.api.dto.TagDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/tags")
+public class TagController {
+
+    private final TagService tagService;
+
+    public TagController(TagService tagService) {
+        this.tagService = tagService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TagDto> createTag(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid CreateTagRequest request) {
+        TagDto response = tagService.createTag(userDetails.getUserId(), request.tagName());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/{tagId}")
+    public ResponseEntity<Void> deleteTag(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long tagId) {
+        tagService.deleteTag(userDetails.getUserId(), tagId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/tag/api/dto/CreateTagRequest.java
+++ b/backend/src/main/java/org/cathori/backend/tag/api/dto/CreateTagRequest.java
@@ -1,0 +1,12 @@
+package org.cathori.backend.tag.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateTagRequest(
+        @NotBlank
+        @Size(max = 20)
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$")
+        String tagName
+) {}

--- a/backend/src/main/java/org/cathori/backend/tag/api/dto/TagDto.java
+++ b/backend/src/main/java/org/cathori/backend/tag/api/dto/TagDto.java
@@ -1,0 +1,3 @@
+package org.cathori.backend.tag.api.dto;
+
+public record TagDto(Long tagId, String tagName) {}

--- a/backend/src/main/java/org/cathori/backend/tag/application/TagService.java
+++ b/backend/src/main/java/org/cathori/backend/tag/application/TagService.java
@@ -1,0 +1,40 @@
+package org.cathori.backend.tag.application;
+
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.tag.TagErrorCode;
+import org.cathori.backend.tag.domain.Tag;
+import org.cathori.backend.tag.domain.TagRepository;
+import org.cathori.backend.tag.api.dto.TagDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TagService {
+
+    private static final int TAG_LIMIT = 20;
+
+    private final TagRepository tagRepository;
+
+    public TagService(TagRepository tagRepository) {
+        this.tagRepository = tagRepository;
+    }
+
+    @Transactional
+    public TagDto createTag(Long userId, String tagName) {
+        if (tagRepository.existsByUserIdAndName(userId, tagName)) {
+            throw new BusinessException(TagErrorCode.TAG_DUPLICATE);
+        }
+        if (tagRepository.countByUserId(userId) >= TAG_LIMIT) {
+            throw new BusinessException(TagErrorCode.TAG_LIMIT_EXCEEDED);
+        }
+        Tag saved = tagRepository.save(Tag.create(userId, tagName));
+        return new TagDto(saved.getId(), saved.getName());
+    }
+
+    @Transactional
+    public void deleteTag(Long userId, Long tagId) {
+        Tag tag = tagRepository.findByIdAndUserId(tagId, userId)
+                .orElseThrow(() -> new BusinessException(TagErrorCode.TAG_NOT_FOUND));
+        tagRepository.delete(tag);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/tag/domain/Tag.java
+++ b/backend/src/main/java/org/cathori/backend/tag/domain/Tag.java
@@ -1,0 +1,37 @@
+package org.cathori.backend.tag.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_tag",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "name"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static Tag create(Long userId, String name) {
+        Tag tag = new Tag();
+        tag.userId = userId;
+        tag.name = name;
+        tag.createdAt = LocalDateTime.now();
+        return tag;
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/tag/domain/TagRepository.java
+++ b/backend/src/main/java/org/cathori/backend/tag/domain/TagRepository.java
@@ -1,0 +1,11 @@
+package org.cathori.backend.tag.domain;
+
+import java.util.Optional;
+
+public interface TagRepository {
+    Tag save(Tag tag);
+    boolean existsByUserIdAndName(Long userId, String name);
+    long countByUserId(Long userId);
+    Optional<Tag> findByIdAndUserId(Long tagId, Long userId);
+    void delete(Tag tag);
+}

--- a/backend/src/main/java/org/cathori/backend/tag/infra/TagJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/tag/infra/TagJpaRepository.java
@@ -1,0 +1,12 @@
+package org.cathori.backend.tag.infra;
+
+import org.cathori.backend.tag.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagJpaRepository extends JpaRepository<Tag, Long> {
+    boolean existsByUserIdAndName(Long userId, String name);
+    long countByUserId(Long userId);
+    Optional<Tag> findByIdAndUserId(Long id, Long userId);
+}

--- a/backend/src/main/java/org/cathori/backend/tag/infra/TagRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/tag/infra/TagRepositoryImpl.java
@@ -1,0 +1,42 @@
+package org.cathori.backend.tag.infra;
+
+import org.cathori.backend.tag.domain.Tag;
+import org.cathori.backend.tag.domain.TagRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class TagRepositoryImpl implements TagRepository {
+
+    private final TagJpaRepository jpaRepository;
+
+    public TagRepositoryImpl(TagJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Tag save(Tag tag) {
+        return jpaRepository.save(tag);
+    }
+
+    @Override
+    public boolean existsByUserIdAndName(Long userId, String name) {
+        return jpaRepository.existsByUserIdAndName(userId, name);
+    }
+
+    @Override
+    public long countByUserId(Long userId) {
+        return jpaRepository.countByUserId(userId);
+    }
+
+    @Override
+    public Optional<Tag> findByIdAndUserId(Long tagId, Long userId) {
+        return jpaRepository.findByIdAndUserId(tagId, userId);
+    }
+
+    @Override
+    public void delete(Tag tag) {
+        jpaRepository.delete(tag);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/LoginResponse.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/LoginResponse.java
@@ -1,5 +1,7 @@
 package org.cathori.backend.user.api.dto;
 
+import org.cathori.backend.tag.api.dto.TagDto;
+
 import java.util.List;
 
 public record LoginResponse(


### PR DESCRIPTION
## 🔧 작업 내용

- 태그 생성 API 구현 (POST /api/tags)
- 태그 삭제 API 구현 (DELETE /api/tags/{tagId})

## 🔍 동작 방식

### 태그 생성

```mermaid
sequenceDiagram
    participant C as Client
    participant TC as TagController
    participant TS as TagService
    participant TR as TagRepository
    participant DB as Database

    C->>TC: POST /api/tags {tagName}
    TC->>TC: @Valid 유효성 검증
    TC->>TS: createTag(userId, tagName)
    TS->>TR: existsByUserIdAndName()
    TR->>DB: SELECT
    DB-->>TR: result
    alt 중복 존재
        TS-->>TC: TAG_DUPLICATE (409)
    end
    TS->>TR: countByUserId()
    TR->>DB: SELECT COUNT
    DB-->>TR: count
    alt 20개 이상
        TS-->>TC: TAG_LIMIT_EXCEEDED (400)
    end
    TS->>TR: save()
    TR->>DB: INSERT
    DB-->>TR: saved
    TS-->>TC: TagDto
    TC-->>C: 201 Created
```

###  태그 삭제

```mermaid
sequenceDiagram
    participant C as Client
    participant TC as TagController
    participant TS as TagService
    participant TR as TagRepository
    participant DB as Database

    C->>TC: DELETE /api/tags/{tagId}
    TC->>TS: deleteTag(userId, tagId)
    TS->>TR: findByIdAndUserId()
    TR->>DB: SELECT
    DB-->>TR: result
    alt 없음
        TS-->>TC: TAG_NOT_FOUND (404)
    end
    TS->>TR: delete()
    TR->>DB: DELETE
    TC-->>C: 200 OK
```

## 💡 설계 근거

> 코드만 봐서는 알 수 없는 판단이 들어간 부분 위주로 작성

### tagId + userId 조합 단일 쿼리 조회
tagId로 먼저 조회 후 userId 비교하는 2단계 방식을 사용하지 않았다. 존재하지 않는 태그와 타인의 태그를 동일하게 TAG_NOT_FOUND로 처리하기 위해 조합 조회로 구현했다.

### TAG_FORBIDDEN 미사용
정상 사용자 플로우에서 타인의 tagId를 요청하는 경로가 없다. 404/403 분리가 클라이언트 처리에 실질적 차이를 만들지 않아 TAG_NOT_FOUND로 통합했다.

### 입력값 검증 에러코드 미생성
@NotBlank, @Pattern 등 DTO 레벨 검증 실패는 GlobalExceptionHandler의 MethodArgumentNotValidException 핸들러가 INVALID_INPUT으로 처리한다. 별도 에러코드 불필요.

### FCM 로직 미포함
태그 생성/삭제는 알림 구독/해지와 논리적으로 동치지만, FCM은 별도 스프린트에서 구현 예정이다


## **✅ 체크리스트**


> PR 올리기 전 스스로 확인한 항목을 작성
>


## **🔗 연관 이슈**

- #24 