### PR TITLE
[FEAT] 공지 검색기능 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/cathori/backend/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.cathori.backend.common.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -27,6 +28,18 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse("입력값이 올바르지 않습니다");
         log.warn("Validation failed: {}", message);
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse("INVALID_INPUT", message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .map(cv -> cv.getMessage())
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다");
+        log.warn("ConstraintViolation: {}", message);
         return ResponseEntity
                 .badRequest()
                 .body(new ErrorResponse("INVALID_INPUT", message));

--- a/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
@@ -1,18 +1,24 @@
 package org.cathori.backend.notice.api;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.cathori.backend.notice.api.dto.NoticeDetailResponse;
 import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
+import org.cathori.backend.notice.api.dto.NoticeSearchResponse;
 import org.cathori.backend.notice.application.NoticeFeedService;
 import org.cathori.backend.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/notices")
 @RequiredArgsConstructor
@@ -32,6 +38,19 @@ public class NoticeController {
                 userDetails.getUserId(), category, tags, page, size
         );
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<NoticeSearchResponse> search(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @NotBlank(message = "검색어를 입력해주세요")
+            @Size(max = 100, message = "검색어는 100자 이하여야 합니다")
+            @Pattern(regexp = "^[^;'\"\\\\=<>]*$", message = "검색어에 허용되지 않는 문자가 포함되어 있습니다")
+            @RequestParam String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        return ResponseEntity.ok(noticeFeedService.search(userDetails.getUserId(), q, page, size));
     }
 
     @GetMapping("/{noticeId}")

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
@@ -1,0 +1,19 @@
+package org.cathori.backend.notice.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+/**
+ * 공지 키워드 검색 결과 목록의 단건 항목.
+ *
+ * 사용자가 검색어를 입력했을 때 결과 목록에 표시되는 카드 한 장에 해당한다.
+ * dDay는 오늘 기준 마감일까지 남은 일수(양수=남음, 음수=초과, null=마감일 없는 공지).
+ */
+public record NoticeSearchItem(
+        @Schema(example = "1") Long noticeId,
+        @Schema(example = "장학") String category,
+        @Schema(example = "2026학년도 1학기 국가장학금 신청 안내") String title,
+        @Schema(example = "학생지원팀") String department,
+        @Schema(example = "2026-03-28") LocalDate publishedAt,
+        @Schema(example = "3") Integer dDay
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchResponse.java
@@ -1,0 +1,17 @@
+package org.cathori.backend.notice.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * 공지 키워드 검색의 페이징 응답.
+ *
+ * hasNext=true이면 다음 페이지가 존재하며, 클라이언트는 page를 +1해 추가 요청한다.
+ * 내부적으로 size+1건을 조회해 초과 여부로 hasNext를 판정하므로 content 크기는 최대 size개다.
+ */
+public record NoticeSearchResponse(
+        List<NoticeSearchItem> content,
+        @Schema(example = "0") int page,
+        @Schema(example = "10") int size,
+        @Schema(example = "true") boolean hasNext
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedPort.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public interface NoticeFeedPort {
     List<NoticeRow> findFeed(NoticeFeedQuery query);
+    List<NoticeSearchRow> findSearch(NoticeSearchQuery query);
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -6,6 +6,8 @@ import org.cathori.backend.common.exception.BusinessException;
 import org.cathori.backend.notice.api.dto.NoticeFeedItem;
 import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
 import org.cathori.backend.notice.api.dto.NoticeDetailResponse;
+import org.cathori.backend.notice.api.dto.NoticeSearchItem;
+import org.cathori.backend.notice.api.dto.NoticeSearchResponse;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.user.UserErrorCode;
@@ -70,6 +72,37 @@ public class NoticeFeedService {
                 .toList();
 
         return new NoticeFeedResponse(content, page, size, hasNext);
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeSearchResponse search(Long userId, String keyword, int page, int size) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        NoticeSearchQuery query = new NoticeSearchQuery(
+                userId, keyword, user.getMajor(), user.getSecondMajor(), page, size
+        );
+
+        List<NoticeSearchRow> rows = noticeFeedPort.findSearch(query);
+
+        boolean hasNext = rows.size() > size;
+        List<NoticeSearchRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+
+        LocalDate today = LocalDate.now();
+        List<NoticeSearchItem> content = pageRows.stream()
+                .map(r -> toSearchItem(r, today))
+                .toList();
+
+        return new NoticeSearchResponse(content, page, size, hasNext);
+    }
+
+    private NoticeSearchItem toSearchItem(NoticeSearchRow row, LocalDate today) {
+        Integer dDay = row.deadlineAt() != null
+                ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
+                : null;
+        return new NoticeSearchItem(
+                row.id(), row.category(), row.title(), row.department(), row.postedAt(), dDay
+        );
     }
 
     @Transactional

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchQuery.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchQuery.java
@@ -1,0 +1,17 @@
+package org.cathori.backend.notice.application;
+
+/**
+ * 공지 키워드 검색 유스케이스의 입력 파라미터.
+ *
+ * 사용자가 입력한 keyword로 공지 제목을 검색하되,
+ * major·secondMajor를 기준으로 전체공지(MAIN)와 해당 학과 공지(DEPARTMENT)를 함께 탐색해
+ * 본인과 관련 있는 공지만 결과에 포함시킨다.
+ */
+public record NoticeSearchQuery(
+        Long userId,
+        String keyword,
+        String major,
+        String secondMajor,
+        int page,
+        int size
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchRow.java
@@ -1,0 +1,19 @@
+package org.cathori.backend.notice.application;
+
+import java.time.LocalDate;
+
+/**
+ * 공지 검색 쿼리의 DB 조회 원본 행(Row).
+ *
+ * 인프라 계층이 SQL 결과를 담아 서비스로 전달하는 내부 전달 객체다.
+ * 서비스 계층에서 deadlineAt을 기준으로 dDay를 계산한 뒤 NoticeSearchItem DTO로 변환된다.
+ * deadlineAt이 null이면 마감 기한이 없는 공지다.
+ */
+public record NoticeSearchRow(
+        Long id,
+        String category,
+        String title,
+        String department,
+        LocalDate postedAt,
+        LocalDate deadlineAt
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.cathori.backend.notice.application.NoticeFeedPort;
 import org.cathori.backend.notice.application.NoticeFeedQuery;
 import org.cathori.backend.notice.application.NoticeRow;
+import org.cathori.backend.notice.application.NoticeSearchQuery;
+import org.cathori.backend.notice.application.NoticeSearchRow;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -175,6 +177,42 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         sql.append(" ORDER BY n.posted_at DESC, n.title ASC LIMIT ? OFFSET ?");
         params.add(q.size() + 1);
         params.add((long) q.page() * q.size());
+    }
+
+    @Override
+    public List<NoticeSearchRow> findSearch(NoticeSearchQuery q) {
+        List<Object> params = new ArrayList<>();
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at " +
+                "FROM notices n " +
+                "WHERE n.title LIKE '%' || ? || '%' " +
+                "AND (n.source_type = 'MAIN'"
+        );
+        params.add(q.keyword());
+
+        sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+        params.add(q.major());
+
+        if (q.secondMajor() != null && !"전공심화".equals(q.secondMajor())) {
+            sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+            params.add(q.secondMajor());
+        }
+
+        sql.append(") ORDER BY n.posted_at DESC, n.title ASC LIMIT ? OFFSET ?");
+        params.add(q.size() + 1);
+        params.add((long) q.page() * q.size());
+
+        RowMapper<NoticeSearchRow> mapper = (rs, rowNum) -> new NoticeSearchRow(
+                rs.getLong("id"),
+                rs.getString("category"),
+                rs.getString("title"),
+                rs.getString("department"),
+                rs.getObject("posted_at", LocalDate.class),
+                rs.getObject("deadline_at", LocalDate.class)
+        );
+
+        return jdbcTemplate.query(sql.toString(), mapper, params.toArray());
     }
 
     private record QueryAndParams(String sql, List<Object> params) {}

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
@@ -1,0 +1,290 @@
+package org.cathori.backend.notice.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.infra.ai.AiSummaryResult;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("공지 검색 통합 테스트")
+class NoticeSearchIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired JwtUtil jwtUtil;
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final String EMAIL_A = "searchtest_a@catholic.ac.kr";
+    private static final String EMAIL_B = "searchtest_b@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+
+    private String tokenA;
+    private String tokenB;
+
+    @BeforeEach
+    void setUp() {
+        verifiedEmailStore.markVerified(EMAIL_A);
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "컴퓨터정보공학", "인공지능", 2, "재학"));
+        Long userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
+        tokenA = jwtUtil.generateAccessToken(userAId);
+
+        verifiedEmailStore.markVerified(EMAIL_B);
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "컴퓨터정보공학", "전공심화", 2, "재학"));
+        Long userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
+        tokenB = jwtUtil.generateAccessToken(userBId);
+    }
+
+    @AfterEach
+    void cleanup() {
+        noticeRepository.deleteAll();
+        userJpaRepository.findByEmail(EMAIL_A).ifPresent(userJpaRepository::delete);
+        userJpaRepository.findByEmail(EMAIL_B).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL_A);
+        verifiedEmailStore.remove(EMAIL_B);
+    }
+
+    // ── 픽스처 헬퍼 ──────────────────────────────────────────────────────────
+
+    private Notice saveNotice(String sourceType, String sourceId, String title, LocalDate postedAt) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType(sourceType)
+                .sourceId(sourceId)
+                .category("장학")
+                .title(title)
+                .department("테스트학과")
+                .postedAt(postedAt.toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        return noticeRepository.save(Notice.from(crawled));
+    }
+
+    private Notice saveNoticeWithDeadline(String sourceType, String sourceId,
+                                          String title, LocalDate postedAt, LocalDate deadline) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType(sourceType)
+                .sourceId(sourceId)
+                .category("장학")
+                .title(title)
+                .department("테스트학과")
+                .postedAt(postedAt.toString())
+                .url("https://test.catholic.ac.kr")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        Notice notice = Notice.from(crawled);
+        notice.applySummary(new AiSummaryResult(List.of(), deadline != null ? deadline.toString() : null));
+        return noticeRepository.save(notice);
+    }
+
+    // ── 테스트 케이스 ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("NS-1: 인증 없이 요청하면 401 반환")
+    void ns1_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/notices/search").param("q", "장학"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("NS-2: q가 빈 문자열이면 400 INVALID_INPUT")
+    void ns2_emptyKeyword() throws Exception {
+        mockMvc.perform(get("/api/notices/search").param("q", "")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value("검색어를 입력해주세요"));
+    }
+
+    @Test
+    @DisplayName("NS-3: q가 공백만이면 400 INVALID_INPUT")
+    void ns3_blankKeyword() throws Exception {
+        mockMvc.perform(get("/api/notices/search").param("q", "   ")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    @DisplayName("NS-2b: q 길이 101자 초과하면 400 INVALID_INPUT")
+    void ns2b_keywordTooLong() throws Exception {
+        String longQ = "a".repeat(101);
+        mockMvc.perform(get("/api/notices/search").param("q", longQ)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value("검색어는 100자 이하여야 합니다"));
+    }
+
+    @Test
+    @DisplayName("NS-2c: q에 SQL 특수문자 포함 시 400 INVALID_INPUT")
+    void ns2c_sqlSpecialChars() throws Exception {
+        mockMvc.perform(get("/api/notices/search").param("q", "장학'; DROP TABLE--")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    @DisplayName("NS-4: 매칭 공지 없으면 빈 배열 반환")
+    void ns4_noMatch() throws Exception {
+        saveNotice("MAIN", null, "전혀 다른 제목", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "국가장학")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("NS-5: MAIN 공지 제목 LIKE 매칭이면 결과에 포함")
+    void ns5_mainNoticeMatched() throws Exception {
+        saveNotice("MAIN", null, "2026학년도 국가장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "국가장학")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].title").value("2026학년도 국가장학금 안내"));
+    }
+
+    @Test
+    @DisplayName("NS-6: 제1전공 학과 공지 제목 매칭이면 결과에 포함")
+    void ns6_majorNoticeMatched() throws Exception {
+        // userA의 major = CSIE (컴퓨터정보공학)
+        saveNotice("DEPARTMENT", "CSIE", "컴퓨터정보공학 장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "장학금")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)));
+    }
+
+    @Test
+    @DisplayName("NS-7: 제2전공 학과 공지 매칭 (전공심화 아님)이면 결과에 포함")
+    void ns7_secondMajorNoticeMatched() throws Exception {
+        // userA의 secondMajor = AI (인공지능)
+        saveNotice("DEPARTMENT", "AI", "인공지능 장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "장학금")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)));
+    }
+
+    @Test
+    @DisplayName("NS-8: secondMajor=전공심화이면 해당 학과 공지 미포함")
+    void ns8_secondMajorIsJeonGongSimhwa() throws Exception {
+        // userB의 secondMajor = 전공심화 → AI 학과 공지 제외
+        saveNotice("DEPARTMENT", "AI", "인공지능 장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "장학금")
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("NS-9: 다른 학과 공지는 결과에 미포함")
+    void ns9_otherDepartmentNoticeExcluded() throws Exception {
+        saveNotice("DEPARTMENT", "BUSINESS", "경영학과 장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "장학금")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("NS-10: 결과가 size 초과이면 hasNext=true")
+    void ns10_hasNextTrue() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            saveNotice("MAIN", null, "국가장학금 안내 " + i, LocalDate.now().minusDays(i));
+        }
+
+        mockMvc.perform(get("/api/notices/search")
+                        .param("q", "국가장학금").param("size", "2")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.hasNext").value(true));
+    }
+
+    @Test
+    @DisplayName("NS-11: 마지막 페이지이면 hasNext=false")
+    void ns11_hasNextFalse() throws Exception {
+        saveNotice("MAIN", null, "국가장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search")
+                        .param("q", "국가장학금").param("size", "10")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("NS-12: deadline 있는 공지는 dDay 정수 반환")
+    void ns12_dDayPresent() throws Exception {
+        LocalDate future = LocalDate.now().plusDays(5);
+        saveNoticeWithDeadline("MAIN", null, "국가장학금 마감 안내", LocalDate.now(), future);
+
+        mockMvc.perform(get("/api/notices/search").param("q", "국가장학금")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].dDay").value(5));
+    }
+
+    @Test
+    @DisplayName("NS-13: deadline 없는 공지는 dDay=null")
+    void ns13_dDayNull() throws Exception {
+        saveNotice("MAIN", null, "국가장학금 안내", LocalDate.now());
+
+        mockMvc.perform(get("/api/notices/search").param("q", "국가장학금")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].dDay").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("NS-14: 동일 날짜 공지는 제목 알파벳 오름차순 정렬")
+    void ns14_sortOrder() throws Exception {
+        LocalDate same = LocalDate.now();
+        saveNotice("MAIN", null, "장학금 나 안내", same);
+        saveNotice("MAIN", null, "장학금 가 안내", same);
+
+        mockMvc.perform(get("/api/notices/search").param("q", "장학금")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].title").value("장학금 가 안내"))
+                .andExpect(jsonPath("$.content[1].title").value("장학금 나 안내"));
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용
공지 검색 API 구현 (`GET /api/notices/search`)

- `NoticeController`에 `search` 엔드포인트 추가
- `NoticeSearchQuery` / `NoticeSearchRow` / `NoticeSearchItem` / `NoticeSearchResponse` 추가
- `NoticeFeedPort`에 `findSearch()` 추가 및 `NoticeFeedAdapter`에 SQL 구현
- `NoticeFeedService.search()` 서비스 로직 구현
- `GlobalExceptionHandler`에 `ConstraintViolationException` 핸들러 추가
- `NoticeSearchIntegrationTest` 통합 테스트 작성 (NS-1 ~ NS-14)

## 🔍 동작 방식
1. JWT에서 `userId` 추출
2. `q` 유효성 검증 — 빈값 / 100자 초과 / SQL 특수문자 포함 시 400
3. `userId`로 사용자 조회 → `major` / `secondMajor` 추출
4. `MAIN` 공지 + 제1전공 학과 공지 + 제2전공 학과 공지대상으로 제목 LIKE 검색
5. `posted_at DESC`, `title ASC` 정렬
6. `size + 1`건 조회 → 초과 시 `hasNext=true`, 초과분 제거
7. `deadline_at` 기준 dDay 계산 (없으면 null)
8. 응답 반환

## 💡 설계 근거
- **`@Validated` + `@NotBlank` / `@Size` / `@Pattern`을 컨트롤러 파라미터에 직접 적용한 이유**: 검색어는 Request Body가 아닌 쿼리 파라미터라 `@Valid`로는 검증이 안 됨. `@Validated`를 클래스 레벨에 붙여야 `@RequestParam`에 붙은 제약 애노테이션이 동작함
- **`ConstraintViolationException` 핸들러 추가한 이유**: `@Validated` 방식은 `MethodArgumentNotValidException`이 아닌 `ConstraintViolationException`을 던지기 때문에 기존 핸들러로는 잡히지 않아 별도 추가
- **SQL Injection 방어를 `@Pattern`으로 처리한 이유**: 쿼리가 `JdbcTemplate` 파라미터 바인딩(`?`)으로 구성되어 있어 기본적으로 안전하지만, 특수문자 자체를 차단하는 방어 레이어를 추가

## ✅ 체크리스트
- [x] 빈 검색어 요청 시 400 INVALID_INPUT 반환 확인
- [x] 101자 초과 검색어 요청 시 400 반환 확인
- [x] SQL 특수문자 포함 검색어 요청 시 400 반환 확인
- [x] 전공심화 사용자 검색 시 제2전공 학과 공지 미포함 확인
- [x] 전체 통합 테스트 로컬에서 통과 확인

## 🔗 연관 이슈
closes #37 

## 비고
- 원래라면 #36 브랜치를 먼저 PR 올리고 머지한 뒤 #37을 진행해야 했으나, 순서가 바뀐 채로 PR이 먼저 올라왔음
- #36 브랜치에 문제가 발견되어 수정이 필요한 상황이었고, #37은 #36을 pull 하지 않아 정상 커밋만 존재하는 유일한 브랜치였음
- #40 브랜치 폐기 후 develop 기준으로 새 브랜치를 따기 위해 #37을 우선 머지하여 develop을 최신화함