### PR TITLE
[Refactor] API 명세 형식 협의 후 통일 및 실기기 테스트 검증 (sprint 1)

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -99,7 +99,8 @@ export default function HomeScreen() {
 
   // 즐겨찾기 토글 (향후 useMutation으로 교체)
   const handleToggleBookmark = (noticeId: string) => {
-    // TODO: 즐겨찾기 낙관적 업데이트 useMutation 연동
+    // TODO(Sprint 2): useMutation({ mutationFn: toggleBookmark, onMutate: 낙관적 업데이트 })
+    //   fetcher: '@/src/services/notices' → toggleBookmark
     console.log('즐겨찾기 토글:', noticeId);
   };
 

--- a/frontend/app/(tabs)/search.tsx
+++ b/frontend/app/(tabs)/search.tsx
@@ -20,7 +20,7 @@
  */
 
 import { Feather } from '@expo/vector-icons';
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -71,24 +71,21 @@ export default function SearchScreen() {
   const results: Notice[] = data?.pages.flatMap((p) => p.content) ?? [];
 
   // 엔터/제출 시점에만 히스토리 추가 (디바운스 키 입력으로는 추가 안 함 — 노이즈 방지)
-  const handleSubmit = useCallback(
-    (text: string) => {
+  const handleSubmit = (text: string) => {
       const t = text.trim();
       if (t) addEntry(t);
-    },
-    [addEntry],
-  );
+  };
 
   // 히스토리 행 탭 → 입력값을 해당 키워드로 채워 검색 트리거
-  const handleSelectHistory = useCallback((keyword: string) => {
+  const handleSelectHistory = (keyword: string) => {
     setQuery(keyword);
-  }, []);
+  };
 
-  const handleEndReached = useCallback(() => {
+  const handleEndReached = () => {
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  };
 
   // FlatList 콜백 — 인라인 화살표 함수 방지 (Global Rules)
   // debouncedQuery를 prop으로 넘겨 매칭 부분 하이라이트에 사용

--- a/frontend/app/(tabs)/search.tsx
+++ b/frontend/app/(tabs)/search.tsx
@@ -41,7 +41,7 @@ import {
 import { EmptyState } from '@/src/shared/components';
 import { useDebounce } from '@/src/shared/hooks';
 import { useSearchHistoryStore } from '@/src/store/useSearchHistoryStore';
-import type { Notice } from '@/src/types/api';
+import type { SearchNoticeListItem } from '@/src/types/api';
 
 /** SearchResultItem 한 행의 추정 높이 (paddingVertical 14*2 + 내용 약 40 = 68) */
 const ESTIMATED_ROW_HEIGHT = 68;
@@ -67,8 +67,8 @@ export default function SearchScreen() {
     isFetchingNextPage,    // ← 다음 페이지 로딩 중인지?
   } = useSearchNotices(debouncedQuery);
 
-  // 모든 페이지의 content를 평탄화
-  const results: Notice[] = data?.pages.flatMap((p) => p.content) ?? [];
+  // 모든 페이지의 content를 평탄화 — 검색 슬림 페이로드(SearchNoticeListItem)
+  const results: SearchNoticeListItem[] = data?.pages.flatMap((p) => p.content) ?? [];
 
   // 엔터/제출 시점에만 히스토리 추가 (디바운스 키 입력으로는 추가 안 함 — 노이즈 방지)
   const handleSubmit = (text: string) => {
@@ -89,10 +89,10 @@ export default function SearchScreen() {
 
   // FlatList 콜백 — 인라인 화살표 함수 방지 (Global Rules)
   // debouncedQuery를 prop으로 넘겨 매칭 부분 하이라이트에 사용
-  const renderItem = ({ item }: { item: Notice }) => (
+  const renderItem = ({ item }: { item: SearchNoticeListItem }) => (
     <SearchResultItem notice={item} query={debouncedQuery} />
   );
-  const keyExtractor = (item: Notice) => item.id;
+  const keyExtractor = (item: SearchNoticeListItem) => item.id;
   const getItemLayout = (_: unknown, index: number) => ({
     length: ESTIMATED_ROW_HEIGHT,
     offset: (ESTIMATED_ROW_HEIGHT + StyleSheet.hairlineWidth) * index,

--- a/frontend/app/(tabs)/search.tsx
+++ b/frontend/app/(tabs)/search.tsx
@@ -76,9 +76,11 @@ export default function SearchScreen() {
       if (t) addEntry(t);
   };
 
-  // 히스토리 행 탭 → 입력값을 해당 키워드로 채워 검색 트리거
+  // 히스토리 행 탭 → 입력값을 해당 키워드로 채워 검색 트리거 + 최상단으로 이동
+  // addEntry 내부 dedup 로직이 기존 항목을 제거하고 최상단에 재삽입함
   const handleSelectHistory = (keyword: string) => {
     setQuery(keyword);
+    addEntry(keyword);
   };
 
   const handleEndReached = () => {

--- a/frontend/app/notice/[id].tsx
+++ b/frontend/app/notice/[id].tsx
@@ -77,7 +77,8 @@ export default function NoticeDetailScreen() {
 
   // 즐겨찾기 토글
   const handleBookmark = () => {
-    // TODO: 즐겨찾기 낙관적 업데이트 useMutation 연동
+    // TODO(Sprint 2): useMutation({ mutationFn: toggleBookmark, onMutate: 낙관적 업데이트 })
+    //   fetcher: '@/src/services/notices' → toggleBookmark
     if (notice) {
       console.log('즐겨찾기 토글:', notice.id);
     }
@@ -156,9 +157,12 @@ export default function NoticeDetailScreen() {
             <Text style={styles.infoText}>{formatDate(notice.postedAt)}</Text>
             <View style={styles.infoDot} />
             <Text style={styles.infoText}>{notice.department}</Text>
-            <View style={styles.infoDot} />
-            {/*TODO: 조회수 API 연동 및 조회 텍스트 눈 이모지로 변경 필요*/}
-            <Text style={styles.infoText}>조회 {notice.viewCount}</Text>
+            {notice.viewCount != null && notice.viewCount > 0 && (
+              <>
+                <View style={styles.infoDot} />
+                <Text style={styles.infoText}>조회 {notice.viewCount}</Text>
+              </>
+            )}
           </View>
         </View>
 
@@ -173,8 +177,8 @@ export default function NoticeDetailScreen() {
           />
         </View>
 
-        {/* 태그 */}
-        {notice.tags.length > 0 && (
+        {/* 태그 — 백엔드 상세 응답에서 미포함 가능 (optional) */}
+        {notice.tags != null && notice.tags.length > 0 && (
           <View style={styles.tagSection}>
             {notice.tags.map((tag) => (
               <View key={tag} style={styles.tagChip}>

--- a/frontend/src/features/notices/components/AiSummarySection.tsx
+++ b/frontend/src/features/notices/components/AiSummarySection.tsx
@@ -1,10 +1,14 @@
 /**
  * AiSummarySection — AI 요약 섹션 컴포넌트
  * aiSummaryStatus별 분기 렌더링:
- *   DONE       → 요약 텍스트 (bullet list)
+ *   SUCCESS    → 요약 텍스트 (bullet list)
  *   PENDING    → 스켈레톤 + "AI 요약을 생성하고 있습니다..."
- *   PROCESSING → 스켈레톤 + "AI 요약을 생성하고 있습니다..."
+ *   SKIPPED    → "요약을 불러올 수 없습니다" 안내 (FAILED와 동일)
  *   FAILED     → "요약을 불러올 수 없습니다" 안내
+ *
+ * aiSummary 형식 대응:
+ *   - JSON 배열 문자열: '["항목1","항목2"]' → JSON.parse 후 배열 순회
+ *   - bullet 텍스트:   '• 항목1\n• 항목2'  → \n 분리 + • 접두어 제거 (Mock 호환)
  */
 
 import { Feather } from '@expo/vector-icons';
@@ -32,9 +36,9 @@ function AiSummarySectionComponent({
       </View>
 
       {/* 상태별 분기 렌더링 */}
-      {aiSummaryStatus === 'DONE' && aiSummary != null ? (
+      {aiSummaryStatus === 'SUCCESS' && aiSummary != null ? (
         <SummaryContent summary={aiSummary} />
-      ) : aiSummaryStatus === 'FAILED' ? (
+      ) : aiSummaryStatus === 'FAILED' || aiSummaryStatus === 'SKIPPED' ? (
         <FailedContent />
       ) : (
         <LoadingContent />
@@ -45,13 +49,18 @@ function AiSummarySectionComponent({
 
 export const AiSummarySection = React.memo(AiSummarySectionComponent);
 
-// ─── DONE: 요약 텍스트 ────────────────────────────────────────────────
+// ─── SUCCESS: 요약 텍스트 ──────────────────────────────────────────────
 
+/**
+ * AI 요약 텍스트를 bullet 리스트로 렌더링한다.
+ *
+ * 백엔드 실제 응답: JSON 배열 문자열 '["항목1","항목2"]'
+ * Mock 데이터:       bullet 텍스트 '• 항목1\n• 항목2'
+ *
+ * 두 형식 모두 처리하여 Mock ↔ 실제 API 전환 시 깨지지 않도록 한다.
+ */
 function SummaryContent({ summary }: { summary: string }) {
-  const bullets = summary
-    .split('\n')
-    .map((line) => line.replace(/^•\s*/, '').trim())
-    .filter((line) => line.length > 0);
+  const bullets = parseSummary(summary);
 
   return (
     <View style={styles.summaryBox}>
@@ -65,7 +74,35 @@ function SummaryContent({ summary }: { summary: string }) {
   );
 }
 
-// ─── PENDING / PROCESSING: 로딩 ──────────────────────────────────────
+/**
+ * aiSummary 문자열을 bullet 배열로 파싱한다.
+ * JSON 배열 문자열이면 JSON.parse, 아니면 \n 분리 + • 제거 (기존 Mock 호환)
+ */
+function parseSummary(summary: string): string[] {
+  const trimmed = summary.trim();
+
+  // JSON 배열 형태인지 판별 ('[' 로 시작)
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((item) => String(item).trim())
+          .filter((item) => item.length > 0);
+      }
+    } catch {
+      // JSON 파싱 실패 시 fallback으로 bullet 텍스트 파싱
+    }
+  }
+
+  // fallback: \n 분리 + • 접두어 제거 (Mock 데이터 호환)
+  return trimmed
+    .split('\n')
+    .map((line) => line.replace(/^•\s*/, '').trim())
+    .filter((line) => line.length > 0);
+}
+
+// ─── PENDING: 로딩 ──────────────────────────────────────────────────
 
 function LoadingContent() {
   return (
@@ -76,7 +113,7 @@ function LoadingContent() {
   );
 }
 
-// ─── FAILED: 실패 ─────────────────────────────────────────────────────
+// ─── FAILED / SKIPPED: 실패 ────────────────────────────────────────────
 
 function FailedContent() {
   return (

--- a/frontend/src/features/notices/components/CategoryBadge.tsx
+++ b/frontend/src/features/notices/components/CategoryBadge.tsx
@@ -11,7 +11,7 @@ import { Colors } from '@/src/constants/colors';
 import type { NoticeCategory } from '@/src/types/api';
 
 interface CategoryBadgeProps {
-  category: NoticeCategory;
+  category: NoticeCategory | null; // 백엔드에서 '학과공지' 등 추가 값 가능성이 있지만 그 부분들은 현재는 null로 보내주기로 함
 }
 
 function CategoryBadgeComponent({ category }: CategoryBadgeProps) {

--- a/frontend/src/features/notices/components/NoticeCard.tsx
+++ b/frontend/src/features/notices/components/NoticeCard.tsx
@@ -67,8 +67,8 @@ function NoticeCardComponent({ notice, onToggleBookmark }: NoticeCardProps) {
         </Text>
       </View>
 
-      {/* AI 요약 미리보기 — DONE 상태일 때만 표시 */}
-      {notice.aiSummaryStatus === 'DONE' && notice.aiSummary != null && (
+      {/* AI 요약 미리보기 — SUCCESS 상태일 때만 표시 */}
+      {notice.aiSummaryStatus === 'SUCCESS' && notice.aiSummary != null && (
         <View style={styles.summaryContainer}>
           <View style={styles.summaryContent}>
             <Feather

--- a/frontend/src/features/search/components/SearchResultItem.tsx
+++ b/frontend/src/features/search/components/SearchResultItem.tsx
@@ -22,10 +22,11 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Colors } from '@/src/constants/colors';
 import { CategoryBadge, DeadlineBadge } from '@/src/features/notices';
 import { formatDate } from '@/src/shared/utils/date';
-import type { Notice } from '@/src/types/api';
+import type { SearchNoticeListItem } from '@/src/types/api';
 
 interface SearchResultItemProps {
-  notice: Notice;
+  // 슬림 페이로드 — aiSummary/url/isBookmarked/tags는 검색 응답에 미포함
+  notice: SearchNoticeListItem;
   /** 검색어 — 제목 내 매칭 부분 하이라이트용. 빈 문자열이면 하이라이트 없이 표시 */
   query: string;
 }

--- a/frontend/src/mocks/notices.ts
+++ b/frontend/src/mocks/notices.ts
@@ -3,22 +3,20 @@
  * 실제 API 연동 시 이 파일의 fetcher 함수만 교체하면 됨
  */
 
-import type { Notice, PageResponse } from '@/src/types/api';
+import type { Notice, PageResponse, SearchNoticeListItem } from '@/src/types/api';
 
 export const MOCK_NOTICES: Notice[] = [
   {
     id: '1',
     title: '2026학년도 1학기 국가장학금 신청 안내',
-    sourceType: 'MAIN',
     category: '장학',
     department: '학생지원팀',
     url: 'https://www.catholic.ac.kr/ko/campuslife/notice.do',
     postedAt: '2026-03-28',
-    createdAt: '2026-03-28T09:05:00Z',
     viewCount: 1240,
     aiSummary:
       '• 1차 신청 기간은 4월 15일까지입니다.\n• 성적 기준 충족 시 최대 전액 수혜 가능합니다.\n• 한국장학재단 앱 또는 홈페이지에서 신청하세요.\n• 소득분위 8구간 이하 학생이 대상입니다.',
-    aiSummaryStatus: 'DONE',
+    aiSummaryStatus: 'SUCCESS',
     deadlineAt: '2026-04-15',
     tags: ['국가장학', '장학금'],
     isBookmarked: false,
@@ -26,16 +24,14 @@ export const MOCK_NOTICES: Notice[] = [
   {
     id: '2',
     title: '2026 하계 해외 연수 프로그램 참가자 모집',
-    sourceType: 'MAIN',
     category: '취창업',
     department: '국제교류팀',
     url: 'https://www.catholic.ac.kr/ko/campuslife/notice.do',
     postedAt: '2026-03-27',
-    createdAt: '2026-03-27T10:05:00Z',
     viewCount: 834,
     aiSummary:
       '• 미국, 영국, 독일 등 12개국 24개 대학 협약 프로그램입니다.\n• 어학 성적 우수자가 우대됩니다.\n• 장학생으로 선발 시 항공료 및 현지 생활비 일부 지원됩니다.',
-    aiSummaryStatus: 'DONE',
+    aiSummaryStatus: 'SUCCESS',
     deadlineAt: '2026-05-30',
     tags: ['교환학생', '해외연수'],
     isBookmarked: false,
@@ -43,16 +39,14 @@ export const MOCK_NOTICES: Notice[] = [
   {
     id: '3',
     title: '성적우수 핵심인재 장학금 지급 규정 변경',
-    sourceType: 'MAIN',
     category: '학사',
     department: '교무팀',
     url: 'https://www.catholic.ac.kr/ko/campuslife/notice.do',
     postedAt: '2026-03-26',
-    createdAt: '2026-03-26T11:05:00Z',
     viewCount: 567,
     aiSummary:
       '• 직전 학기 평점 평균 4.0 이상 대상자 중 상위 5% 이내 지급으로 요건이 강화되었습니다.\n• 변경 시점은 2026학년도 1학기부터입니다.\n• 이의신청 기간은 3월 30일까지입니다.',
-    aiSummaryStatus: 'DONE',
+    aiSummaryStatus: 'SUCCESS',
     deadlineAt: '2026-04-09',
     tags: ['장학금', '성적우수'],
     isBookmarked: true,
@@ -60,12 +54,10 @@ export const MOCK_NOTICES: Notice[] = [
   {
     id: '4',
     title: '2026-1학기 수강신청 정정 기간 안내',
-    sourceType: 'MAIN',
     category: '학사',
     department: '교학처',
     url: 'https://www.catholic.ac.kr/ko/campuslife/notice.do',
     postedAt: '2026-03-08',
-    createdAt: '2026-03-08T09:05:00Z',
     viewCount: 2103,
     // AI 요약 생성 중 상태 예시 — PENDING일 때 UI 스켈레톤 표시
     aiSummary: null,
@@ -77,15 +69,13 @@ export const MOCK_NOTICES: Notice[] = [
   {
     id: '5',
     title: '2026 캡스톤디자인 경진대회 참가팀 모집',
-    sourceType: 'MAIN',
     category: '일반',
     department: '산학협력단',
     url: 'https://www.catholic.ac.kr/ko/campuslife/notice.do',
     postedAt: '2026-04-01',
-    createdAt: '2026-04-01T09:05:00Z',
     viewCount: 451,
     aiSummary:
-      // '• 접수 기간: 4월 30일까지\n• 팀당 3~5명 구성, 지도교수 필수\n• 우수팀에게 총장상 및 장학금 수여',
+      // '• 접수 기간: 4월 30일까지\n• 팀당 3~5명 구성, 지도교수 필수\n• 우수팀에게 총장상 및 장학금 수여'
       null,
     aiSummaryStatus: 'FAILED',
     deadlineAt: '2026-04-30',
@@ -113,7 +103,7 @@ export function getMockNotices(params: {
   if (params.tags) {
     const tagKeyword = params.tags.replace('#', '');
     filtered = filtered.filter((n) =>
-      n.tags.some((t) => t.includes(tagKeyword)),
+      n.tags?.some((t) => t.includes(tagKeyword)) ?? false,
     );
   }
 
@@ -124,8 +114,6 @@ export function getMockNotices(params: {
     content,
     page: params.page,
     size: params.size,
-    totalElements: filtered.length,
-    totalPages: Math.ceil(filtered.length / params.size),
     hasNext: start + params.size < filtered.length,
   };
 }
@@ -140,15 +128,16 @@ export function getMockNoticeById(id: string): Notice | undefined {
 
 /**
  * 공지 검색 Mock fetcher
- * - title / department / tags 세 필드에 대해 대소문자 무시 부분일치
+ * - title / department / tags 세 필드에 대해 대소문자 무시 부분일치 (tags는 매칭 기여만, 응답 미포함)
  * - 빈 쿼리는 빈 결과 반환 (호출 측 enabled 처리와 별개로 안전망)
+ * - 실제 API와 동일하게 슬림 페이로드(SearchNoticeListItem) 반환 — 행형 UI 전용
  * - 실제 API 교체 시 이 함수만 수정
  */
 export function getMockSearchNotices(params: {
   q: string;
   page: number;
   size: number;
-}): PageResponse<Notice> {
+}): PageResponse<SearchNoticeListItem> {
   const q = params.q.trim().toLowerCase();
 
   if (!q) {
@@ -156,8 +145,6 @@ export function getMockSearchNotices(params: {
       content: [],
       page: params.page,
       size: params.size,
-      totalElements: 0,
-      totalPages: 0,
       hasNext: false,
     };
   }
@@ -165,18 +152,26 @@ export function getMockSearchNotices(params: {
   const filtered = MOCK_NOTICES.filter((n) =>
     n.title.toLowerCase().includes(q) ||
     n.department.toLowerCase().includes(q) ||
-    n.tags.some((t) => t.toLowerCase().includes(q)),
+    (n.tags?.some((t) => t.toLowerCase().includes(q)) ?? false),
   );
 
   const start = (params.page - 1) * params.size;
-  const content = filtered.slice(start, start + params.size);
+  // 실제 API 응답과 동일한 슬림 페이로드로 매핑 — aiSummary/url/isBookmarked/tags 제외
+  const content: SearchNoticeListItem[] = filtered
+    .slice(start, start + params.size)
+    .map((n) => ({
+      id: n.id,
+      category: n.category,
+      title: n.title,
+      department: n.department,
+      postedAt: n.postedAt,
+      deadlineAt: n.deadlineAt ?? null,
+    }));
 
   return {
     content,
     page: params.page,
     size: params.size,
-    totalElements: filtered.length,
-    totalPages: Math.ceil(filtered.length / params.size),
     hasNext: start + params.size < filtered.length,
   };
 }

--- a/frontend/src/services/notices.ts
+++ b/frontend/src/services/notices.ts
@@ -23,11 +23,23 @@ import apiClient from '@/src/services/api';
 import type {
   BookmarkToggleResponse,
   Notice,
+  NoticeCategory,
   NoticeListParams,
   NoticeSearchParams,
   PageResponse,
   SearchNoticeListItem,
 } from '@/src/types/api';
+
+/** 허용되는 카테고리 enum (백엔드 협의: enum 외 값은 null로 변환) */
+const KNOWN_CATEGORIES: readonly NoticeCategory[] = ['일반', '장학', '학사', '취창업'];
+
+/** 백엔드 category 문자열을 NoticeCategory | null로 정규화 */
+function normalizeCategory(raw: string | null | undefined): NoticeCategory | null {
+  if (raw == null) return null;
+  return (KNOWN_CATEGORIES as readonly string[]).includes(raw)
+    ? (raw as NoticeCategory)
+    : null;
+}
 
 // ─── 백엔드 응답 원본 타입 (매핑 전) ────────────────────────────────
 
@@ -89,7 +101,7 @@ function mapListItemToNotice(item: BackendNoticeListItem): Notice {
   return {
     id: String(item.noticeId),
     title: item.title,
-    category: item.category,
+    category: normalizeCategory(item.category),
     department: item.department,
     postedAt: item.publishedAt,
     url: item.url,
@@ -107,7 +119,7 @@ function mapListItemToNotice(item: BackendNoticeListItem): Notice {
 function mapSearchItem(item: BackendSearchListItem): SearchNoticeListItem {
   return {
     id: String(item.noticeId),
-    category: item.category,
+    category: normalizeCategory(item.category),
     title: item.title,
     department: item.department,
     postedAt: item.publishedAt,
@@ -120,7 +132,7 @@ function mapDetailToNotice(detail: BackendNoticeDetail): Notice {
   return {
     id: String(detail.noticeId),
     title: detail.title,
-    category: detail.category,
+    category: normalizeCategory(detail.category),
     department: detail.department,
     postedAt: detail.publishedAt,
     url: detail.url,

--- a/frontend/src/services/notices.ts
+++ b/frontend/src/services/notices.ts
@@ -1,0 +1,235 @@
+/**
+ * 공지 서비스 레이어 — 실제 백엔드 API fetcher
+ *
+ * Mock 전환 방법:
+ *   훅에서 import 경로만 교체하면 됨
+ *   import { fetchNotices } from '@/src/services/notices';
+ *   ↓ (Mock으로 되돌릴 때)
+ *   import { getMockNotices } from '@/src/mocks/notices';
+ *
+ * 매핑 규칙 (백엔드 → 프론트):
+ *   noticeId (number)  → id (string)
+ *   publishedAt        → postedAt
+ *   viewCount 미포함   → 기본값 0
+ *   tags 미포함        → 기본값 []
+ *   aiSummary          → JSON 배열 문자열 그대로 전달 (파싱은 컴포넌트에서)
+ *
+ * JWT 토큰:
+ *   apiClient 인터셉터에서 자동 주입 (Sprint 2 활성화 예정)
+ *   현재 TODO 주석 상태 — useAuthStore 연동 시 주석 해제만 하면 됨
+ */
+
+import apiClient from '@/src/services/api';
+import type {
+  BookmarkToggleResponse,
+  Notice,
+  NoticeListParams,
+  NoticeSearchParams,
+  PageResponse,
+  SearchNoticeListItem,
+} from '@/src/types/api';
+
+// ─── 백엔드 응답 원본 타입 (매핑 전) ────────────────────────────────
+
+/** 백엔드 공지 목록 응답의 개별 아이템 */
+interface BackendNoticeListItem {
+  noticeId: number;
+  category: string;
+  title: string;
+  department: string;
+  publishedAt: string;
+  aiSummary: string | null;
+  aiSummaryStatus?: string;
+  url: string;
+  deadlineAt?: string | null;
+  isBookmarked: boolean;
+  tags?: string[];
+}
+
+/**
+ * 백엔드 공지 검색 응답의 슬림 아이템
+ * 목록/상세보다 적은 6필드만 — aiSummary/url/isBookmarked/tags 미포함
+ * (검색 결과는 행 단위 빠른 스캔 UX, 행 탭 시 상세에서 재조회)
+ */
+interface BackendSearchListItem {
+  noticeId: number;
+  category: string;
+  title: string;
+  department: string;
+  publishedAt: string;
+  deadlineAt?: string | null;
+}
+
+/** 백엔드 공지 상세 응답 */
+interface BackendNoticeDetail {
+  noticeId: number;
+  category: string;
+  title: string;
+  department: string;
+  publishedAt: string;
+  aiSummary: string | null;
+  aiSummaryStatus: string;
+  url: string;
+  deadlineAt?: string | null;
+  isBookmarked: boolean;
+}
+
+/** 백엔드 페이지 응답 래퍼 */
+interface BackendPageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  hasNext: boolean;
+}
+
+// ─── 매핑 함수 ──────────────────────────────────────────────────────
+
+/** 백엔드 목록 아이템 → 프론트 Notice 변환 */
+function mapListItemToNotice(item: BackendNoticeListItem): Notice {
+  return {
+    id: String(item.noticeId),
+    title: item.title,
+    category: item.category,
+    department: item.department,
+    postedAt: item.publishedAt,
+    url: item.url,
+    aiSummary: item.aiSummary,
+    aiSummaryStatus: (item.aiSummaryStatus as Notice['aiSummaryStatus']) ?? 'PENDING',
+    deadlineAt: item.deadlineAt ?? null,
+    isBookmarked: item.isBookmarked,
+    // 백엔드 미포함 시 기본값
+    viewCount: 0,
+    tags: item.tags ?? [],
+  };
+}
+
+/** 백엔드 검색 슬림 아이템 → 프론트 SearchNoticeListItem */
+function mapSearchItem(item: BackendSearchListItem): SearchNoticeListItem {
+  return {
+    id: String(item.noticeId),
+    category: item.category,
+    title: item.title,
+    department: item.department,
+    postedAt: item.publishedAt,
+    deadlineAt: item.deadlineAt ?? null,
+  };
+}
+
+/** 백엔드 상세 응답 → 프론트 Notice 변환 */
+function mapDetailToNotice(detail: BackendNoticeDetail): Notice {
+  return {
+    id: String(detail.noticeId),
+    title: detail.title,
+    category: detail.category,
+    department: detail.department,
+    postedAt: detail.publishedAt,
+    url: detail.url,
+    aiSummary: detail.aiSummary,
+    aiSummaryStatus: detail.aiSummaryStatus as Notice['aiSummaryStatus'],
+    deadlineAt: detail.deadlineAt ?? null,
+    isBookmarked: detail.isBookmarked,
+    // 상세에서 tags, viewCount 미포함
+    viewCount: 0,
+    tags: [],
+  };
+}
+
+// ─── Fetcher 함수 ──────────────────────────────────────────────────
+
+/**
+ * 공지 목록 조회 fetcher
+ * 프론트 page는 1-based → API 호출 시 0-based로 변환
+ */
+export async function fetchNotices(
+  params: NoticeListParams,
+): Promise<PageResponse<Notice>> {
+  const { data } = await apiClient.get<BackendPageResponse<BackendNoticeListItem>>(
+    '/api/notices',
+    {
+      params: {
+        category: params.category,
+        tags: params.tags,
+        page: params.page - 1, // 프론트 1-based → 백엔드 0-based
+        size: params.size,
+      },
+    },
+  );
+
+  return {
+    content: data.content.map(mapListItemToNotice),
+    page: data.page + 1, // 백엔드 0-based → 프론트 1-based로 복원
+    size: data.size,
+    hasNext: data.hasNext,
+  };
+}
+
+/**
+ * 공지 상세 조회 fetcher
+ */
+export async function fetchNoticeById(id: string): Promise<Notice> {
+  const { data } = await apiClient.get<BackendNoticeDetail>(
+    `/api/notices/${id}`,
+  );
+
+  return mapDetailToNotice(data);
+}
+
+/**
+ * 공지 검색 fetcher — 슬림 응답
+ * - URL: /api/notices/search (백엔드 실제 구현 기준)
+ * - 반환: PageResponse<SearchNoticeListItem> — Pick으로 좁힌 슬림 타입
+ * - 페이지 양방향 변환: 요청 page-1, 응답 page+1
+ */
+export async function fetchSearchNotices(
+  params: NoticeSearchParams,
+): Promise<PageResponse<SearchNoticeListItem>> {
+  const { data } = await apiClient.get<BackendPageResponse<BackendSearchListItem>>(
+    '/api/notices/search',
+    {
+      params: {
+        q: params.q,
+        page: params.page - 1, // 프론트 1-based → 백엔드 0-based
+        size: params.size,
+      },
+    },
+  );
+
+  return {
+    content: data.content.map(mapSearchItem),
+    page: data.page + 1, // 백엔드 0-based → 프론트 1-based로 복원
+    size: data.size,
+    hasNext: data.hasNext,
+  };
+}
+
+/**
+ * 즐겨찾기 토글 fetcher — 단일 POST
+ *
+ * 정책: 등록/해제를 별도 엔드포인트로 분리하지 않고, 동일 POST 호출이
+ * 현재 상태의 반대를 적용. 응답의 `isBookmarked`가 토글 후 최종 상태.
+ *
+ * 호출 예시 (인증 활성화 후 Sprint 2):
+ *   const mutation = useMutation({
+ *     mutationFn: toggleBookmark,
+ *     onMutate: async (noticeId) => {
+ *       // 낙관적 업데이트: 캐시에서 현재 isBookmarked 즉시 반전
+ *     },
+ *     onError: (_err, _id, ctx) => {
+ *       // 롤백
+ *     },
+ *     onSettled: () => queryClient.invalidateQueries(...),
+ *   });
+ *
+ * 주의:
+ *   - 인증 토큰 인터셉터 미활성 (Sprint 2). 현 시점 호출 시 401 반환.
+ *   - BookmarkToggleResponse.noticeId는 추후 string으로 반환하도록 협의
+ */
+export async function toggleBookmark(
+  noticeId: string,
+): Promise<BookmarkToggleResponse> {
+  const { data } = await apiClient.post<BookmarkToggleResponse>(
+    `/api/notices/${noticeId}/bookmark`,
+  );
+
+  return data;
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -124,7 +124,7 @@ export interface PageResponse<T> {
 
 /** 즐겨찾기 토글 응답 */
 export interface BookmarkToggleResponse {
-  noticeId: number;
+  noticeId: string;
   isBookmarked: boolean;
 }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,6 +1,6 @@
 /**
  * Cathori API 공통 타입 정의
- * 백엔드 계약(CLAUDE.md API Endpoints) 기반
+ * 백엔드 계약(ERD v2 + _from_backend 명세) 기반
  */
 
 // ─── 도메인 타입 ────────────────────────────────────────────────────
@@ -8,62 +8,67 @@
 /** 공지 대분류 카테고리 */
 export type NoticeCategory = '일반' | '장학' | '학사' | '취창업';
 
-/** 공지 출처 레벨 — ERD v2 source_type 허용값 */
-export type SourceType = 'MAIN' | 'DEPARTMENT';
-// COMMUNITY(인스타그램/에브리타임)는 아키텍처만 설계, MVP 미구현
-
 /**
  * AI 요약 생성 상태 — ERD v2 ai_summary_status 허용값
  * - PENDING: 요약 생성 전 (최초 조회 시)
- * - PROCESSING: 생성 중
- * - DONE: 생성 완료
- * - FAILED: 생성 실패
+ * - SUCCESS: 요약 생성 완료
+ * - SKIPPED: 일시 스킵 (백엔드가 일괄 재시도 예정) — 프론트에서는 FAILED와 동일 표시
+ * - FAILED: 최종 실패
  */
-export type AiSummaryStatus = 'PENDING' | 'PROCESSING' | 'DONE' | 'FAILED';
+export type AiSummaryStatus = 'PENDING' | 'SUCCESS' | 'SKIPPED' | 'FAILED';
 
 /** 공지 알림 빈도 */
 export type NotificationFrequency = 'INSTANT' | 'DAILY'; // * 향후 변경 가능성 있음
 
 // ─── 공지 타입 ──────────────────────────────────────────────────────
 
-/** 공지 엔티티 — ERD v2 notice 테이블 기준 */
+/**
+ * 공지 엔티티 — 프론트 내부 표현
+ *
+ * 백엔드 응답과 필드명이 다른 부분은 서비스 레이어(fetchNotices 등)에서 매핑:
+ *   noticeId (number) → id (string)
+ *   publishedAt       → postedAt
+ */
 export interface Notice {
   id: string;
   title: string;
-  /** 공지 출처 타입 (MAIN: 학교 공식, DEPARTMENT: 학과) */
-  sourceType: SourceType;
-  category: NoticeCategory;
+  category: NoticeCategory | string; // 백엔드에서 '학과공지' 등 추가 값 가능성이 있지만 그 부분들은 현재는 null로 보내주기로 함
   /** 작성 부서 (ERD NOT NULL) */
   department: string;
   /** 공지 원문 링크 */
   url: string;
-  /** 공지 원문 등록일 (ISO 8601 date) */
+  /** 공지 원문 등록일 (ISO 8601 date) — 백엔드 필드명: publishedAt */
   postedAt: string;
-  /** DB 저장 시각 (ISO 8601 timestamp) */
-  createdAt: string;
-  /** 조회수 */
-  viewCount: number;
 
   // ─── AI 요약 관련 ────────────────────────────────────────────────
-  /** AI 요약 결과 — DONE 상태일 때만 존재 */
+  /** AI 요약 결과 — SUCCESS 상태일 때만 존재. JSON 배열 문자열 또는 bullet 텍스트 */
   aiSummary: string | null;
   /** AI 요약 생성 상태 */
   aiSummaryStatus: AiSummaryStatus;
 
-  // ─── 선택적 필드 ────────────────────────────────────────────────
-  /** 마감일 — ERD v2 deadline_at, 없으면 null */
-  deadlineAt: string | null;
-  /** 공지 본문 텍스트 — 상세 화면에서만 사용, ERD v2 body_text */
-  bodyText?: string | null;
-  /** 공지 이미지 URL 목록 — ERD v2 image_urls (JSON 문자열로 저장) */
-  imageUrls?: string[] | null;
-
-  // ─── API 조합 필드 (tags는 추후에 ERD가 수정되더라도 api를 통해서 보내주는 걸로 유지될 예정) ──────
-  /** 백엔드에서 매칭한 태그 목록 */
-  tags: string[];
-  /** 즐겨찾기 여부 — 로그인 사용자 기준, erd에 추후에 추가하기로 합의함 */
+  // ─── 선택적 필드 (백엔드 응답에 포함되지 않을 수 있음) ───────────
+  /** 마감일 — ERD v2 deadline_at, ISO date. 없으면 null */
+  deadlineAt?: string | null;
+  /** 조회수 — 추후 구현, 백엔드 미포함 시 기본값 0 */
+  viewCount?: number;
+  /** 백엔드에서 매칭한 태그 목록 — 목록에서는 포함, 상세에서는 보류 */
+  tags?: string[];
+  /** 즐겨찾기 여부 — 로그인 사용자 기준 */
   isBookmarked: boolean;
 }
+
+/**
+ * 검색 결과 슬림 페이로드
+ * 백엔드 GET /api/notices/search 응답이 카드형이 아닌 행형 UI(SearchResultItem)에 맞춰
+ * 6필드만 내려옴. aiSummary/url/isBookmarked/tags는 미포함 — 행 탭 시 상세에서 재조회.
+ *
+ * Pick으로 좁혀두어 검색 결과를 다루는 코드가 무심코 aiSummary 등을 참조하면
+ * TS 컴파일 단계에서 차단된다. (실수 사전 방지)
+ */
+export type SearchNoticeListItem = Pick<
+  Notice,
+  'id' | 'category' | 'title' | 'department' | 'postedAt' | 'deadlineAt'
+>;
 
 /** 공지 목록 API 요청 파라미터 */
 export interface NoticeListParams {
@@ -106,18 +111,31 @@ export interface UserSettings {
 
 // ─── API 응답 공통 래퍼 ─────────────────────────────────────────────
 
-/** 페이지네이션 응답 래퍼 */
+/**
+ * 페이지네이션 응답 래퍼
+ * 백엔드는 totalElements/totalPages 미지원 → hasNext만 사용
+ */
 export interface PageResponse<T> {
   content: T[];
   page: number;
   size: number;
-  totalElements: number;
-  totalPages: number;
   hasNext: boolean;
+}
+
+/** 즐겨찾기 토글 응답 */
+export interface BookmarkToggleResponse {
+  noticeId: number;
+  isBookmarked: boolean;
 }
 
 /** 단일 아이템 응답 래퍼 */
 export interface ApiResponse<T> {
   data: T;
   message?: string;
+}
+
+/** API 에러 응답 */
+export interface ApiError {
+  code: string;
+  message: string;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -32,7 +32,7 @@ export type NotificationFrequency = 'INSTANT' | 'DAILY'; // * 향후 변경 가�
 export interface Notice {
   id: string;
   title: string;
-  category: NoticeCategory | string; // 백엔드에서 '학과공지' 등 추가 값 가능성이 있지만 그 부분들은 현재는 null로 보내주기로 함
+  category: NoticeCategory | null; // 백엔드에서 '학과공지' 등 추가 값 가능성이 있지만 그 부분들은 현재는 null로 보내주기로 함
   /** 작성 부서 (ERD NOT NULL) */
   department: string;
   /** 공지 원문 링크 */


### PR DESCRIPTION
# 📖 작업 배경

Phase 4(검색 화면)까지 Mock 기반 구현이 완료된 상태에서, 백엔드 팀이 실제 API 명세 4종을 제공했다. Mock 시점에 프론트가 추측으로 정의한 타입·필드명·상태값과 실제 백엔드 응답 사이에 다음과 같은 불일치가 확인되어, **실제 API 전환 전에 프론트 코드를 백엔드 계약 기준으로 정합**하는 작업이 본 PR의 주된 내용이다.

1. **필드명 차이** — `noticeId ↔ id`, `publishedAt ↔ postedAt`
2. **`aiSummaryStatus` 허용값** — `DONE/PROCESSING` (Mock 가정) vs `SUCCESS/SKIPPED/FAILED` (ERD 실제)
3. **AI 요약 형식** — bullet 텍스트(Mock) vs JSON 배열 문자열(실제)
4. **검색 응답이 슬림 페이로드** — `aiSummary/url/isBookmarked/tags` 미포함 (행 UI 전용)
5. **검색 URL** — 프론트 명세 `/api/search/notices` vs 백엔드 실제 `/api/notices/search`
6. **`dDay`(파생) → `deadlineAt`(원천)** 변경 협의

또한 Phase 5(통합 검증)도 본 PR에 함께 포함된다. 
- 5-1(네비 회귀)·5-3(UX 일관성)·5-4(실기기 회귀)는 직접 확인 완료, 
- 5-2(Mock↔실API 전환 구조)는 fetcher 4종 신설로 준비 완료, 
- 5-5(성능 점검)는 실제 데이터 볼륨이 필요한 작업이라 Sprint 2로 이연

본 PR은 어떤 새 화면도 추가하지 않고 정리 및 검증 작업이다.

- #16

<br>

## 🔧 작업 내용

### 신규 파일

- `src/services/notices.ts` — 실제 API fetcher 4종 (`fetchNotices` / `fetchNoticeById` / `fetchSearchNotices` / `toggleBookmark`) + 양방향 페이지 변환 + 슬림 매핑

### 수정 파일

- `src/types/api.ts` — `SearchNoticeListItem = Pick<Notice, ...>` 슬림 타입 신설
- `src/features/notices/components/CategoryBadge.tsx` — prop 타입을 백엔드 enum 외 값에 대응하도록 넓힘
- `src/features/search/components/SearchResultItem.tsx` — props 타입 `Notice` → `SearchNoticeListItem`
- `src/mocks/notices.ts` — `getMockSearchNotices` 슬림 매핑 추가 + `||`/`??` 괄호
- `app/(tabs)/search.tsx` — 슬림 타입 동기화 + `handleSelectHistory`에 `addEntry(keyword)` 추가 (행 탭 시 최근 검색어 최상단 이동)
- `app/(tabs)/index.tsx`, `app/notice/[id].tsx` — 즐겨찾기 TODO 주석에 fetcher 안내 추가
- `src/services/notices.ts`에 `normalizeCategory` 헬퍼 — 백엔드 응답의 enum 외 카테고리(예: "학과공지")를 `null`로 정규화 (협의 사항 안전망)

<br>

## 🔍 동작 방식

### 백엔드 ↔ 프론트 매핑 (fetcher 경계)

```
─────────── 백엔드 응답 ───────────       ─────────── 프론트 도메인 ───────────
GET /api/notices                ──→   fetchNotices
  { noticeId, publishedAt, ... }       → mapListItemToNotice
                                       → Notice (id, postedAt, ...)

GET /api/notices/{id}           ──→   fetchNoticeById
  { noticeId, ..., aiSummary }         → mapDetailToNotice
                                       → Notice

GET /api/notices/search         ──→   fetchSearchNotices
  슬림 6필드                            → mapSearchItem
                                       → SearchNoticeListItem (Pick)

POST /api/notices/{id}/bookmark ──→   toggleBookmark
  { noticeId, isBookmarked }           → BookmarkToggleResponse
```

### 양방향 페이지 변환

`useInfiniteQuery`의 `getNextPageParam`이 항상 1-based만 보도록 fetcher 안쪽에서 캡슐화. 화면 코드에는 0-based가 노출되지 않는다.

```
요청  프론트 1-based → 백엔드 0-based   (page - 1)
응답  백엔드 0-based → 프론트 1-based   (page + 1)
```

### 검색 슬림 타입의 책임 격리

```
Notice (카드 UI용)               SearchNoticeListItem (행 UI용)
─────────────────                ─────────────────────────────
id                               id
title                            title   ← 검색어 하이라이트
category                         category
department                       department
postedAt                         postedAt
deadlineAt?                      deadlineAt?
url                              ✕ (외부 이동 안 함)
aiSummary, aiSummaryStatus       ✕ (행 UI에 요약 없음)
isBookmarked                     ✕ (행에서 토글 안 함)
viewCount, tags                  ✕
```

`SearchResultItem`이 무심코 `notice.aiSummary`를 참조하면 TS 컴파일 단계에서 차단.

### Sprint 2 전환 흐름

```
Sprint 1 (현재)                   Sprint 2 (인증 활성화 후)
─────────────                    ─────────────────────────
useNotices    → getMockNotices    useNotices    → fetchNotices
useNoticeById → getMockNoticeById useNoticeById → fetchNoticeById
useSearchNotices → getMockSearchNotices  useSearchNotices → fetchSearchNotices
```

훅의 `queryFn` 한 줄만 교체하면 화면 코드는 무수정.

<br>

## 💡 설계 근거

- **검색 결과 응답을 슬림으로 받는 게 옳은 이유**: 
  - 검색 결과는 사용자가 "원하는 것 찾기 위해 훑어보는" 단계라 대부분의 행은 클릭되지 않는다.
  - 모든 행에 풍부한 메타(`aiSummary`, `url`, `isBookmarked`, `tags`)를 실어 보내면 트래픽·렌더링이 둘 다 손해.
  - 행 탭 시 상세 화면으로 라우팅되어 거기서 풀 페이로드를 다시 조회하는 게 모바일 친화적.

- **검색용 타입을 `Pick<Notice, ...>` 슬림으로 분리한 이유!!**: 
  - `Notice` 풀 객체를 옵셔널 천국으로 만들면 어디서나 null 가드가 필요해진다.
  - `SearchNoticeListItem`을 별도 정의하면 `Notice`는 카드 UI용으로 비교적 엄격하게 유지 가능.
  - 무심코 `aiSummary`를 참조하면 TS 컴파일 단계에서 즉시 차단.
  - `queryFn` 반환 타입에서 자동 추론되므로 훅·화면 코드가 사슬을 타고 자동 동기화.

- **`dDay → deadlineAt` 변경 협의가 옳은 이유**: 
  - `dDay`는 *조회 시점*에 따라 값이 변하는 파생 데이터 → HTTP 캐시·TanStack Query stale 정책과 충돌.
  - 1시간 뒤 같은 응답을 다시 봐도 의미가 유지되어야 캐싱 가치가 있다.
  - 무엇보다 관련 유틸 함수는 클라이언트 측에서 먼저 만들어졌다.

- **양방향 페이지 변환을 fetcher 안에 캡슐화**: 
  - 요청만 `page - 1`로 변환하고 응답을 그대로 두면, `getNextPageParam`이 받는 `last.page`가 0-based가 되어 `last.page + 1 = 1`이 *백엔드의 다음 페이지*인지 *프론트의 다음 페이지*인지 모호해진다.
  - fetcher가 응답에서도 `page + 1`로 해야 프론트 내부 코드가 페이지 진영을 한쪽(1-based)으로만 알게 됨.

- **`CategoryBadge`의 prop을 `NoticeCategory | null`)으로 넓힘**: 
  - 백엔드랑 협의 본 부분 enum타입에 포함되지 않지만, 속성으로 넘어가는 부분에 대해서는 `null`로 보내기로 합의

- **즐겨찾기 mutation 훅을 Sprint 2로 이연한 이유**: 
  - 인증 토큰 인터셉터가 비활성인 현재 상태에서 mutation을 만들어봤자 호출 즉시 401 반환.
  - 호출이 검증된 적이 없는 코드를 메인에 두면 *진짜 동작 여부*가 미스터리로 남는다.
  - "지금 끝낸 척"보다 "지금 가능한 것까지만 + 다음에 할 것 명시"가 훨씬 낫다.
  - fetcher는 인증과 무관하게 시그니처가 확정 가능하므로 미리 작성, 호출 측 TODO 주석에 사용 예시만 안내.

<br>

## ✅ 체크리스트

- [x] `npx tsc --noEmit` 오류 없음 (각 단계 게이트마다 통과 확인)
- [x] `services/notices.ts` fetcher 4종 작성 + 양방향 페이지 변환
- [x] `SearchNoticeListItem` 슬림 타입으로 검색 응답 책임 격리
- [x] `CategoryBadge` prop widening — 백엔드 enum 외 값 대응
- [x] `AiSummarySection`의 `SUCCESS / PENDING / SKIPPED / FAILED` 4상태 분기 + JSON 배열 파싱 (`parseSummary`) 확인
- [x] `Mock fetcher`의 1-based echo 동작과 실제 fetcher의 응답 정규화가 같은 계약 위에서 동작 확인
- [x] 즐겨찾기 fetcher는 단일 POST 토글 (`{ noticeId, isBookmarked }` 응답) — 호출 측 TODO 주석에 사용 예시 안내
- [x] 최근 검색어 행 탭 시 `addEntry` 호출로 최상단 이동 (zustand dedup 활용)
- [x] `normalizeCategory`로 백엔드 enum 외 카테고리 값을 `null`로 안전 변환
- [x] (수동 검증) 메인 → 상세 → 뒤로 흐름 확인 (5-1)
- [x] (수동 검증) 검색 → 상세 → 뒤로 흐름 확인 (5-1)
- [x] (수동 검증) 로딩 / 에러 / 빈 결과 UX 패턴이 화면 간 동일 (5-3)
- [x] (수동 검증) 갤럭시 실기기에서 메인/상세/검색 흐름 확인 (5-4)
- [ ] 성능 점검 (5-5) — Sprint 2 follow-up (실제 데이터 볼륨에서 측정)

<br>

## 🔗 연관 이슈

- #4  
- #41 