### PR TITLE
[FEAT] AI공지요약화면 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Thumbs.db
 
 # forlder
 personal_docs/
+temp/
 
 # agent
 .agents/

--- a/frontend/app/notice/[id].tsx
+++ b/frontend/app/notice/[id].tsx
@@ -2,17 +2,23 @@
  * 공지 상세 화면 — app/notice/[id].tsx
  *
  * 구조:
- * ┌─ 헤더 (fixed) ─────────────────────────────┐
- * │ ← 뒤로          🔖 즐겨찾기  🔗 공유      │
- * ├─ ScrollView ──────────────────────────────┤
- * │  [카테고리뱃지] [D-day뱃지]               │
- * │  제목                                     │
- * │  작성일 · 부서 · 조회수                   │
- * │  ── AI 요약 섹션 ──                        │
- * │  태그                                     │
- * ├─ Footer (fixed) ──────────────────────────┤
- * │  [링크 복사]  [    원문 보기    ]          │
- * └───────────────────────────────────────────┘
+ * ┌─ SafeAreaView (edges=['top']) ──────────────┐
+ * │  ─ 헤더: ← 뒤로  🔖 즐겨찾기  🔗 공유     │
+ * │  ─ ScrollView (flex:1)                     │
+ * │     [카테고리뱃지] [D-day뱃지]             │
+ * │     제목                                   │
+ * │     작성일 · 부서 · 조회수                 │
+ * │     ── AI 요약 섹션 ──                      │
+ * │     태그                                   │
+ * │  ─ SafeAreaView (edges=['bottom'])          │
+ * │     [링크 복사]  [    원문 보기    ]        │
+ * └─────────────────────────────────────────────┘
+ *
+ * [레이아웃 설계 의도]
+ * Footer를 position:absolute에서 꺼내 normal flow에 배치.
+ * 상단 Safe Area는 최상위 SafeAreaView가, 하단 Safe Area는
+ * Footer를 감싼 SafeAreaView edges={['bottom']}이 각각 처리.
+ * 기기별 insets 수동 계산 불필요.
  */
 
 import { Feather } from '@expo/vector-icons';
@@ -30,7 +36,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
 import {
@@ -44,7 +50,6 @@ import { formatDate } from '@/src/shared/utils/date';
 export default function NoticeDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>(); // URL 파라미터에서 ID 가져오기
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const { data: notice, isLoading } = useNoticeDetail(id ?? ''); // ID를 이용해 공지 상세 데이터 가져오기
 
   // 원문 링크 열기
@@ -78,9 +83,6 @@ export default function NoticeDetailScreen() {
     }
   };
 
-  // 하단 고정 Footer 높이 (Safe Area 하단 포함)
-  const footerHeight = 56 + 32 + insets.bottom; // 버튼 높이 + 패딩 + 안전영역
-
   // 로딩 상태
   if (isLoading) {
     return (
@@ -110,37 +112,33 @@ export default function NoticeDetailScreen() {
   }
 
   return (
-    <View style={styles.container}>
-      <SafeAreaView edges={['top']} style={styles.safeTop}>
-        {/* ─── 헤더: 뒤로가기 + 액션 버튼 ─── */}
-        <View style={styles.header}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
-            <Feather name="arrow-left" size={24} color={Colors.textPrimary} />
+    // 루트: 상단 Safe Area만 처리
+    <SafeAreaView style={styles.container} edges={['top']}>
+      {/* ─── 헤더: 뒤로가기 + 액션 버튼 ─── */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
+          <Feather name="arrow-left" size={24} color={Colors.textPrimary} />
+        </TouchableOpacity>
+        <View style={styles.headerActions}>
+          <TouchableOpacity onPress={handleBookmark} hitSlop={8}>
+            <Feather
+              name="bookmark"
+              size={22}
+              color={
+                notice.isBookmarked ? Colors.primary : Colors.bookmarkInactive
+              }
+            />
           </TouchableOpacity>
-          <View style={styles.headerActions}>
-            <TouchableOpacity onPress={handleBookmark} hitSlop={8}>
-              <Feather
-                name="bookmark"
-                size={22}
-                color={
-                  notice.isBookmarked ? Colors.primary : Colors.bookmarkInactive
-                }
-              />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={handleShare} hitSlop={8}>
-              <Feather name="share-2" size={22} color={Colors.textSecondary} />
-            </TouchableOpacity>
-          </View>
+          <TouchableOpacity onPress={handleShare} hitSlop={8}>
+            <Feather name="share-2" size={22} color={Colors.textSecondary} />
+          </TouchableOpacity>
         </View>
-      </SafeAreaView>
+      </View>
 
       {/* ─── 스크롤 영역 ─── */}
       <ScrollView
         style={styles.scrollView}
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: footerHeight + 16 },
-        ]}
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         {/* 공지 메타 정보 */}
@@ -187,15 +185,12 @@ export default function NoticeDetailScreen() {
         )}
       </ScrollView>
 
-      {/* ─── 하단 고정 Footer ─── */}
-      <View
-        style={[
-          styles.footer,
-          { paddingBottom: insets.bottom > 0 ? insets.bottom : 16 },
-        ]}
-      >
+      {/* ─── 하단 고정 Footer ───
+          edges={['bottom']}으로 홈 인디케이터 Safe Area를 Footer가 직접 처리.
+          position:absolute 불필요 — normal flow로 ScrollView 아래에 배치. */}
+      <SafeAreaView edges={['bottom']} style={styles.footer}>
         <View style={styles.footerButtonRow}>
-          {/* 링크 복사 — 작은 회색 버튼 (서브 액션) */}
+          {/* 링크 복사 */}
           <TouchableOpacity
             style={styles.copyButton}
             onPress={handleCopyUrl}
@@ -205,7 +200,7 @@ export default function NoticeDetailScreen() {
             <Text style={styles.copyButtonText}>링크 복사</Text>
           </TouchableOpacity>
 
-          {/* 원문 보기 — 큰 블루 버튼 (메인 액션) */}
+          {/* 원문 보기 — 메인 액션 */}
           <TouchableOpacity
             style={styles.openButton}
             onPress={handleOpenUrl}
@@ -215,17 +210,14 @@ export default function NoticeDetailScreen() {
             <Feather name="external-link" size={18} color="#FFFFFF" />
           </TouchableOpacity>
         </View>
-      </View>
-    </View>
+      </SafeAreaView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
-  },
-  safeTop: {
     backgroundColor: Colors.background,
   },
   loadingContainer: {
@@ -264,6 +256,7 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingTop: 8,
+    paddingBottom: 24,
   },
   // ─── 메타 정보 ───
   metaSection: {
@@ -331,18 +324,16 @@ const styles = StyleSheet.create({
     color: Colors.chipText,
     lineHeight: 16,
   },
-  // ─── 하단 고정 Footer ───
+  // ─── Footer ───
+  // normal flow로 ScrollView 아래에 위치. 하단 Safe Area는 edges로 자동 처리.
   footer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
     backgroundColor: 'rgba(255,255,255,0.92)',
     borderTopWidth: 1,
     borderTopColor: 'rgba(197,197,212,0.15)',
     paddingTop: 16,
     paddingHorizontal: 16,
-    // Android only — elevation으로 blur 효과 대체
+    paddingBottom: 16,
+    // Android only
     ...Platform.select({
       android: { elevation: 8 },
       ios: {
@@ -358,7 +349,7 @@ const styles = StyleSheet.create({
     gap: 12,
     alignItems: 'center',
   },
-  // 링크 복사 — 원문 보기와 동일 비율 (flex:1), 아이콘 좌측 배치
+  // 링크 복사 — flex:1로 원문 보기와 동일 비율
   copyButton: {
     flex: 1,
     flexDirection: 'row',
@@ -377,7 +368,7 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     textAlign: 'center',
   },
-  // 원문 보기 — 큰 블루 버튼 (메인 액션)
+  // 원문 보기 — 메인 액션 블루 버튼
   openButton: {
     flex: 1,
     flexDirection: 'row',

--- a/frontend/app/notice/[id].tsx
+++ b/frontend/app/notice/[id].tsx
@@ -1,28 +1,222 @@
 /**
- * 공지 상세 화면 — Task 3에서 구현 예정
- * 동적 라우팅: notice/[id]
+ * 공지 상세 화면 — app/notice/[id].tsx
+ *
+ * 구조:
+ * ┌─ 헤더 (fixed) ─────────────────────────────┐
+ * │ ← 뒤로          🔖 즐겨찾기  🔗 공유      │
+ * ├─ ScrollView ──────────────────────────────┤
+ * │  [카테고리뱃지] [D-day뱃지]               │
+ * │  제목                                     │
+ * │  작성일 · 부서 · 조회수                   │
+ * │  ── AI 요약 섹션 ──                        │
+ * │  태그                                     │
+ * ├─ Footer (fixed) ──────────────────────────┤
+ * │  [링크 복사]  [    원문 보기    ]          │
+ * └───────────────────────────────────────────┘
  */
 
+import { Feather } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import React from 'react';
+import {
+  ActivityIndicator,
+  Linking,
+  Platform,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
+import {
+  AiSummarySection,
+  CategoryBadge,
+  DeadlineBadge,
+} from '@/src/features/notices';
+import { useNoticeDetail } from '@/src/features/notices/hooks';
+import { formatDate } from '@/src/shared/utils/date';
 
 export default function NoticeDetailScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams<{ id: string }>(); // URL 파라미터에서 ID 가져오기
   const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { data: notice, isLoading } = useNoticeDetail(id ?? ''); // ID를 이용해 공지 상세 데이터 가져오기
+
+  // 원문 링크 열기
+  const handleOpenUrl = () => {
+    if (notice?.url) {
+      Linking.openURL(notice.url);
+    }
+  };
+
+  // 원문 링크 복사
+  const handleCopyUrl = async () => {
+    if (notice?.url) {
+      await Clipboard.setStringAsync(notice.url);
+    }
+  };
+
+  // 공유
+  const handleShare = () => {
+    if (notice) {
+      Share.share({
+        message: `[Cathori] ${notice.title}\n${notice.url}`,
+      });
+    }
+  };
+
+  // 즐겨찾기 토글
+  const handleBookmark = () => {
+    // TODO: 즐겨찾기 낙관적 업데이트 useMutation 연동
+    if (notice) {
+      console.log('즐겨찾기 토글:', notice.id);
+    }
+  };
+
+  // 하단 고정 Footer 높이 (Safe Area 하단 포함)
+  const footerHeight = 56 + 32 + insets.bottom; // 버튼 높이 + 패딩 + 안전영역
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.primary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // 공지를 찾을 수 없는 경우
+  if (notice == null) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
+            <Feather name="arrow-left" size={24} color={Colors.textPrimary} />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.errorContainer}>
+          <Feather name="alert-circle" size={48} color={Colors.separator} />
+          <Text style={styles.errorText}>공지를 찾을 수 없습니다</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <TouchableOpacity style={styles.back} onPress={() => router.back()}>
-        <Text style={styles.backText}>← 뒤로</Text>
-      </TouchableOpacity>
-      <View style={styles.placeholder}>
-        <Text style={styles.text}>공지 상세 화면 — Task 3에서 구현 예정</Text>
-        <Text style={styles.subText}>공지 ID: {id}</Text>
+    <View style={styles.container}>
+      <SafeAreaView edges={['top']} style={styles.safeTop}>
+        {/* ─── 헤더: 뒤로가기 + 액션 버튼 ─── */}
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
+            <Feather name="arrow-left" size={24} color={Colors.textPrimary} />
+          </TouchableOpacity>
+          <View style={styles.headerActions}>
+            <TouchableOpacity onPress={handleBookmark} hitSlop={8}>
+              <Feather
+                name="bookmark"
+                size={22}
+                color={
+                  notice.isBookmarked ? Colors.primary : Colors.bookmarkInactive
+                }
+              />
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleShare} hitSlop={8}>
+              <Feather name="share-2" size={22} color={Colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+        </View>
+      </SafeAreaView>
+
+      {/* ─── 스크롤 영역 ─── */}
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: footerHeight + 16 },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* 공지 메타 정보 */}
+        <View style={styles.metaSection}>
+          <View style={styles.badgeRow}>
+            <CategoryBadge category={notice.category} />
+            {notice.deadlineAt != null && (
+              <DeadlineBadge deadlineAt={notice.deadlineAt} />
+            )}
+          </View>
+
+          <Text style={styles.title}>{notice.title}</Text>
+
+          <View style={styles.infoRow}>
+            <Text style={styles.infoText}>{formatDate(notice.postedAt)}</Text>
+            <View style={styles.infoDot} />
+            <Text style={styles.infoText}>{notice.department}</Text>
+            <View style={styles.infoDot} />
+            {/*TODO: 조회수 API 연동 및 조회 텍스트 눈 이모지로 변경 필요*/}
+            <Text style={styles.infoText}>조회 {notice.viewCount}</Text>
+          </View>
+        </View>
+
+        {/* 구분선 */}
+        <View style={styles.divider} />
+
+        {/* AI 요약 섹션 */}
+        <View style={styles.summarySection}>
+          <AiSummarySection
+            aiSummary={notice.aiSummary}
+            aiSummaryStatus={notice.aiSummaryStatus}
+          />
+        </View>
+
+        {/* 태그 */}
+        {notice.tags.length > 0 && (
+          <View style={styles.tagSection}>
+            {notice.tags.map((tag) => (
+              <View key={tag} style={styles.tagChip}>
+                <Text style={styles.tagText}>#{tag}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+
+      {/* ─── 하단 고정 Footer ─── */}
+      <View
+        style={[
+          styles.footer,
+          { paddingBottom: insets.bottom > 0 ? insets.bottom : 16 },
+        ]}
+      >
+        <View style={styles.footerButtonRow}>
+          {/* 링크 복사 — 작은 회색 버튼 (서브 액션) */}
+          <TouchableOpacity
+            style={styles.copyButton}
+            onPress={handleCopyUrl}
+            activeOpacity={0.7}
+          >
+            <Feather name="copy" size={18} color={Colors.textPrimary} />
+            <Text style={styles.copyButtonText}>링크 복사</Text>
+          </TouchableOpacity>
+
+          {/* 원문 보기 — 큰 블루 버튼 (메인 액션) */}
+          <TouchableOpacity
+            style={styles.openButton}
+            onPress={handleOpenUrl}
+            activeOpacity={0.85}
+          >
+            <Text style={styles.openButtonText}>원문 보기</Text>
+            <Feather name="external-link" size={18} color="#FFFFFF" />
+          </TouchableOpacity>
+        </View>
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 
@@ -31,25 +225,174 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
   },
-  back: {
-    padding: 16,
+  safeTop: {
+    backgroundColor: Colors.background,
   },
-  backText: {
-    color: Colors.primary,
-    fontSize: 16,
-  },
-  placeholder: {
+  loadingContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  errorText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+  },
+  // ─── 헤더 ───
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  // ─── 스크롤 ───
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingTop: 8,
+  },
+  // ─── 메타 정보 ───
+  metaSection: {
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: 8,
   },
-  text: {
-    color: Colors.textSecondary,
-    fontSize: 16,
+  title: {
+    fontFamily: 'Pretendard',
+    fontSize: 20,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    lineHeight: 28,
   },
-  subText: {
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  infoText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '400',
     color: Colors.textSecondary,
-    fontSize: 13,
+    lineHeight: 16,
+  },
+  infoDot: {
+    width: 3,
+    height: 3,
+    borderRadius: 9999,
+    backgroundColor: Colors.separator,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Colors.divider,
+    marginHorizontal: 24,
+    marginVertical: 20,
+  },
+  // ─── AI 요약 ───
+  summarySection: {
+    paddingHorizontal: 24,
+  },
+  // ─── 태그 ───
+  tagSection: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 24,
+    paddingTop: 20,
+  },
+  tagChip: {
+    backgroundColor: Colors.chipBg,
+    borderRadius: 9999,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+  },
+  tagText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '500',
+    color: Colors.chipText,
+    lineHeight: 16,
+  },
+  // ─── 하단 고정 Footer ───
+  footer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(197,197,212,0.15)',
+    paddingTop: 16,
+    paddingHorizontal: 16,
+    // Android only — elevation으로 blur 효과 대체
+    ...Platform.select({
+      android: { elevation: 8 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: -2 },
+        shadowOpacity: 0.06,
+        shadowRadius: 8,
+      },
+    }),
+  },
+  footerButtonRow: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'center',
+  },
+  // 링크 복사 — 원문 보기와 동일 비율 (flex:1), 아이콘 좌측 배치
+  copyButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    height: 56,
+    backgroundColor: Colors.ddayNormalBg,
+    borderRadius: 12,
+  },
+  copyButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    lineHeight: 16,
+    textAlign: 'center',
+  },
+  // 원문 보기 — 큰 블루 버튼 (메인 액션)
+  openButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    height: 56,
+    backgroundColor: Colors.primary,
+    borderRadius: 12,
+  },
+  openButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    lineHeight: 24,
   },
 });

--- a/frontend/src/constants/colors.ts
+++ b/frontend/src/constants/colors.ts
@@ -55,8 +55,10 @@ export const Colors = {
   ddayNormalText: '#444652',
 
   // ─── AI 요약 영역 ──────────────────────────────────────
-  /** AI 요약 배경 (회색 박스) */
-  summaryBg: '#F3F3F3',
+  /** AI 요약 배경 — 시안 기준 연한 하늘색 */
+  summaryBg: '#EDF2FF',
+  /** AI 요약 배경 (회색 fallback) */
+  summaryBgGray: '#F3F3F3',
 
   // ─── 구분선 / 기타 ──────────────────────────────────────
   divider: '#E5E5E5',

--- a/frontend/src/features/notices/components/AiSummarySection.tsx
+++ b/frontend/src/features/notices/components/AiSummarySection.tsx
@@ -1,0 +1,149 @@
+/**
+ * AiSummarySection — AI 요약 섹션 컴포넌트
+ * aiSummaryStatus별 분기 렌더링:
+ *   DONE       → 요약 텍스트 (bullet list)
+ *   PENDING    → 스켈레톤 + "AI 요약을 생성하고 있습니다..."
+ *   PROCESSING → 스켈레톤 + "AI 요약을 생성하고 있습니다..."
+ *   FAILED     → "요약을 불러올 수 없습니다" 안내
+ */
+
+import { Feather } from '@expo/vector-icons';
+import React from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import type { AiSummaryStatus } from '@/src/types/api';
+
+interface AiSummarySectionProps {
+  aiSummary: string | null;
+  aiSummaryStatus: AiSummaryStatus;
+}
+
+function AiSummarySectionComponent({
+  aiSummary,
+  aiSummaryStatus,
+}: AiSummarySectionProps) {
+  return (
+    <View style={styles.container}>
+      {/* 섹션 헤더 */}
+      <View style={styles.header}>
+        <Feather name="cpu" size={14} color={Colors.primary} />
+        <Text style={styles.headerText}>AI 요약</Text>
+      </View>
+
+      {/* 상태별 분기 렌더링 */}
+      {aiSummaryStatus === 'DONE' && aiSummary != null ? (
+        <SummaryContent summary={aiSummary} />
+      ) : aiSummaryStatus === 'FAILED' ? (
+        <FailedContent />
+      ) : (
+        <LoadingContent />
+      )}
+    </View>
+  );
+}
+
+export const AiSummarySection = React.memo(AiSummarySectionComponent);
+
+// ─── DONE: 요약 텍스트 ────────────────────────────────────────────────
+
+function SummaryContent({ summary }: { summary: string }) {
+  const bullets = summary
+    .split('\n')
+    .map((line) => line.replace(/^•\s*/, '').trim())
+    .filter((line) => line.length > 0);
+
+  return (
+    <View style={styles.summaryBox}>
+      {bullets.map((bullet, index) => (
+        <View key={`bullet-${index}`} style={styles.bulletRow}>
+          <Text style={styles.bulletDot}>•</Text>
+          <Text style={styles.bulletText}>{bullet}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+// ─── PENDING / PROCESSING: 로딩 ──────────────────────────────────────
+
+function LoadingContent() {
+  return (
+    <View style={styles.statusBox}>
+      <ActivityIndicator size="small" color={Colors.primary} />
+      <Text style={styles.statusText}>AI 요약을 생성하고 있습니다...</Text>
+    </View>
+  );
+}
+
+// ─── FAILED: 실패 ─────────────────────────────────────────────────────
+
+function FailedContent() {
+  return (
+    <View style={styles.statusBox}>
+      <Feather name="alert-circle" size={16} color={Colors.textSecondary} />
+      <Text style={styles.statusText}>요약을 불러올 수 없습니다</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  headerText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '700',
+    color: Colors.primary,
+    lineHeight: 20,
+  },
+  summaryBox: {
+    backgroundColor: Colors.summaryBg,
+    borderRadius: 12,
+    padding: 16,
+    gap: 8,
+  },
+  bulletRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  bulletDot: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.primary,
+    lineHeight: 22,
+    marginTop: 1,
+  },
+  bulletText: {
+    flex: 1,
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  statusBox: {
+    backgroundColor: Colors.summaryBg,
+    borderRadius: 12,
+    padding: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+  },
+  statusText: {
+    fontFamily: 'Pretendard',
+    fontSize: 13,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    lineHeight: 18,
+  },
+});

--- a/frontend/src/features/notices/components/index.ts
+++ b/frontend/src/features/notices/components/index.ts
@@ -2,6 +2,7 @@
  * notices 컴포넌트 배럴 export
  */
 
+export { AiSummarySection } from './AiSummarySection';
 export { CategoryBadge } from './CategoryBadge';
 export { CategoryTab } from './CategoryTab';
 export { DeadlineBadge } from './DeadlineBadge';

--- a/frontend/src/features/notices/hooks/index.ts
+++ b/frontend/src/features/notices/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useNoticeDetail } from './useNoticeDetail';
 export { useNotices } from './useNotices';

--- a/frontend/src/features/notices/hooks/useNoticeDetail.ts
+++ b/frontend/src/features/notices/hooks/useNoticeDetail.ts
@@ -1,0 +1,21 @@
+/**
+ * useNoticeDetail — 공지 상세 조회 TanStack Query hook
+ * 현재 Mock fetcher 기반, API 전환 시 fetchNoticeById만 교체하면 됨
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getMockNoticeById } from '@/src/mocks/notices';
+import type { Notice } from '@/src/types/api';
+
+/**
+ * 공지 상세를 조회한다.
+ * @param id 공지 ID
+ */
+export function useNoticeDetail(id: string) {
+  return useQuery<Notice | undefined>({
+    queryKey: ['notice', id],
+    queryFn: () => getMockNoticeById(id),
+    enabled: id != null && id !== '', // id가 유효할 때만 실행
+  });
+}

--- a/frontend/src/mocks/notices.ts
+++ b/frontend/src/mocks/notices.ts
@@ -85,8 +85,9 @@ export const MOCK_NOTICES: Notice[] = [
     createdAt: '2026-04-01T09:05:00Z',
     viewCount: 451,
     aiSummary:
-      '• 접수 기간: 4월 30일까지\n• 팀당 3~5명 구성, 지도교수 필수\n• 우수팀에게 총장상 및 장학금 수여',
-    aiSummaryStatus: 'DONE',
+      // '• 접수 기간: 4월 30일까지\n• 팀당 3~5명 구성, 지도교수 필수\n• 우수팀에게 총장상 및 장학금 수여',
+      null,
+    aiSummaryStatus: 'FAILED',
     deadlineAt: '2026-04-30',
     tags: ['공모전', '캡스톤'],
     isBookmarked: false,

--- a/frontend/src/mocks/notices.ts
+++ b/frontend/src/mocks/notices.ts
@@ -36,7 +36,7 @@ export const MOCK_NOTICES: Notice[] = [
     aiSummary:
       '• 미국, 영국, 독일 등 12개국 24개 대학 협약 프로그램입니다.\n• 어학 성적 우수자가 우대됩니다.\n• 장학생으로 선발 시 항공료 및 현지 생활비 일부 지원됩니다.',
     aiSummaryStatus: 'DONE',
-    deadlineAt: null,
+    deadlineAt: '2026-05-30',
     tags: ['교환학생', '해외연수'],
     isBookmarked: false,
   },
@@ -129,3 +129,10 @@ export function getMockNotices(params: {
   };
 }
 
+/**
+ * 공지 상세 Mock fetcher — ID로 개별 공지 조회
+ * 실제 API 교체 시 이 함수만 수정
+ */
+export function getMockNoticeById(id: string): Notice | undefined {
+  return MOCK_NOTICES.find((n) => n.id === id);
+}


### PR DESCRIPTION
# 📖 작업 배경

- Phase 2 메인 피드에서 공지 카드를 탭했을 때 이동하는 `app/notice/[id].tsx`가 플레이스홀더 상태였다.
- Figma 시안을 기반으로 공지 상세 화면 전체를 구현하고, AI 요약 섹션의 상태별 분기와 하단 고정 액션 버튼을 설계했다.

<br>

## 🔧 작업 내용

### 신규 파일
- `src/features/notices/hooks/useNoticeDetail.ts` — TanStack Query hook, ID로 개별 공지 Mock 조회
- `src/features/notices/components/AiSummarySection.tsx` — AI 요약 섹션 (4가지 status 분기 렌더링)

### 수정 파일
- `src/mocks/notices.ts` — `getMockNoticeById` 추가
- `src/features/notices/hooks/index.ts` — `useNoticeDetail` 배럴 export 추가
- `src/features/notices/components/index.ts` — `AiSummarySection` 배럴 export 추가
- `src/constants/colors.ts` — `summaryBg: '#EDF2FF'` (시안 하늘색) 토큰 추가
- `app/notice/[id].tsx` — 플레이스홀더 → 실제 화면 전체 구현

<br>

## 🔍 동작 방식

```
메인 피드 NoticeCard 탭
  → router.push('/notice/${id}')
  → app/notice/[id].tsx 마운트
  → useLocalSearchParams()로 id 추출
  → useNoticeDetail(id)
      queryKey: ['notice', id]
      getMockNoticeById(id) → MOCK_NOTICES.find()
  → 화면 렌더링

[Footer 액션]
원문 보기 탭 → Linking.openURL(notice.url) → 기기 기본 브라우저 열기
링크 복사 탭 → Clipboard.setStringAsync(notice.url) → 클립보드 저장
공유 탭      → Share.share({ message }) → OS 공유 시트 표시
즐겨찾기 탭  → console.log (TODO: useMutation 연동)
```

**레이아웃 구조 (최종)**
```
SafeAreaView (edges=['top'], flex:1)
  ├─ 헤더 View
  ├─ ScrollView (flex:1, paddingBottom:24 고정)
  └─ SafeAreaView (edges=['bottom'])  ← Footer가 직접 하단 Safe Area 처리
       └─ 버튼 Row (링크 복사 | 원문 보기)
```

<img width="1080" height="1920" alt="Phase3_시연영상" src="https://github.com/user-attachments/assets/99fa9ee3-0ae3-440d-b0da-036cd7a8b470" />

<br>

## 💡 설계 근거

- **Footer를 `position: absolute` → normal flow로 전환**: 
  - 초기 구현에서 Footer를 절대 위치로 배치하면서 `useSafeAreaInsets().bottom`을 직접 계산해 ScrollView의 `paddingBottom`에 박아야 했다. 
  - Footer 높이가 바뀌면 이 숫자도 함께 바꿔야 하는 유지보수 부담이 생기고, 비표준 기기에서 Safe Area 계산이 어긋날 수 있다. 
  - SafeAreaView `edges={['bottom']}`으로 Footer가 직접 하단 여백을 처리하도록 변경해 `useSafeAreaInsets` import 자체를 제거했다.

- **SafeAreaView edges 분리 패턴**: 
  - 상단(`edges=['top']`)은 루트 SafeAreaView가, 하단(`edges=['bottom']`)은 Footer를 감싼 SafeAreaView가 각각 담당. 
  - 하나의 SafeAreaView가 모든 방향을 처리할 때 ScrollView가 하단 Safe Area까지 밀려내려가는 현상을 방지한다.

- **AiSummarySection 컴포넌트 분리**: 
  - `aiSummaryStatus` 4가지 상태(DONE/PENDING/PROCESSING/FAILED)를 별도 컴포넌트에서 처리. 
  - 향후 메인 피드 NoticeCard 내 미리보기 영역에도 재사용 가능.

- **`summaryBg` 색상 토큰 교체**: 
  - 기존 `#F3F3F3`(회색)을 pencil.dev 시안 기준 `#EDF2FF`(연한 하늘색)로 교체. 
  - 기존 회색이 필요한 경우를 위해 `summaryBgGray`도 병행 등록.

- **하단 버튼 1:1 비율 (`flex:1`)**: 
  - 시안에서는 원문 보기(230px):링크 복사(115px) = 2:1이었으나, 에뮬레이터에서 작은 버튼의 아이콘이 텍스트 영역을 침범하는 UX 문제가 발생해 두 버튼 모두 `flex: 1`로 통일.

<br>

## ✅ 체크리스트

- [x] `npx tsc --noEmit` 오류 없음
- [x] 공지 카드 탭 → 상세 화면 진입 확인
- [x] `aiSummaryStatus: 'DONE'` → bullet 요약 표시 확인
- [x] `aiSummaryStatus: 'PENDING'` → 로딩 인디케이터 표시 확인
- [x] `aiSummaryStatus: 'FAILED'` → 실패 안내 표시 확인
- [x] Footer normal flow 전환 — 기기별 Safe Area 자동 처리 확인
- [x] 하단 버튼 두 개 동일 비율, 아이콘 텍스트 옆 배치 확인
- [x] 뒤로가기 `router.back()` 동작 확인
- [x] `StyleSheet.create()` 사용, 인라인 스타일 없음
- [x] `any` 타입 없음

<br>

## 🔗 연관 이슈

- #4 
- #14 
