### PR TITLE
[FEAT] 공지 상세조회 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
@@ -1,12 +1,14 @@
 package org.cathori.backend.notice.api;
 
 import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.api.dto.NoticeDetailResponse;
 import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
 import org.cathori.backend.notice.application.NoticeFeedService;
 import org.cathori.backend.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +32,12 @@ public class NoticeController {
                 userDetails.getUserId(), category, tags, page, size
         );
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<NoticeDetailResponse> getDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long noticeId) {
+        return ResponseEntity.ok(noticeFeedService.getDetail(userDetails.getUserId(), noticeId));
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
@@ -1,0 +1,16 @@
+package org.cathori.backend.notice.api.dto;
+
+import java.time.LocalDate;
+
+public record NoticeDetailResponse(
+        Long noticeId,
+        String category,
+        String title,
+        String department,
+        LocalDate publishedAt,
+        String aiSummary,
+        String aiSummaryStatus,
+        String url,
+        boolean isBookmarked,
+        Integer dDay
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeErrorCode.java
@@ -18,16 +18,16 @@ public enum NoticeErrorCode implements ErrorCode {
 
     @Override
     public HttpStatus getStatus() {
-        return null;
+        return status;
     }
 
     @Override
     public String getCode() {
-        return "";
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -1,9 +1,13 @@
 package org.cathori.backend.notice.application;
 
 import lombok.RequiredArgsConstructor;
+import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
 import org.cathori.backend.common.exception.BusinessException;
 import org.cathori.backend.notice.api.dto.NoticeFeedItem;
 import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
+import org.cathori.backend.notice.api.dto.NoticeDetailResponse;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.user.UserErrorCode;
 import org.cathori.backend.user.domain.User;
 import org.cathori.backend.user.domain.UserRepository;
@@ -21,6 +25,8 @@ public class NoticeFeedService {
 
     private final NoticeFeedPort noticeFeedPort;
     private final UserRepository userRepository;
+    private final NoticeRepository noticeRepository;
+    private final BookmarkJpaRepository bookmarkJpaRepository;
 
     /**
      * 사용자의 전공·복수전공을 자동으로 주입해 개인화된 공지 피드를 구성하는 메인 유스케이스.
@@ -64,6 +70,32 @@ public class NoticeFeedService {
                 .toList();
 
         return new NoticeFeedResponse(content, page, size, hasNext);
+    }
+
+    @Transactional
+    public NoticeDetailResponse getDetail(Long userId, Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BusinessException(NoticeErrorCode.NOTICE_NOT_FOUND));
+
+        noticeRepository.incrementViewCount(noticeId);
+
+        boolean isBookmarked = bookmarkJpaRepository.existsByUserIdAndNoticeId(userId, noticeId);
+
+        return toDetail(notice, isBookmarked);
+    }
+
+    private NoticeDetailResponse toDetail(Notice notice, boolean isBookmarked) {
+        String aiSummary = "SUCCESS".equals(notice.getAiSummaryStatus()) ? notice.getAiSummary() : null;
+        String category = (notice.getCategory() == null || notice.getCategory().isBlank())
+                ? "학과공지" : notice.getCategory();
+        Integer dDay = notice.getDeadlineAt() != null
+                ? (int) ChronoUnit.DAYS.between(LocalDate.now(), notice.getDeadlineAt())
+                : null;
+        return new NoticeDetailResponse(
+                notice.getId(), category, notice.getTitle(), notice.getDepartment(),
+                notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
+                notice.getUrl(), isBookmarked, dDay
+        );
     }
 
     /**

--- a/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
@@ -2,6 +2,7 @@ package org.cathori.backend.notice.model;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,6 +12,10 @@ import java.util.Optional;
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     boolean existsByArticleNo(String articleNo);
+
+    @Modifying
+    @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :id")
+    void incrementViewCount(@Param("id") Long id);
 
     @Query(value = "SELECT MAX(CAST(article_no AS INTEGER)) FROM notices" +
             " WHERE source_type = :sourceType AND (source_id = :sourceId OR source_id IS NULL)",


### PR DESCRIPTION
## 🔧 작업 내용
공지 상세 조회 API 구현 (`GET /api/notices/{noticeId}`)

- `NoticeController`에 `getDetail` 엔드포인트 추가
- `NoticeDetailResponse` DTO 추가
- `NoticeFeedService.getDetail()` 서비스 로직 구현
- `NoticeRepository.incrementViewCount()` 쿼리 메서드 추가
- `NoticeErrorCode` 메서드 반환값 버그 수정

## 🔍 동작 방식
1. JWT에서 `userId` 추출
2. `noticeId`로 공지 조회 → 없으면 `NOTICE_NOT_FOUND` (404)
3. `view_count + 1` 업데이트
4. 북마크 여부 조회 (`userId` + `noticeId`)
5. `ai_summary_status` 확인 → `SUCCESS`면 `aiSummary` 반환, 그 외 null
6. `category` null/blank면 "학과공지"로 변환
7. `deadline_at` 기준 D-day 계산 (없으면 null)
8. 응답 반환

## 💡 설계 근거
- **`aiSummaryStatus`를 응답에 포함한 이유**: `aiSummary`가 null일 때 프론트가 "요약 준비 중"과 "요약 없음"을 구분할 수 있도록 상태값도 함께 내려줌
- **`incrementViewCount`를 `@Modifying` JPQL로 구현한 이유**: `findById` 후 setter로 업데이트하면 dirty checking으로 처리되지만, 동시 요청 시 race condition이 생길 수 있어 DB 레벨 단일 쿼리로 처리
- **`getDetail`에 `@Transactional` 적용**: `incrementViewCount`가 `@Modifying`이라 트랜잭션 컨텍스트 필요

## ✅ 체크리스트
- [ x] 존재하지 않는 `noticeId` 요청 시 404 응답 확인
- [ x] 조회 시 `view_count` 실제로 증가하는지 DB 확인
- [ x] 북마크 여부 true/false 정상 반환 확인
- [ x] `ai_summary_status`가 `PENDING`, `FAILED`일 때 `aiSummary` null 반환 확인
- [ x] `category`가 null인 학과공지에서 "학과공지" 반환 확인. 
- [ x] `deadline_at` 없는 공지에서 `dDay` null 반환 확인

## 🔗 연관 이슈
closes #28 

## 비고
- null 대신 학과 공지반환
- deadLineAt이 응답DTO에 없는것
- 기타 FE 정훈의 요청사항은 이번 PR에는 없음. 
- 이유는 현재 PR은 FE 요청이 오기전에 구현된부분이고, 정훈의 요청을 반영한 PR은 따로 올릴예정임
- 그 PR에 noticeID String, deadLineAt 응답필드, 학과공지대신 null 등. 요구사항이 반영되어있음.
