### PR TITLE
[FIX] 휴대폰에서 시스템 하단바와 앱 하단바가 겹치는 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ temp/
 # agent
 .agents/
 claude.md
+CLAUDE.md
 antigravity.md
 
 

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -1,24 +1,33 @@
 import { Feather } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
 
 // 탭 화면 타입 정의
 type TabBarIconProps = { color: string; size: number };
 
+// 탭바 기본 높이/패딩 — 디자인 시안 기준. OS 시스템 UI 영역(insets.bottom)은 별도 가산.
+const TAB_BAR_BASE_HEIGHT = 72;
+const TAB_BAR_BASE_PADDING_BOTTOM = 8;
+
 export default function TabLayout() {
+  // OS 네비게이션 바 / 홈 인디케이터가 차지하는 하단 영역(픽셀).
+  // 갤럭시 소프트웨어 네비바, 아이폰 홈 인디케이터 등 기기별로 자동 계산됨.
+  const insets = useSafeAreaInsets();
+
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
-          // 하단 네비게이션 바 스타일 — pencil.dev 시안 기반
+          // 하단 네비게이션 바 스타일
           backgroundColor: Colors.navBarBg,
           borderTopWidth: 0,
           elevation: 0,
-          // Android only: 소프트웨어 네비게이션 바 대응
-          paddingBottom: 8,
-          height: 72,
+          // SafeArea inset을 가산해 OS 네비바와 겹치지 않도록 함
+          paddingBottom: TAB_BAR_BASE_PADDING_BOTTOM + insets.bottom,
+          height: TAB_BAR_BASE_HEIGHT + insets.bottom,
         },
         tabBarActiveTintColor: Colors.navActive,
         tabBarInactiveTintColor: Colors.navInactive,

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 // TanStack Query 클라이언트 설정
 const queryClient = new QueryClient({
@@ -23,18 +24,23 @@ export const unstable_settings = {
 };
 
 export default function RootLayout() {
+  // SafeAreaProvider — react-native-safe-area-context의 inset 컨텍스트를 트리에 주입.
+  // 트리 상단에 Provider가 없으면 useSafeAreaInsets() - SafeAreaView가 inset을 0으로
+  // 계산하여 갤럭시(Android)의 OS 네비바 영역을 침범한다.
   return (
-    <QueryClientProvider client={queryClient}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        {/* 공지 상세 화면 — Task 3에서 구현 예정 */}
-        <Stack.Screen
-          name="notice/[id]"
-          options={{ headerShown: false, animation: 'slide_from_right' }}
-        />
-      </Stack>
-      {/* Android only: 상태바 스타일 */}
-      <StatusBar style="light" backgroundColor="transparent" translucent />
-    </QueryClientProvider>
+    <SafeAreaProvider>
+      <QueryClientProvider client={queryClient}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          {/* 공지 상세 화면 */}
+          <Stack.Screen
+            name="notice/[id]"
+            options={{ headerShown: false, animation: 'slide_from_right' }}
+          />
+        </Stack>
+        {/* Android only: 상태바 스타일 */}
+        <StatusBar style="light" backgroundColor="transparent" translucent />
+      </QueryClientProvider>
+    </SafeAreaProvider>
   );
 }


### PR DESCRIPTION
# 📖 작업 배경

React Native 공식 문서에서 코어 `SafeAreaView`가 deprecated되었고 iOS 11+ 전용이라는 안내(`Use react-native-safe-area-context instead.`)에 따라 SafeArea 처리 전반을 점검했다.

점검 과정에서 갤럭시(Android) 실기기에서 **하단 탭바(HOME/SEARCH/TIPS/SETTINGS)가 OS 소프트웨어 네비게이션 바 영역으로 밀려 들어가 일부가 가려지는 문제**가 함께 확인되었다

4개 SafeArea 사용 파일(`search.tsx`, `settings.tsx`, `tips.tsx`, `notice/[id].tsx`)은 모두 이미 `react-native-safe-area-context`의 `SafeAreaView`를 import하고 있어 import 라인 자체의 교체는 불필요했으나, **루트 레이아웃에 `SafeAreaProvider`가 없고 탭바 스타일에 `insets.bottom`이 반영되지 않은 것**이 본질적 원인이었다. 

본 PR은 이 두 누락을 보완하여 Android 실기기에서의 탭바 가림 문제를 해결한다.

<br>

## 🔧 작업 내용

### 1. `app/_layout.tsx` — `SafeAreaProvider`로 트리 감싸기

`react-native-safe-area-context`의 `SafeAreaView` / `useSafeAreaInsets`는 트리 상단의 `SafeAreaProvider` 컨텍스트로부터 inset 값을 받는다. Provider가 없으면 inset이 0으로 계산되어 OS 시스템 UI 영역이 무시된다.

```diff
+ import { SafeAreaProvider } from 'react-native-safe-area-context';
  ...
  export default function RootLayout() {
    return (
+     <SafeAreaProvider>
        <QueryClientProvider client={queryClient}>
          <Stack>...</Stack>
          <StatusBar style="light" backgroundColor="transparent" translucent />
        </QueryClientProvider>
+     </SafeAreaProvider>
    );
  }
```

### 2. `app/(tabs)/_layout.tsx` — `useSafeAreaInsets()`로 탭바 하단 inset 반영

`tabBarStyle`의 `paddingBottom`/`height`가 고정 수치(`8`, `72`)였던 것을 `insets.bottom`을 가산하도록 변경.

```diff
+ import { useSafeAreaInsets } from 'react-native-safe-area-context';
  ...
+ const TAB_BAR_BASE_HEIGHT = 72;
+ const TAB_BAR_BASE_PADDING_BOTTOM = 8;
+
  export default function TabLayout() {
+   const insets = useSafeAreaInsets();
    return (
      <Tabs screenOptions={{
        tabBarStyle: {
          ...
-         paddingBottom: 8,
-         height: 72,
+         paddingBottom: TAB_BAR_BASE_PADDING_BOTTOM + insets.bottom,
+         height: TAB_BAR_BASE_HEIGHT + insets.bottom,
        },
      }} />
    );
  }
```

### 수정 파일

- `frontend/app/_layout.tsx`
- `frontend/app/(tabs)/_layout.tsx`

<br>

## 🔍 동작 방식

### inset 전파 흐름

```
SafeAreaProvider (루트 _layout.tsx)
   │  ── OS로부터 시스템 UI 영역(insets) 수신
   │     · 갤럭시 S/A 시리즈: insets.bottom ≈ 24~48 px (네비바/제스처바)
   │     · 아이폰 노치 기기:  insets.bottom ≈ 34 px      (홈 인디케이터)
   │     · 아이폰 SE 등:      insets.bottom = 0
   ▼
QueryClientProvider
   ▼
Stack
   ├─ (tabs)
   │    └─ Tabs (tabBarStyle: 72 + insets.bottom)
   │         └─ HomeScreen / SearchScreen / TipsScreen / SettingsScreen
   │              └─ SafeAreaView (각 화면) ← Provider로부터 inset 수신
   │
   └─ notice/[id]
        └─ SafeAreaView edges={['top','bottom']}  ← 기존 동작 영향 없음
```

### 탭바 높이 계산 모델

```
┌────────────────────────┐
│  [HOME] [SEARCH] [TIPS] [SETTINGS]   ← TAB_BAR_BASE_HEIGHT = 72 (디자인값)
├────────────────────────┤
│   ▬▬▬▬▬ (OS 네비바)    ← insets.bottom (기기별 동적 값)
└────────────────────────┘

실제 height = TAB_BAR_BASE_HEIGHT + insets.bottom
```

<br>

## 💡 설계 근거

- **`SafeAreaProvider`는 트리 최상위에 단 한 번**: 
  - `QueryClientProvider` 안쪽이 아닌 **바깥쪽**에 두었다. 
  - inset 컨텍스트는 어차피 데이터 페칭과 무관하므로 외곽에서 한 번만 주입하면 그 아래 탭/스택/상세 화면이 모두 같은 inset을 공유한다. 
  - Provider를 안쪽에 두면 일부 트리(예: 모달, Stack의 형제 노드)가 컨텍스트를 못 받을 수 있다.

- **"자동값(`insets.bottom`)"과 "수동값(`72`)"의 책임 분리**: 
  - `insets.bottom`은 기기/OS별로 다른 시스템 UI 영역을 라이브러리가 알아내주는 값이고, `72`는 우리 앱의 탭바 콘텐츠(아이콘+라벨)가 차지할 디자인 크기다.

- **`<Tabs>`의 `tabBarStyle`에는 `SafeAreaView` 래핑이 불가**: 
  - `expo-router`의 `<Tabs>`는 내부 구조에 접근할 수 없고 외부에서 제공할 수 있는 건 `tabBarStyle` 객체뿐이다. 
  - 따라서 `notice/[id].tsx`의 Footer처럼 `<SafeAreaView edges={['bottom']}>` 컴포넌트 패턴이 통하지 않고, `useSafeAreaInsets()` 훅으로 값을 꺼내 직접 가산하는 fallback 패턴을 사용했다.

- **`StatusBar translucent`와의 결합**: 
  - 기존 루트의 `<StatusBar translucent />`는 시스템 UI 위에 앱이 그리는 edge-to-edge 모드를 켠다. 
  - 이 모드에서는 상·하단 시스템 영역 처리가 앱 책임이 되므로 `SafeAreaProvider` 도입의 필요성이 더 커진다.

- **`useNotices`/Zustand 등 비-UI 컨텍스트와의 격리**: 
  - Provider 추가는 트리 구조 변경이지만 상태/데이터 계층에 부수효과가 없다.

<br>

## ✅ 체크리스트

- [x] `npx tsc --noEmit` 오류 없음
- [x] `app/_layout.tsx`에서 `SafeAreaProvider`로 트리 래핑 확인
- [x] `app/(tabs)/_layout.tsx`에서 `useSafeAreaInsets()` 적용 및 `paddingBottom`/`height` 가산 확인
- [x] 코어 `SafeAreaView` import가 코드 전체에 남아 있지 않음 (grep 검증)
- [x] `StyleSheet.create()` 사용, 인라인 스타일 없음 (탭바 스타일은 `screenOptions.tabBarStyle` 정책상 객체 직접 지정)
- [x] `any` 타입 없음
- [ ] (수동 검증) 갤럭시 실기기 또는 Android 에뮬레이터에서 탭바가 OS 네비바 위로 안전하게 배치되는지 확인
- [ ] (수동 검증) iOS 시뮬레이터(노치 기기, SE)에서도 회귀 없는지 확인
- [ ] (수동 검증) `notice/[id]` Footer가 기존과 동일하게 동작하는지 확인 (SafeAreaProvider 추가가 부정적 영향을 주지 않아야 함)

<br>

## 🔗 연관 이슈

- #30 
