### PR TITLE
[FEAT] 북마크 저장/취소 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/bookmark/api/BookmarkController.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/api/BookmarkController.java
@@ -1,0 +1,28 @@
+package org.cathori.backend.bookmark.api;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.bookmark.api.dto.BookmarkToggleResponse;
+import org.cathori.backend.bookmark.application.BookmarkService;
+import org.cathori.backend.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notices")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/{noticeId}/bookmark")
+    public ResponseEntity<BookmarkToggleResponse> toggle(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long noticeId) {
+        BookmarkToggleResponse response = bookmarkService.toggle(userDetails.getUserId(), noticeId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/bookmark/api/dto/BookmarkToggleResponse.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/api/dto/BookmarkToggleResponse.java
@@ -1,0 +1,3 @@
+package org.cathori.backend.bookmark.api.dto;
+
+public record BookmarkToggleResponse(Long noticeId, boolean isBookmarked) {}

--- a/backend/src/main/java/org/cathori/backend/bookmark/application/BookmarkService.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/application/BookmarkService.java
@@ -1,0 +1,34 @@
+package org.cathori.backend.bookmark.application;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.bookmark.api.dto.BookmarkToggleResponse;
+import org.cathori.backend.bookmark.domain.Bookmark;
+import org.cathori.backend.bookmark.domain.BookmarkRepository;
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.notice.application.NoticeErrorCode;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public BookmarkToggleResponse toggle(Long userId, Long noticeId) {
+        if (!noticeRepository.existsById(noticeId)) {
+            throw new BusinessException(NoticeErrorCode.NOTICE_NOT_FOUND);
+        }
+
+        if (bookmarkRepository.existsByUserIdAndNoticeId(userId, noticeId)) {
+            bookmarkRepository.deleteByUserIdAndNoticeId(userId, noticeId);
+            return new BookmarkToggleResponse(noticeId, false);
+        }
+
+        bookmarkRepository.save(Bookmark.create(userId, noticeId));
+        return new BookmarkToggleResponse(noticeId, true);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/bookmark/domain/Bookmark.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/domain/Bookmark.java
@@ -1,0 +1,41 @@
+package org.cathori.backend.bookmark.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "bookmark",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "notice_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "notice_id", nullable = false)
+    private Long noticeId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static Bookmark create(Long userId, Long noticeId) {
+        Bookmark bookmark = new Bookmark();
+        bookmark.userId = userId;
+        bookmark.noticeId = noticeId;
+        return bookmark;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/bookmark/domain/BookmarkRepository.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/domain/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package org.cathori.backend.bookmark.domain;
+
+public interface BookmarkRepository {
+    boolean existsByUserIdAndNoticeId(Long userId, Long noticeId);
+    Bookmark save(Bookmark bookmark);
+    void deleteByUserIdAndNoticeId(Long userId, Long noticeId);
+}

--- a/backend/src/main/java/org/cathori/backend/bookmark/infra/BookmarkJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/infra/BookmarkJpaRepository.java
@@ -1,0 +1,9 @@
+package org.cathori.backend.bookmark.infra;
+
+import org.cathori.backend.bookmark.domain.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
+    boolean existsByUserIdAndNoticeId(Long userId, Long noticeId);
+    void deleteByUserIdAndNoticeId(Long userId, Long noticeId);
+}

--- a/backend/src/main/java/org/cathori/backend/bookmark/infra/BookmarkRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/infra/BookmarkRepositoryImpl.java
@@ -1,0 +1,28 @@
+package org.cathori.backend.bookmark.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.bookmark.domain.Bookmark;
+import org.cathori.backend.bookmark.domain.BookmarkRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkRepositoryImpl implements BookmarkRepository {
+
+    private final BookmarkJpaRepository jpaRepository;
+
+    @Override
+    public boolean existsByUserIdAndNoticeId(Long userId, Long noticeId) {
+        return jpaRepository.existsByUserIdAndNoticeId(userId, noticeId);
+    }
+
+    @Override
+    public Bookmark save(Bookmark bookmark) {
+        return jpaRepository.save(bookmark);
+    }
+
+    @Override
+    public void deleteByUserIdAndNoticeId(Long userId, Long noticeId) {
+        jpaRepository.deleteByUserIdAndNoticeId(userId, noticeId);
+    }
+}


### PR DESCRIPTION

## 🔧 작업 내용

북마크 토글 API를 구현했다. 같은 엔드포인트(`POST /api/notices/{noticeId}/bookmark`) 하나로 저장/해제를 처리하며, 현재 상태에 따라 결과를 반환한다.

**추가된 파일**
- `BookmarkController` — `POST /api/notices/{noticeId}/bookmark` 엔드포인트
- `BookmarkService` — 공지 존재 확인 → 북마크 유무 분기 → 저장 또는 삭제
- `Bookmark` — 북마크 엔티티 (`@PrePersist`로 `createdAt` 자동 세팅)
- `BookmarkRepository` — domain 레이어 인터페이스
- `BookmarkRepositoryImpl` — JPA 위임 구현체
- `BookmarkJpaRepository` — Spring Data JPA 인터페이스
- `BookmarkToggleResponse` — 응답 DTO

---

## 🔍 동작 방식

```
클라이언트
  │  POST /api/notices/{noticeId}/bookmark
  ▼
BookmarkController
  │  userId 추출 (JWT) + noticeId 전달
  ▼
BookmarkService
  │  1. noticeId로 공지 존재 확인 → 없으면 NOTICE_NOT_FOUND
  │  2. userId + noticeId 조합 조회
  │     - 없으면 → save() → isBookmarked: true
  │     - 있으면 → delete() → isBookmarked: false
  ▼
BookmarkRepository (→ BookmarkRepositoryImpl → BookmarkJpaRepository)
```

---

## 💡 설계 근거

**토글 방식 채택**
저장/해제를 별도 엔드포인트(`POST`, `DELETE`)로 분리하지 않고 단일 엔드포인트로 처리했다. 클라이언트가 현재 북마크 상태를 서버에 전달하지 않아도 되고, 응답의 `isBookmarked`로 최종 상태를 확인할 수 있어 프론트 구현이 단순해진다.

**`BookmarkRepository` 인터페이스 도입 (DIP)**
`BookmarkService`가 `BookmarkJpaRepository`를 직접 의존하지 않고 domain 레이어의 `BookmarkRepository` 인터페이스를 통해 호출한다. application/domain 레이어가 infra 레이어를 직접 참조하지 않는 레이어 경계 원칙을 유지하기 위함이다.

**`Bookmark.create()` 정적 팩토리 메서드**
생성자를 `protected`로 막고 `create()`를 통해서만 인스턴스를 만들도록 했다. `createdAt`은 `@PrePersist`가 세팅하므로 생성 시점에 외부에서 주입할 필요가 없다.

---

## ✅ 체크리스트

- [x] 북마크 안 된 상태 → 저장 후 `isBookmarked: true` 반환 확인
- [x] 북마크 된 상태 → 삭제 후 `isBookmarked: false` 반환 확인
- [x] 존재하지 않는 `noticeId` → `NOTICE_NOT_FOUND` 반환 확인

---

## 🔗 연관 이슈

closes #26 
