### PR TITLE
[FEAT] 공지피드 조회 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
@@ -1,0 +1,34 @@
+package org.cathori.backend.notice.api;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
+import org.cathori.backend.notice.application.NoticeFeedService;
+import org.cathori.backend.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeFeedService noticeFeedService;
+
+    @GetMapping
+    public ResponseEntity<NoticeFeedResponse> getFeed(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String tags,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        NoticeFeedResponse response = noticeFeedService.getFeed(
+                userDetails.getUserId(), category, tags, page, size
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -1,0 +1,33 @@
+package org.cathori.backend.notice.api.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 피드 목록의 단일 공지 카드 DTO. 클라이언트가 카드 UI를 렌더링하는 데 필요한 모든 필드를 담으며,
+ * dDay는 마감일 기준 남은 일수(양수=남음, 0=당일, 음수=지남)로 계산되어 내려온다.
+ *
+ * <pre>
+ * {
+ *   "noticeId": 42,
+ *   "category": "장학",
+ *   "title": "2026학년도 1학기 교내 장학금 신청 안내",
+ *   "department": "학생처",
+ *   "publishedAt": "2026-05-01",
+ *   "aiSummary": "교내 장학금 신청 기간은 5/10~5/20이며 성적 3.0 이상 대상입니다.",
+ *   "url": "https://...",
+ *   "dDay": 5,
+ *   "isBookmarked": false
+ * }
+ * </pre>
+ */
+public record NoticeFeedItem(
+        Long noticeId,
+        String category,
+        String title,
+        String department,
+        LocalDate publishedAt,
+        String aiSummary,
+        String url,
+        Integer dDay,
+        boolean isBookmarked
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedResponse.java
@@ -1,0 +1,36 @@
+package org.cathori.backend.notice.api.dto;
+
+import java.util.List;
+
+
+/**
+ * 공지사항 피드 페이지 응답 DTO. 사용자가 피드 화면에서 공지 목록을 스크롤할 때 반환되며,
+ * 각 항목에는 AI 요약·D-Day·북마크 여부가 포함되어 클라이언트가 별도 요청 없이 카드 UI를 렌더링할 수 있다.
+ *
+ * <pre>
+ * {
+ *   "content": [
+ *     {
+ *       "noticeId": 42,
+ *       "category": "장학",
+ *       "title": "2026학년도 1학기 교내 장학금 신청 안내",
+ *       "department": "학생처",
+ *       "publishedAt": "2026-05-01",
+ *       "aiSummary": "교내 장학금 신청 기간은 5/10~5/20이며 성적 3.0 이상 대상입니다.",
+ *       "url": "https://...",
+ *       "dDay": -3,
+ *       "isBookmarked": false
+ *     }
+ *   ],
+ *   "page": 0,
+ *   "size": 20,
+ *   "hasNext": true
+ * }
+ * </pre>
+ */
+public record NoticeFeedResponse(
+        List<NoticeFeedItem> content,
+        int page,
+        int size,
+        boolean hasNext
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedPort.java
@@ -1,0 +1,7 @@
+package org.cathori.backend.notice.application;
+
+import java.util.List;
+
+public interface NoticeFeedPort {
+    List<NoticeRow> findFeed(NoticeFeedQuery query);
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedQuery.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedQuery.java
@@ -1,0 +1,18 @@
+package org.cathori.backend.notice.application;
+
+import java.util.List;
+
+
+/**
+ * 공지 피드 조회 조건을 담는 쿼리 객체. 사용자의 전공·복수전공·관심 태그를 기반으로
+ * 개인화된 공지를 필터링하며, category가 null이면 전체 카테고리를 대상으로 조회한다.
+ */
+public record NoticeFeedQuery(
+        Long userId,
+        String major,
+        String secondMajor,
+        String category,
+        List<String> tags,
+        int page,
+        int size
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -1,0 +1,82 @@
+package org.cathori.backend.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.notice.api.dto.NoticeFeedItem;
+import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
+import org.cathori.backend.user.UserErrorCode;
+import org.cathori.backend.user.domain.User;
+import org.cathori.backend.user.domain.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeFeedService {
+
+    private final NoticeFeedPort noticeFeedPort;
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자의 전공·복수전공을 자동으로 주입해 개인화된 공지 피드를 구성하는 메인 유스케이스.
+     * 호출자는 userId만 넘기면 되고, 전공 기반 필터링은 서비스 내부에서 처리된다.
+     * <p>
+     * hasNext 판정은 인프라에서 size+1 건을 가져온 뒤 초과 여부로 결정하므로,
+     * 포트 구현체는 반드시 {@code query.size() + 1} 만큼 조회해야 한다.
+     */
+    @Transactional(readOnly = true)
+    public NoticeFeedResponse getFeed(Long userId, String category, String tags, int page, int size) {
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. tags 문자열 파싱
+        List<String> tagList = (tags == null || tags.isBlank())
+                ? List.of()
+                : Arrays.stream(tags.split(","))
+                        .map(String::trim)
+                        .filter(t -> !t.isBlank())
+                        .toList();
+
+        // 3. 쿼리 객체 생성 + 포트 위임
+        NoticeFeedQuery query = new NoticeFeedQuery(
+                userId, user.getMajor(), user.getSecondMajor(),
+                category, tagList, page, size
+        );
+
+        List<NoticeRow> rows = noticeFeedPort.findFeed(query);
+
+        // 4. hasNext 판정
+        boolean hasNext = rows.size() > size;
+        List<NoticeRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+
+
+        // 5. DTO 매핑 + 반환
+        LocalDate today = LocalDate.now();
+        List<NoticeFeedItem> content = pageRows.stream()
+                .map(r -> toItem(r, today))
+                .toList();
+
+        return new NoticeFeedResponse(content, page, size, hasNext);
+    }
+
+    /**
+     * {@code ChronoUnit.DAYS.between(today, deadlineAt)} 기준으로 dDay를 계산한다.
+     * 양수 = 마감까지 남은 일수, 음수 = 마감 초과, null = 마감일 없는 공지.
+     */
+    private NoticeFeedItem toItem(NoticeRow row, LocalDate today) {
+        Integer dDay = row.deadlineAt() != null
+                ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
+                : null;
+        return new NoticeFeedItem(
+                row.id(), row.category(), row.title(), row.department(),
+                row.postedAt(), row.aiSummary(), row.url(), dDay, row.isBookmarked()
+        );
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
@@ -1,0 +1,19 @@
+package org.cathori.backend.notice.application;
+
+import java.time.LocalDate;
+
+/**
+ * 인프라에서 application 레이어로 올라오는 공지 단건 조회 결과. NoticeFeedQuery가 "무엇을 가져올지"를 정의하는 입력이라면,
+ * NoticeRow는 DB에서 읽어온 raw 결과이며, dDay 계산 등 가공은 이 객체를 받은 서비스에서 처리한다.
+ */
+public record NoticeRow(
+        Long id,
+        String category,
+        String title,
+        String department,
+        LocalDate postedAt,
+        LocalDate deadlineAt,
+        String aiSummary,
+        String url,
+        boolean isBookmarked
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -1,0 +1,181 @@
+package org.cathori.backend.notice.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.application.NoticeFeedPort;
+import org.cathori.backend.notice.application.NoticeFeedQuery;
+import org.cathori.backend.notice.application.NoticeRow;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeFeedAdapter implements NoticeFeedPort {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    // DB컬럼 -> 자바객체로 전환
+    private static final RowMapper<NoticeRow> ROW_MAPPER = (rs, rowNum) -> new NoticeRow(
+            rs.getLong("id"),
+            rs.getString("category"),
+            rs.getString("title"),
+            rs.getString("department"),
+            rs.getObject("posted_at", LocalDate.class),
+            rs.getObject("deadline_at", LocalDate.class),
+            rs.getString("ai_summary"),
+            rs.getString("url"),
+            rs.getBoolean("is_bookmarked")
+    );
+
+    @Override
+    public List<NoticeRow> findFeed(NoticeFeedQuery q) {
+        boolean hasCategory = q.category() != null && !q.category().isBlank();
+        boolean hasTags = !q.tags().isEmpty();
+
+        QueryAndParams qp;
+        if (!hasCategory && !hasTags) {
+            qp = buildCase1(q);
+        } else if (hasCategory && !hasTags) {
+            qp = buildCase2(q);
+        } else if (!hasCategory) {
+            qp = buildCase3(q);
+        } else {
+            qp = buildCase4(q);
+        }
+
+        return jdbcTemplate.query(qp.sql(), ROW_MAPPER, qp.params().toArray());
+
+    }
+
+    // Case1: category도 없고 tags도 없음 — MAIN + 제1전공 + 제2전공(전공심화 제외)
+    private QueryAndParams buildCase1(NoticeFeedQuery q) {
+        List<Object> params = new ArrayList<>();
+        params.add(q.userId());
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT n.*, CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked " +
+                "FROM notices n " +
+                "LEFT JOIN bookmark b ON b.notice_id = n.id AND b.user_id = ? " +
+                "WHERE n.source_type = 'MAIN'"
+        );
+
+        sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+        params.add(q.major());
+
+        if (q.secondMajor() != null && !"전공심화".equals(q.secondMajor())) {
+            sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+            params.add(q.secondMajor());
+        }
+
+        appendOrderAndPage(sql, params, q);
+        return new QueryAndParams(sql.toString(), params);
+    }
+
+    // Case2: category만 있음 — MAIN에서 category 필터
+    private QueryAndParams buildCase2(NoticeFeedQuery q) {
+        List<Object> params = new ArrayList<>();
+        params.add(q.userId());
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT n.*, CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked " +
+                "FROM notices n " +
+                "LEFT JOIN bookmark b ON b.notice_id = n.id AND b.user_id = ? " +
+                "WHERE n.source_type = 'MAIN' AND n.category = ?"
+        );
+        params.add(q.category());
+
+        appendOrderAndPage(sql, params, q);
+        return new QueryAndParams(sql.toString(), params);
+    }
+
+    // Case3: tags만 있음 — MAIN + 학과 전체에서 제목 LIKE 필터
+    private QueryAndParams buildCase3(NoticeFeedQuery q) {
+        List<Object> params = new ArrayList<>();
+        params.add(q.userId());
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT n.*, CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked " +
+                "FROM notices n " +
+                "LEFT JOIN bookmark b ON b.notice_id = n.id AND b.user_id = ? " +
+                "WHERE ("
+        );
+        appendTagLikes(sql, params, q.tags(), "n.title");
+        sql.append(") AND (n.source_type = 'MAIN'");
+
+        sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+        params.add(q.major());
+
+        if (q.secondMajor() != null && !"전공심화".equals(q.secondMajor())) {
+            sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+            params.add(q.secondMajor());
+        }
+        sql.append(")");
+
+        appendOrderAndPage(sql, params, q);
+        return new QueryAndParams(sql.toString(), params);
+    }
+
+    // Case4: category + tags 둘 다 있음 — 태그 우선(priority 1) UNION category(priority 2)
+    private QueryAndParams buildCase4(NoticeFeedQuery q) {
+        List<Object> params = new ArrayList<>();
+
+        // Part1: 태그 매칭 (출처 무관)
+        StringBuilder sql = new StringBuilder(
+                "SELECT * FROM (" +
+                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
+                "       n.ai_summary, n.url, " +
+                "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
+                "       1 AS priority " +
+                "FROM notices n " +
+                "LEFT JOIN bookmark b ON b.notice_id = n.id AND b.user_id = ? " +
+                "WHERE ("
+        );
+        params.add(q.userId());
+        appendTagLikes(sql, params, q.tags(), "n.title");
+        sql.append(")");
+
+        // Part2: category 매칭 MAIN, 태그 미매칭
+        sql.append(
+                " UNION " +
+                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
+                "       n.ai_summary, n.url, " +
+                "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
+                "       2 AS priority " +
+                "FROM notices n " +
+                "LEFT JOIN bookmark b ON b.notice_id = n.id AND b.user_id = ? " +
+                "WHERE n.source_type = 'MAIN' AND n.category = ? AND NOT ("
+        );
+        params.add(q.userId());
+        params.add(q.category());
+        appendTagLikes(sql, params, q.tags(), "n.title");
+        sql.append(")");
+
+        sql.append(") sub ORDER BY sub.priority ASC, sub.posted_at DESC, sub.title ASC LIMIT ? OFFSET ?");
+        params.add(q.size() + 1);
+        params.add((long) q.page() * q.size());
+
+        return new QueryAndParams(sql.toString(), params);
+    }
+
+    private void appendTagLikes(StringBuilder sql, List<Object> params, List<String> tags, String column) {
+        StringJoiner joiner = new StringJoiner(" OR ");
+        for (String tag : tags) {
+            joiner.add(column + " LIKE '%' || ? || '%'");
+            params.add(tag);
+        }
+        sql.append(joiner);
+    }
+
+    private void appendOrderAndPage(StringBuilder sql, List<Object> params, NoticeFeedQuery q) {
+        sql.append(" ORDER BY n.posted_at DESC, n.title ASC LIMIT ? OFFSET ?");
+        params.add(q.size() + 1);
+        params.add((long) q.page() * q.size());
+    }
+
+    private record QueryAndParams(String sql, List<Object> params) {}
+}


### PR DESCRIPTION

## 🔧 작업 내용

### 공지 피드 조회 (`GET /api/notices`)

사용자의 전공·복수전공을 서버가 자동으로 주입해, 개인화된 공지 목록을 반환한다.  
`category`와 `tags` 쿼리 파라미터의 유무 조합에 따라 4가지 쿼리 전략으로 분기된다.

- **Case 1** (필터 없음): MAIN 공지 + 사용자 전공 학과 공지 + 복수전공 학과 공지 (전공심화 제외)
- **Case 2** (category만): MAIN 공지 중 해당 카테고리만
- **Case 3** (tags만): Case 1 범위에서 태그 키워드로 제목 LIKE 필터
- **Case 4** (category + tags): 태그 매칭 공지(priority 1) UNION 카테고리 매칭 MAIN 공지(priority 2)

피드 항목 하나에는 AI 요약(`aiSummary`), D-Day, 북마크 여부가 포함돼 클라이언트가 카드 UI를 한 번에 렌더링할 수 있다.

### 공지 검색 (`GET /api/notices/search`)

사용자가 입력한 키워드로 공지 제목을 LIKE 검색한다.  
검색 범위는 피드와 동일하게 MAIN + 사용자 전공·복수전공 학과 공지로 한정된다.

Controller 레이어에서 `@NotBlank`, `@Size(max=100)`, `@Pattern` 어노테이션으로 입력값을 검증하고, 이를 위한 `ConstraintViolationException` 핸들러를 `GlobalExceptionHandler`에 추가했다.

### 통합 테스트

피드(NF-1 ~ NF-17)·검색(NS-1 ~ NS-14) 총 31개 케이스로 실제 DB를 대상으로 검증한다.

## 🔍 동작 방식

---

```
Client
  │
  ▼
NoticeController
  │  userId, category?, tags?, page, size
  ▼
NoticeFeedService
  │  1. UserRepository로 User 조회 → 전공/복수전공 추출
  │  2. 필터 조합에 따라 NoticeFeedQuery 생성
  │  3. NoticeFeedPort.findFeed() 위임
  │  4. size+1 건 중 초과 여부로 hasNext 판정
  │  5. dDay 계산 후 NoticeFeedItem DTO 매핑
  ▼
NoticeFeedPort (interface)
  ▼
NoticeFeedAdapter (JdbcTemplate)
  │  Case 1/2/3: 단일 SQL 동적 빌드
  │  Case 4: UNION SQL (priority 컬럼으로 정렬 우선순위 부여)
  ▼
DB (notices + bookmark 테이블 LEFT JOIN)
```

검색 흐름도 동일하나 `NoticeFeedPort.findSearch()`로 위임하고, `BookmarkJpaRepository` LEFT JOIN 없이 제목 LIKE만 수행한다.

## 💡 설계 근거


**`size + 1` 조회로 hasNext 판정**  
COUNT(*) 쿼리를 별도로 날리지 않고, 요청 size보다 1건 더 조회해 초과 여부로 다음 페이지를 판단한다. 커서 기반이 아닌 오프셋 페이징이므로 COUNT 대신 이 방식이 DB 부하를 낮춘다. 포트 구현체가 반드시 `size + 1`을 LIMIT으로 넘겨야 한다는 계약은 `NoticeFeedPort` Javadoc에 명시했다.

**Case 4에서 UNION + priority 컬럼**  
category와 tags를 동시에 쓸 때 태그 매칭 공지가 더 관련성이 높다고 판단해 우선 노출한다. 하나의 쿼리로 처리하되 priority 컬럼을 붙여 정렬 기준을 통일했다. UNION ALL이 아닌 UNION인 이유는 두 파트에 동시 매칭되는 공지(태그 + 카테고리 모두 해당)가 중복 반환될 수 있기 때문이다.

**`전공심화` 제외 처리**  
`전공심화`는 별도 학과 학과공지가 없는 이수 방식이므로, `secondMajor == "전공심화"`이면 DEPARTMENT 필터 조건 자체를 추가하지 않는다.

**검색 입력 검증을 Controller에서**  
`@NotBlank`, `@Size`, `@Pattern`을 `@RequestParam`에 직접 걸어 Controller가 early reject한다. 이렇게 하면 서비스 계층이 항상 유효한 입력만 받게 되고, SQL Injection 가능성이 있는 특수문자(`; ' " \ = < >`)는 Pattern 검증에서 걸러진다.

**JdbcTemplate 선택**  
필터 조합에 따라 WHERE절 구조 자체가 달라지는 동적 쿼리다. JPA Criteria나 QueryDSL도 가능하지만, SQL이 이미 명확히 보이는 상황에서 추상화 계층을 한 단계 더 쌓는 것보다 JdbcTemplate으로 SQL을 직접 빌드하는 게 가독성과 디버깅 측면에서 낫다고 판단했다.

**`NoticeFeedPort` 인터페이스 도입**  
infra 구현체(NoticeFeedAdapter)를 직접 service에서 의존하지 않고 Port로 분리했다. 검색과 피드 두 기능을 Port 하나에 묶은 이유는 둘 다 동일한 "공지 목록 조회" 관심사를 다루며, 구현체도 동일한 JdbcTemplate 인스턴스를 공유하기 때문이다.

## **✅ 체크리스트**


- [x] 인증 없이 접근 시 401 반환 확인 (NF-1, NS-1)
- [x] 4가지 피드 필터 케이스 동작 확인 (NF-2 ~ NF-8)
- [x] 페이징 hasNext 판정 확인 (NF-9, NF-10, NS-10, NS-11)
- [x] 북마크 여부 반영 확인 (NF-11, NF-12)
- [x] D-Day 계산 확인 (NF-13 ~ NF-15, NS-12, NS-13)
- [x] AI 요약 status별 반환 확인 (NF-16, NF-17)
- [x] 검색어 유효성 검증 (NS-2, NS-2b, NS-2c, NS-3)
- [x] 전공 범위 필터링 확인 (NS-6, NS-7, NS-8, NS-9)
- [x] 정렬 순서 확인 — 최신순, 동일 날짜는 제목 오름차순 (NS-14)
- [x] 전공심화 secondMajor 예외 처리 확인 (NF-3, NS-8)

## 🔗 연관 이슈


closes #25 
