### PR TITLE
[FEAT] 통합테스트 코드 및 Swagger 설정

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -39,9 +39,10 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
     annotationProcessor("org.projectlombok:lombok")
     implementation("org.jsoup:jsoup:1.18.1")
-    testImplementation("org.springframework.boot:spring-boot-starter-batch-test")
-    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
-    testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:testcontainers-postgresql:2.0.5")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/backend/src/main/java/org/cathori/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/cathori/backend/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.cathori.backend.config;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.cathori.backend.security.JwtFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,11 +31,18 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/auth/register",
                                 "/api/auth/email/send",
-                                "/api/auth/email/verify"
+                                "/api/auth/email/verify",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(ex -> ex
+                    .authenticationEntryPoint((request, response, authException) ->
+                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                );
 
         return http.build();
     }

--- a/backend/src/main/java/org/cathori/backend/config/SwaggerConfig.java
+++ b/backend/src/main/java/org/cathori/backend/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package org.cathori.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme bearerScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name("bearerAuth");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(new Info().title("Cathori API").version("v1"))
+                .addSecurityItem(securityRequirement)
+                .components(new Components().addSecuritySchemes("bearerAuth", bearerScheme));
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/tag/api/dto/CreateTagRequest.java
+++ b/backend/src/main/java/org/cathori/backend/tag/api/dto/CreateTagRequest.java
@@ -1,10 +1,12 @@
 package org.cathori.backend.tag.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record CreateTagRequest(
+        @Schema(example = "장학")
         @NotBlank
         @Size(max = 20)
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$")

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/EmailSendRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/EmailSendRequest.java
@@ -1,9 +1,11 @@
 package org.cathori.backend.user.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record EmailSendRequest(
+        @Schema(example = "user256@catholic.ac.kr")
         @NotBlank(message = "이메일을 입력해 주세요")
         @Email(message = "이메일 형식이 올바르지 않습니다")
         String email

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/EmailVerifyRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/EmailVerifyRequest.java
@@ -1,13 +1,16 @@
 package org.cathori.backend.user.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record EmailVerifyRequest(
+        @Schema(example = "user256@catholic.ac.kr")
         @NotBlank(message = "이메일을 입력해 주세요")
         @Email(message = "이메일 형식이 올바르지 않습니다")
         String email,
 
+        @Schema(example = "482917")
         @NotBlank(message = "인증번호를 입력해 주세요")
         String code
 ) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/LoginRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/LoginRequest.java
@@ -1,9 +1,10 @@
 package org.cathori.backend.user.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
-        @Email @NotBlank String email,
-        @NotBlank String password
+        @Schema(example = "user256@catholic.ac.kr") @Email @NotBlank String email,
+        @Schema(example = "password123!") @NotBlank String password
 ) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/RegisterRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/RegisterRequest.java
@@ -1,24 +1,31 @@
 package org.cathori.backend.user.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 public record RegisterRequest(
+        @Schema(example = "user256@catholic.ac.kr")
         @NotBlank(message = "이메일을 입력해 주세요")
         @Email(message = "이메일 형식이 올바르지 않습니다")
         String email,
 
+        @Schema(example = "password123!")
         @NotBlank(message = "비밀번호를 입력해 주세요")
         String password,
 
+        @Schema(example = "컴퓨터정보공학부")
         @NotBlank(message = "전공을 입력해 주세요")
         String major1,
 
+        @Schema(example = "수학과")
         String major2,
 
+        @Schema(example = "2")
         @Min(value = 1, message = "학년은 1 이상이어야 합니다")
         @Max(value = 4, message = "학년은 4 이하이어야 합니다")
         int grade,
 
+        @Schema(example = "재학")
         @NotBlank(message = "재학 상태를 입력해 주세요")
         String status
 ) {}

--- a/backend/src/test/java/org/cathori/backend/IntegrationTestBase.java
+++ b/backend/src/test/java/org/cathori/backend/IntegrationTestBase.java
@@ -1,0 +1,12 @@
+package org.cathori.backend;
+
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public abstract class IntegrationTestBase {
+}

--- a/backend/src/test/java/org/cathori/backend/bookmark/api/BookmarkIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/bookmark/api/BookmarkIntegrationTest.java
@@ -1,0 +1,143 @@
+package org.cathori.backend.bookmark.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.bookmark.domain.Bookmark;
+import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("북마크 통합 테스트")
+class BookmarkIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired BookmarkJpaRepository bookmarkJpaRepository;
+    @Autowired JwtUtil jwtUtil;
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final String EMAIL_A = "bookmarktest_a@catholic.ac.kr";
+    private static final String EMAIL_B = "bookmarktest_b@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+
+    private Long userAId;
+    private Long userBId;
+    private String tokenA;
+    private String tokenB;
+
+    @BeforeEach
+    void setUp() {
+        verifiedEmailStore.markVerified(EMAIL_A);
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "csie", null, 2, "재학"));
+        userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
+        tokenA = jwtUtil.generateAccessToken(userAId);
+
+        verifiedEmailStore.markVerified(EMAIL_B);
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "csie", null, 2, "재학"));
+        userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
+        tokenB = jwtUtil.generateAccessToken(userBId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        bookmarkJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+        userJpaRepository.findByEmail(EMAIL_A).ifPresent(userJpaRepository::delete);
+        userJpaRepository.findByEmail(EMAIL_B).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL_A);
+        verifiedEmailStore.remove(EMAIL_B);
+    }
+
+    private Notice saveNotice() {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType("MAIN")
+                .sourceId(null)
+                .category("장학")
+                .title("테스트 공지")
+                .department("학생처")
+                .postedAt(LocalDate.now().toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        return noticeRepository.save(Notice.from(crawled));
+    }
+
+    @Test
+    @DisplayName("B-1: 인증 없이 요청 시 401 반환")
+    void toggle_unauthorized() throws Exception {
+        mockMvc.perform(post("/api/notices/1/bookmark"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("B-2: 존재하지 않는 noticeId 토글 시 404 NOTICE_NOT_FOUND 반환")
+    void toggle_noticeNotFound() throws Exception {
+        mockMvc.perform(post("/api/notices/99999/bookmark")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOTICE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("B-3: 북마크 없는 공지 토글 시 200, isBookmarked=true 반환 (추가)")
+    void toggle_addBookmark() throws Exception {
+        Notice notice = saveNotice();
+
+        mockMvc.perform(post("/api/notices/" + notice.getId() + "/bookmark")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.noticeId").value(notice.getId()))
+                .andExpect(jsonPath("$.isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("B-4: 이미 북마크한 공지 토글 시 200, isBookmarked=false 반환 (삭제)")
+    void toggle_removeBookmark() throws Exception {
+        Notice notice = saveNotice();
+        bookmarkJpaRepository.save(Bookmark.create(userAId, notice.getId()));
+
+        mockMvc.perform(post("/api/notices/" + notice.getId() + "/bookmark")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.noticeId").value(notice.getId()))
+                .andExpect(jsonPath("$.isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("B-5: 유저A가 북마크한 공지를 유저B가 토글 시 200, isBookmarked=true 반환 (유저 간 독립)")
+    void toggle_independentPerUser() throws Exception {
+        Notice notice = saveNotice();
+        bookmarkJpaRepository.save(Bookmark.create(userAId, notice.getId()));
+
+        mockMvc.perform(post("/api/notices/" + notice.getId() + "/bookmark")
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(true));
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/bookmark/api/BookmarkIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/bookmark/api/BookmarkIntegrationTest.java
@@ -52,12 +52,12 @@ class BookmarkIntegrationTest extends IntegrationTestBase {
     @BeforeEach
     void setUp() {
         verifiedEmailStore.markVerified(EMAIL_A);
-        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "csie", null, 2, "재학"));
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "컴퓨터정보공학", null, 2, "재학"));
         userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
         tokenA = jwtUtil.generateAccessToken(userAId);
 
         verifiedEmailStore.markVerified(EMAIL_B);
-        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "csie", null, 2, "재학"));
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "컴퓨터정보공학", null, 2, "재학"));
         userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
         tokenB = jwtUtil.generateAccessToken(userBId);
     }

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
@@ -1,0 +1,225 @@
+package org.cathori.backend.notice.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.bookmark.domain.Bookmark;
+import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("공지 상세 조회 통합 테스트")
+class NoticeDetailIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired BookmarkJpaRepository bookmarkJpaRepository;
+    @Autowired JwtUtil jwtUtil;
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final String EMAIL = "detailtest@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+
+    private Long userId;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        verifiedEmailStore.markVerified(EMAIL);
+        authService.register(new RegisterRequest(EMAIL, PASSWORD, "csie", null, 2, "재학"));
+        userId = userJpaRepository.findByEmail(EMAIL).orElseThrow().getId();
+        token = jwtUtil.generateAccessToken(userId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        bookmarkJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+        userJpaRepository.findByEmail(EMAIL).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL);
+    }
+
+    private Notice saveNotice(String category, String title, LocalDate postedAt) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType("MAIN")
+                .sourceId(null)
+                .category(category)
+                .title(title)
+                .department("학생처")
+                .postedAt(postedAt.toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        return noticeRepository.save(Notice.from(crawled));
+    }
+
+    private Notice saveNoticeWithSummary(LocalDate deadline) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType("MAIN")
+                .sourceId(null)
+                .category("장학")
+                .title("요약 있는 공지")
+                .department("학생처")
+                .postedAt(LocalDate.now().toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        Notice notice = Notice.from(crawled);
+        String deadlineStr = deadline != null ? deadline.toString() : null;
+        notice.applySummary(new AiSummaryResult(List.of("요약 문장"), deadlineStr));
+        return noticeRepository.save(notice);
+    }
+
+    @Test
+    @DisplayName("ND-1: 인증 없이 요청 시 401 반환")
+    void getDetail_unauthorized() throws Exception {
+        mockMvc.perform(get("/api/notices/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("ND-2: 존재하지 않는 noticeId 조회 시 404 NOTICE_NOT_FOUND 반환")
+    void getDetail_notFound() throws Exception {
+        mockMvc.perform(get("/api/notices/99999")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOTICE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("ND-3: 성공 조회 시 200과 기본 필드 반환")
+    void getDetail_success() throws Exception {
+        Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.noticeId").value(notice.getId()))
+                .andExpect(jsonPath("$.category").value("장학"))
+                .andExpect(jsonPath("$.title").value("테스트 공지"))
+                .andExpect(jsonPath("$.department").value("학생처"))
+                .andExpect(jsonPath("$.publishedAt").isString())
+                .andExpect(jsonPath("$.url").value("https://test.catholic.ac.kr"))
+                .andExpect(jsonPath("$.aiSummaryStatus").value("PENDING"));
+    }
+
+    @Test
+    @DisplayName("ND-4: 북마크한 공지 조회 시 isBookmarked=true 반환")
+    void getDetail_isBookmarkedTrue() throws Exception {
+        Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
+        bookmarkJpaRepository.save(Bookmark.create(userId, notice.getId()));
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("ND-5: 북마크 안한 공지 조회 시 isBookmarked=false 반환")
+    void getDetail_isBookmarkedFalse() throws Exception {
+        Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("ND-6: aiSummaryStatus=SUCCESS 공지 조회 시 aiSummary 내용 반환")
+    void getDetail_aiSummary_success() throws Exception {
+        Notice notice = saveNoticeWithSummary(null);
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.aiSummaryStatus").value("SUCCESS"))
+                .andExpect(jsonPath("$.aiSummary").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("ND-7: aiSummaryStatus=PENDING 공지 조회 시 aiSummary=null 반환")
+    void getDetail_aiSummary_pending() throws Exception {
+        Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.aiSummaryStatus").value("PENDING"))
+                .andExpect(jsonPath("$.aiSummary").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("ND-8: deadlineAt 있는 공지 조회 시 dDay 반환")
+    void getDetail_dDay_returned() throws Exception {
+        Notice futureNotice = saveNoticeWithSummary(LocalDate.now().plusDays(10));
+        Notice pastNotice   = saveNoticeWithSummary(LocalDate.now().minusDays(3));
+
+        mockMvc.perform(get("/api/notices/" + futureNotice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dDay").value(greaterThan(0)));
+
+        mockMvc.perform(get("/api/notices/" + pastNotice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dDay").value(lessThan(0)));
+    }
+
+    @Test
+    @DisplayName("ND-9: deadlineAt 없는 공지 조회 시 dDay=null 반환")
+    void getDetail_dDay_null() throws Exception {
+        Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dDay").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("ND-10: 공지 조회 시 viewCount 1 증가")
+    void getDetail_incrementsViewCount() throws Exception {
+        Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/" + notice.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        long viewCount = noticeRepository.findById(notice.getId())
+                .orElseThrow()
+                .getViewCount();
+        assertThat(viewCount).isEqualTo(1L);
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
@@ -52,7 +52,7 @@ class NoticeDetailIntegrationTest extends IntegrationTestBase {
     @BeforeEach
     void setUp() {
         verifiedEmailStore.markVerified(EMAIL);
-        authService.register(new RegisterRequest(EMAIL, PASSWORD, "csie", null, 2, "재학"));
+        authService.register(new RegisterRequest(EMAIL, PASSWORD, "컴퓨터정보공학", null, 2, "재학"));
         userId = userJpaRepository.findByEmail(EMAIL).orElseThrow().getId();
         token = jwtUtil.generateAccessToken(userId);
     }

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
@@ -60,12 +60,12 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     @BeforeEach
     void setUp() {
         verifiedEmailStore.markVerified(EMAIL_A);
-        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "csie", "ai", 2, "재학"));
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "컴퓨터정보공학", "인공지능", 2, "재학"));
         userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
         tokenA = jwtUtil.generateAccessToken(userAId);
 
         verifiedEmailStore.markVerified(EMAIL_B);
-        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "csie", "전공심화", 2, "재학"));
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "컴퓨터정보공학", "전공심화", 2, "재학"));
         userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
         tokenB = jwtUtil.generateAccessToken(userBId);
     }
@@ -158,11 +158,11 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("NF-2: 기본 피드 — MAIN + 전공(csie) 공지 포함, 무관 학과 제외")
+    @DisplayName("NF-2: 기본 피드 — MAIN + 전공(CSIE) 공지 포함, 무관 학과 제외")
     void getFeed_case1_defaultFeed() throws Exception {
         saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
-        saveNotice("DEPARTMENT", "csie", "학과공지", "csie 학과 공지", TODAY);
-        saveNotice("DEPARTMENT", "business", "학과공지", "business 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "BUSINESS", "학과공지", "business 학과 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA))
@@ -175,11 +175,11 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("NF-3: secondMajor=전공심화인 유저 — ai 학과 공지 제외")
+    @DisplayName("NF-3: secondMajor=전공심화인 유저 — AI 학과 공지 제외")
     void getFeed_case1_excludeJeonGongSimhwa() throws Exception {
         saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
-        saveNotice("DEPARTMENT", "csie", "학과공지", "csie 학과 공지", TODAY);
-        saveNotice("DEPARTMENT", "ai", "학과공지", "ai 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "AI", "학과공지", "ai 학과 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenB))
@@ -196,7 +196,7 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     void getFeed_case2_categoryFilter() throws Exception {
         saveNotice("MAIN", null, "장학", "장학 공지", TODAY);
         saveNotice("MAIN", null, "취업", "취업 공지", TODAY);
-        saveNotice("DEPARTMENT", "csie", "장학", "csie 장학 공지", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "장학", "csie 장학 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA)
@@ -227,7 +227,7 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     void getFeed_case3_tagFilter() throws Exception {
         saveNotice("MAIN", null, "장학", "장학금 신청 안내", TODAY);
         saveNotice("MAIN", null, "취업", "일반 공지", TODAY);
-        saveNotice("DEPARTMENT", "csie", "학과공지", "장학금 혜택 안내", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "장학금 혜택 안내", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA)
@@ -257,7 +257,7 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     void getFeed_case4_unionPriority() throws Exception {
         saveNotice("MAIN", null, "장학", "장학금 공모", TODAY);           // priority 1
         saveNotice("MAIN", null, "장학", "일반 행사 안내", TODAY.minusDays(1)); // priority 2
-        saveNotice("DEPARTMENT", "csie", "학과공지", "장학 혜택 안내", TODAY); // priority 1
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "장학 혜택 안내", TODAY); // priority 1
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA)

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
@@ -1,0 +1,394 @@
+package org.cathori.backend.notice.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.bookmark.domain.Bookmark;
+import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("공지피드 통합 테스트")
+class NoticeFeedIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired BookmarkJpaRepository bookmarkJpaRepository;
+    @Autowired JwtUtil jwtUtil;
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final String EMAIL_A = "feedtest_a@catholic.ac.kr";
+    private static final String EMAIL_B = "feedtest_b@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+
+    private Long userAId;
+    private Long userBId;
+    private String tokenA;
+    private String tokenB;
+
+    @BeforeEach
+    void setUp() {
+        verifiedEmailStore.markVerified(EMAIL_A);
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "csie", "ai", 2, "재학"));
+        userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
+        tokenA = jwtUtil.generateAccessToken(userAId);
+
+        verifiedEmailStore.markVerified(EMAIL_B);
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "csie", "전공심화", 2, "재학"));
+        userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
+        tokenB = jwtUtil.generateAccessToken(userBId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        bookmarkJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+        userJpaRepository.findByEmail(EMAIL_A).ifPresent(userJpaRepository::delete);
+        userJpaRepository.findByEmail(EMAIL_B).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL_A);
+        verifiedEmailStore.remove(EMAIL_B);
+    }
+
+    // ── 픽스처 헬퍼 ─────────────────────────────────────────────────────────
+
+    private Notice saveNotice(String sourceType, String sourceId,
+                               String category, String title, LocalDate postedAt) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType(sourceType)
+                .sourceId(sourceId)
+                .category(category)
+                .title(title)
+                .department("테스트학과")
+                .postedAt(postedAt.toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        return noticeRepository.save(Notice.from(crawled));
+    }
+
+    private Notice saveNoticeWithSummary(String sourceType, String sourceId,
+                                          String category, String title,
+                                          LocalDate postedAt, LocalDate deadline) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType(sourceType)
+                .sourceId(sourceId)
+                .category(category)
+                .title(title)
+                .department("테스트학과")
+                .postedAt(postedAt.toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        Notice notice = Notice.from(crawled);
+        String deadlineStr = deadline != null ? deadline.toString() : null;
+        notice.applySummary(new AiSummaryResult(List.of("요약 문장"), deadlineStr));
+        return noticeRepository.save(notice);
+    }
+
+    private Notice saveNoticeWithFailedSummary(String sourceType, String sourceId,
+                                                String category, String title, LocalDate postedAt) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType(sourceType)
+                .sourceId(sourceId)
+                .category(category)
+                .title(title)
+                .department("테스트학과")
+                .postedAt(postedAt.toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        Notice notice = Notice.from(crawled);
+        notice.markSummaryFailed();
+        return noticeRepository.save(notice);
+    }
+
+    private List<String> extractTitles(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        List<String> titles = new ArrayList<>();
+        root.get("content").forEach(item -> titles.add(item.get("title").asText()));
+        return titles;
+    }
+
+    private static final LocalDate TODAY = LocalDate.now();
+
+    // ── 테스트 케이스 ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("NF-1: 인증 없이 요청 시 401 반환")
+    void getFeed_unauthorized() throws Exception {
+        mockMvc.perform(get("/api/notices"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("NF-2: 기본 피드 — MAIN + 전공(csie) 공지 포함, 무관 학과 제외")
+    void getFeed_case1_defaultFeed() throws Exception {
+        saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
+        saveNotice("DEPARTMENT", "csie", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "business", "학과공지", "business 학과 공지", TODAY);
+
+        MvcResult result = mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<String> titles = extractTitles(result);
+        assertThat(titles).contains("MAIN 공지", "csie 학과 공지");
+        assertThat(titles).doesNotContain("business 학과 공지");
+    }
+
+    @Test
+    @DisplayName("NF-3: secondMajor=전공심화인 유저 — ai 학과 공지 제외")
+    void getFeed_case1_excludeJeonGongSimhwa() throws Exception {
+        saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
+        saveNotice("DEPARTMENT", "csie", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "ai", "학과공지", "ai 학과 공지", TODAY);
+
+        MvcResult result = mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<String> titles = extractTitles(result);
+        assertThat(titles).contains("MAIN 공지", "csie 학과 공지");
+        assertThat(titles).doesNotContain("ai 학과 공지");
+    }
+
+    @Test
+    @DisplayName("NF-4: 카테고리 필터 — 해당 카테고리 MAIN 공지만 반환")
+    void getFeed_case2_categoryFilter() throws Exception {
+        saveNotice("MAIN", null, "장학", "장학 공지", TODAY);
+        saveNotice("MAIN", null, "취업", "취업 공지", TODAY);
+        saveNotice("DEPARTMENT", "csie", "장학", "csie 장학 공지", TODAY);
+
+        MvcResult result = mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("category", "장학"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<String> titles = extractTitles(result);
+        assertThat(titles).contains("장학 공지");
+        assertThat(titles).doesNotContain("취업 공지", "csie 장학 공지");
+    }
+
+    @Test
+    @DisplayName("NF-5: 매칭 공지 없는 카테고리 → 빈 배열")
+    void getFeed_case2_noMatch_emptyContent() throws Exception {
+        saveNotice("MAIN", null, "장학", "장학 공지", TODAY);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("category", "없는카테고리"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("NF-6: 태그 필터 — 제목 LIKE 매칭")
+    void getFeed_case3_tagFilter() throws Exception {
+        saveNotice("MAIN", null, "장학", "장학금 신청 안내", TODAY);
+        saveNotice("MAIN", null, "취업", "일반 공지", TODAY);
+        saveNotice("DEPARTMENT", "csie", "학과공지", "장학금 혜택 안내", TODAY);
+
+        MvcResult result = mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("tags", "장학금"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<String> titles = extractTitles(result);
+        assertThat(titles).contains("장학금 신청 안내", "장학금 혜택 안내");
+        assertThat(titles).doesNotContain("일반 공지");
+    }
+
+    @Test
+    @DisplayName("NF-7: 매칭 공지 없는 태그 → 빈 배열")
+    void getFeed_case3_noMatch_emptyContent() throws Exception {
+        saveNotice("MAIN", null, "장학", "일반 공지", TODAY);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("tags", "없는키워드"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("NF-8: 카테고리 + 태그 동시 — 태그 매칭 공지가 카테고리 매칭 공지보다 앞에 위치")
+    void getFeed_case4_unionPriority() throws Exception {
+        saveNotice("MAIN", null, "장학", "장학금 공모", TODAY);           // priority 1
+        saveNotice("MAIN", null, "장학", "일반 행사 안내", TODAY.minusDays(1)); // priority 2
+        saveNotice("DEPARTMENT", "csie", "학과공지", "장학 혜택 안내", TODAY); // priority 1
+
+        MvcResult result = mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("category", "장학")
+                        .param("tags", "장학"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<String> titles = extractTitles(result);
+        assertThat(titles).contains("장학금 공모", "일반 행사 안내", "장학 혜택 안내");
+        assertThat(titles.indexOf("일반 행사 안내"))
+                .isGreaterThan(titles.indexOf("장학금 공모"));
+    }
+
+    @Test
+    @DisplayName("NF-9: 결과가 size 초과 시 hasNext=true")
+    void getFeed_pagination_hasNextTrue() throws Exception {
+        saveNotice("MAIN", null, "장학", "공지1", TODAY);
+        saveNotice("MAIN", null, "장학", "공지2", TODAY.minusDays(1));
+        saveNotice("MAIN", null, "장학", "공지3", TODAY.minusDays(2));
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("size", "2")
+                        .param("page", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.content", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("NF-10: 마지막 페이지 시 hasNext=false")
+    void getFeed_pagination_hasNextFalse() throws Exception {
+        saveNotice("MAIN", null, "장학", "공지1", TODAY);
+        saveNotice("MAIN", null, "장학", "공지2", TODAY.minusDays(1));
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("size", "5")
+                        .param("page", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("NF-11: 북마크한 공지 → isBookmarked=true")
+    void getFeed_bookmark_isBookmarkedTrue() throws Exception {
+        Notice notice = saveNotice("MAIN", null, "장학", "공지", TODAY);
+        bookmarkJpaRepository.save(Bookmark.create(userAId, notice.getId()));
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("NF-12: 북마크 없는 공지 → isBookmarked=false")
+    void getFeed_bookmark_isBookmarkedFalse() throws Exception {
+        saveNotice("MAIN", null, "장학", "공지", TODAY);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("NF-13: deadlineAt 없는 공지 → dDay=null")
+    void getFeed_dDay_null() throws Exception {
+        saveNotice("MAIN", null, "장학", "공지", TODAY);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].dDay").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("NF-14: deadlineAt 미래 → dDay > 0")
+    void getFeed_dDay_positive() throws Exception {
+        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, TODAY.plusDays(30));
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].dDay").value(greaterThan(0)));
+    }
+
+    @Test
+    @DisplayName("NF-15: deadlineAt 과거 → dDay < 0")
+    void getFeed_dDay_negative() throws Exception {
+        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, TODAY.minusDays(5));
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].dDay").value(lessThan(0)));
+    }
+
+    @Test
+    @DisplayName("NF-16: aiSummaryStatus=SUCCESS → aiSummary 내용 반환")
+    void getFeed_aiSummary_success() throws Exception {
+        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, null);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].aiSummary").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("NF-17: aiSummaryStatus=PENDING/FAILED → aiSummary=null")
+    void getFeed_aiSummary_nullWhenNotSuccess() throws Exception {
+        // PENDING
+        saveNotice("MAIN", null, "장학", "PENDING 공지", TODAY);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].aiSummary").value(nullValue()));
+
+        noticeRepository.deleteAll();
+
+        // FAILED
+        saveNoticeWithFailedSummary("MAIN", null, "장학", "FAILED 공지", TODAY);
+
+        mockMvc.perform(get("/api/notices")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].aiSummary").value(nullValue()));
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/tag/api/TagIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/tag/api/TagIntegrationTest.java
@@ -1,0 +1,180 @@
+package org.cathori.backend.tag.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.tag.api.dto.CreateTagRequest;
+import org.cathori.backend.tag.application.TagService;
+import org.cathori.backend.tag.infra.TagJpaRepository;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Tag 통합 테스트")
+class TagIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired TagJpaRepository tagJpaRepository;
+    @Autowired TagService tagService;
+    @Autowired JwtUtil jwtUtil;
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final String EMAIL_A = "tagtest_a@catholic.ac.kr";
+    private static final String EMAIL_B = "tagtest_b@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+    private static final String MAJOR = "컴퓨터공학과";
+
+    private Long userAId;
+    private Long userBId;
+    private String tokenA;
+    private String tokenB;
+
+    @BeforeEach
+    void setUp() {
+        verifiedEmailStore.markVerified(EMAIL_A);
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, MAJOR, null, 2, "재학"));
+        userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
+        tokenA = jwtUtil.generateAccessToken(userAId);
+
+        verifiedEmailStore.markVerified(EMAIL_B);
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, MAJOR, null, 2, "재학"));
+        userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
+        tokenB = jwtUtil.generateAccessToken(userBId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        tagJpaRepository.deleteAll();
+        userJpaRepository.findByEmail(EMAIL_A).ifPresent(userJpaRepository::delete);
+        userJpaRepository.findByEmail(EMAIL_B).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL_A);
+        verifiedEmailStore.remove(EMAIL_B);
+    }
+
+    @Test
+    @DisplayName("T-1: 태그 생성 성공 시 201과 tagId/tagName 반환")
+    void createTag_success() throws Exception {
+        mockMvc.perform(post("/api/tags")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("개발"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tagId").isNumber())
+                .andExpect(jsonPath("$.tagName").value("개발"));
+    }
+
+    @Test
+    @DisplayName("T-2: 인증 없이 태그 생성 요청 시 401 반환")
+    void createTag_unauthorized() throws Exception {
+        mockMvc.perform(post("/api/tags")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("개발"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("T-3: 유효하지 않은 tagName 입력 시 400 반환")
+    void createTag_invalidTagName() throws Exception {
+        mockMvc.perform(post("/api/tags")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("invalid!"))))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/tags")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("a".repeat(21)))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("T-4: 동일 유저가 중복 태그 생성 시 409 TAG_DUPLICATE 반환")
+    void createTag_duplicate() throws Exception {
+        tagService.createTag(userAId, "개발");
+
+        mockMvc.perform(post("/api/tags")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("개발"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TAG_DUPLICATE"));
+    }
+
+    @Test
+    @DisplayName("T-5: 태그 20개 보유 상태에서 추가 시 400 TAG_LIMIT_EXCEEDED 반환")
+    void createTag_limitExceeded() throws Exception {
+        for (int i = 1; i <= 20; i++) {
+            tagService.createTag(userAId, "태그" + i);
+        }
+
+        mockMvc.perform(post("/api/tags")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("태그21"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TAG_LIMIT_EXCEEDED"));
+    }
+
+    @Test
+    @DisplayName("T-6: 다른 유저가 동일 태그명 생성 시 201 반환 (유저 간 격리)")
+    void createTag_differentUser_sameTagName() throws Exception {
+        tagService.createTag(userAId, "개발");
+
+        mockMvc.perform(post("/api/tags")
+                        .header("Authorization", "Bearer " + tokenB)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateTagRequest("개발"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tagName").value("개발"));
+    }
+
+    @Test
+    @DisplayName("T-7: 본인 태그 삭제 성공 시 200 반환")
+    void deleteTag_success() throws Exception {
+        var tag = tagService.createTag(userAId, "개발");
+
+        mockMvc.perform(delete("/api/tags/" + tag.tagId())
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("T-8: 존재하지 않는 tagId 삭제 시 404 TAG_NOT_FOUND 반환")
+    void deleteTag_notFound() throws Exception {
+        mockMvc.perform(delete("/api/tags/99999")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TAG_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("T-9: 다른 유저의 태그 삭제 시도 시 404 TAG_NOT_FOUND 반환")
+    void deleteTag_otherUser() throws Exception {
+        var tag = tagService.createTag(userAId, "개발");
+
+        mockMvc.perform(delete("/api/tags/" + tag.tagId())
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TAG_NOT_FOUND"));
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/tag/api/TagIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/tag/api/TagIntegrationTest.java
@@ -41,7 +41,7 @@ class TagIntegrationTest extends IntegrationTestBase {
     private static final String EMAIL_A = "tagtest_a@catholic.ac.kr";
     private static final String EMAIL_B = "tagtest_b@catholic.ac.kr";
     private static final String PASSWORD = "password123!";
-    private static final String MAJOR = "컴퓨터공학과";
+    private static final String MAJOR = "컴퓨터정보공학";
 
     private Long userAId;
     private Long userBId;

--- a/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
@@ -37,7 +37,7 @@ class AuthIntegrationTest extends IntegrationTestBase {
 
     private static final String EMAIL    = "test@catholic.ac.kr";
     private static final String PASSWORD = "password123!";
-    private static final String MAJOR    = "컴퓨터공학과";
+    private static final String MAJOR    = "컴퓨터정보공학";
     private static final int    GRADE    = 2;
     private static final String STATUS   = "재학";
 

--- a/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
@@ -1,0 +1,134 @@
+package org.cathori.backend.user.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerificationStore;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.LoginRequest;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Auth 통합 테스트")
+class AuthIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired VerificationStore verificationStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @MockitoBean
+    NotificationPort notificationPort;
+
+    private static final String EMAIL    = "test@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+    private static final String MAJOR    = "컴퓨터공학과";
+    private static final int    GRADE    = 2;
+    private static final String STATUS   = "재학";
+
+    @AfterEach
+    void cleanup() {
+        userJpaRepository.findByEmail(EMAIL).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL);
+        verificationStore.remove(EMAIL);
+    }
+
+    private void createVerifiedUser(String email, String password) {
+        verifiedEmailStore.markVerified(email);
+        authService.register(new RegisterRequest(email, password, MAJOR, null, GRADE, STATUS));
+    }
+
+    @Test
+    @DisplayName("A-1: 이메일 인증 완료 후 회원가입 성공 시 201과 userId/email 반환")
+    void register_success() throws Exception {
+        verifiedEmailStore.markVerified(EMAIL);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(EMAIL, PASSWORD, MAJOR, null, GRADE, STATUS))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.email").value(EMAIL))
+                .andExpect(jsonPath("$.userId").isNumber());
+
+    }
+
+    @Test
+    @DisplayName("A-2: 이메일 인증 없이 회원가입 시 403 USER_NOT_VERIFIED 반환")
+    void register_emailNotVerified() throws Exception {
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(EMAIL, PASSWORD, MAJOR, null, GRADE, STATUS))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_NOT_VERIFIED"));
+    }
+
+    @Test
+    @DisplayName("A-3: 이미 가입된 이메일로 재가입 시 409 USER_EMAIL_DUPLICATE 반환")
+    void register_duplicateEmail() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+
+        verifiedEmailStore.markVerified(EMAIL);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest(EMAIL, PASSWORD, MAJOR, null, GRADE, STATUS))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("USER_EMAIL_DUPLICATE"));
+    }
+
+    @Test
+    @DisplayName("A-4: 올바른 이메일/비밀번호로 로그인 시 200과 JWT 토큰 반환")
+    void login_success() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest(EMAIL, PASSWORD))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isString())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty())
+                .andExpect(jsonPath("$.email").value(EMAIL))
+                .andExpect(jsonPath("$.userId").isNumber());
+    }
+
+    @Test
+    @DisplayName("A-5: 잘못된 비밀번호로 로그인 시 401 USER_INVALID_PASSWORD 반환")
+    void login_wrongPassword() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest(EMAIL, "wrongPassword!"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("USER_INVALID_PASSWORD"));
+    }
+
+    @Test
+    @DisplayName("A-6: 존재하지 않는 이메일로 로그인 시 404 USER_NOT_FOUND 반환")
+    void login_userNotFound() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest("nobody@catholic.ac.kr", PASSWORD))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용
Swagger UI 연동 및 API 통합 테스트 작성

- `springdoc-openapi` 의존성 추가 및 `SwaggerConfig` 설정
- Swagger UI 경로 Security 인증 예외 처리
- 미인증 요청 시 기본 동작을 401로 명시 (`authenticationEntryPoint` 추가)
- 각 Request DTO 필드에 `@Schema(example = ...)` 예시값 추가
- `IntegrationTestBase` 공통 베이스 클래스 추가
- 통합 테스트 작성: Auth / Tag / Bookmark / 공지 피드 / 공지 상세 조회

## 🔍 동작 방식
테스트 구조는 아래 흐름으로 동작한다.

1. `@SpringBootTest` + `@AutoConfigureMockMvc` + `@ActiveProfiles("test")`를 `IntegrationTestBase`로 공통화
2. 각 테스트는 `@BeforeEach`에서 인메모리 스토어에 이메일 인증 → 회원가입 → JWT 발급
3. MockMvc로 HTTP 요청 → 응답 상태코드 / JSON 필드 검증
4. `@AfterEach`에서 DB 및 인메모리 스토어 정리

## 💡 설계 근거
- **`authenticationEntryPoint` 추가**: 기존에는 미인증 요청 시 Spring Security 기본 동작(302 리다이렉트)이 발생할 수 있어서, 401을 명시적으로 반환하도록 설정. 테스트에서 401 검증이 가능해짐
- **`NotificationPort`를 `@MockitoBean`으로 처리**: FCM 발송이 테스트 환경에서 실제로 실행되지 않도록 mock 처리
- **픽스처 헬퍼 메서드 분리**: `saveNotice()` / `saveNoticeWithSummary()` 등으로 공지 생성 로직을 분리해 테스트 가독성 확보
- **`@AfterEach` 정리 순서**: FK 제약 때문에 bookmark → notice → user 순서로 삭제

## ✅ 체크리스트
- [x] `/swagger-ui/index.html` 접근 시 인증 없이 Swagger UI 정상 노출 확인
- [ x] JWT 없이 보호된 API 요청 시 401 반환 확인
- [x ] 전체 통합 테스트 로컬에서 통과 확인
- [ x] `@AfterEach` 정리 후 테스트 간 데이터 간섭 없는지 확인

## 🔗 연관 이슈
- closes #34 