### PR TITLE
[fix]: 로그인 응답에 사용자 커스텀 태그 목록 포함

### DIFF
--- a/backend/src/main/java/org/cathori/backend/tag/application/TagService.java
+++ b/backend/src/main/java/org/cathori/backend/tag/application/TagService.java
@@ -8,6 +8,8 @@ import org.cathori.backend.tag.api.dto.TagDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 public class TagService {
 
@@ -29,6 +31,13 @@ public class TagService {
         }
         Tag saved = tagRepository.save(Tag.create(userId, tagName));
         return new TagDto(saved.getId(), saved.getName());
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagDto> getTagsByUserId(Long userId) {
+        return tagRepository.findAllByUserId(userId).stream()
+                .map(t -> new TagDto(t.getId(), t.getName()))
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/cathori/backend/tag/domain/TagRepository.java
+++ b/backend/src/main/java/org/cathori/backend/tag/domain/TagRepository.java
@@ -1,5 +1,6 @@
 package org.cathori.backend.tag.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagRepository {
@@ -7,5 +8,6 @@ public interface TagRepository {
     boolean existsByUserIdAndName(Long userId, String name);
     long countByUserId(Long userId);
     Optional<Tag> findByIdAndUserId(Long tagId, Long userId);
+    List<Tag> findAllByUserId(Long userId);
     void delete(Tag tag);
 }

--- a/backend/src/main/java/org/cathori/backend/tag/infra/TagJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/tag/infra/TagJpaRepository.java
@@ -3,10 +3,12 @@ package org.cathori.backend.tag.infra;
 import org.cathori.backend.tag.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagJpaRepository extends JpaRepository<Tag, Long> {
     boolean existsByUserIdAndName(Long userId, String name);
     long countByUserId(Long userId);
     Optional<Tag> findByIdAndUserId(Long id, Long userId);
+    List<Tag> findAllByUserId(Long userId);
 }

--- a/backend/src/main/java/org/cathori/backend/tag/infra/TagRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/tag/infra/TagRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.cathori.backend.tag.domain.Tag;
 import org.cathori.backend.tag.domain.TagRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,6 +34,11 @@ public class TagRepositoryImpl implements TagRepository {
     @Override
     public Optional<Tag> findByIdAndUserId(Long tagId, Long userId) {
         return jpaRepository.findByIdAndUserId(tagId, userId);
+    }
+
+    @Override
+    public List<Tag> findAllByUserId(Long userId) {
+        return jpaRepository.findAllByUserId(userId);
     }
 
     @Override

--- a/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
@@ -2,6 +2,8 @@ package org.cathori.backend.user.application;
 
 import org.cathori.backend.common.exception.BusinessException;
 import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.tag.application.TagService;
+import org.cathori.backend.tag.api.dto.TagDto;
 import org.cathori.backend.user.UserErrorCode;
 import org.cathori.backend.user.api.dto.LoginRequest;
 import org.cathori.backend.user.api.dto.LoginResponse;
@@ -20,13 +22,15 @@ public class AuthService {
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final TagService tagService;
 
     public AuthService(VerifiedEmailStore verifiedEmailStore, UserService userService,
-                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil, TagService tagService) {
         this.verifiedEmailStore = verifiedEmailStore;
         this.userService = userService;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil = jwtUtil;
+        this.tagService = tagService;
     }
 
     public RegisterResponse register(RegisterRequest request) {
@@ -54,12 +58,14 @@ public class AuthService {
         String accessToken = jwtUtil.generateAccessToken(user.getId());
         String refreshToken = jwtUtil.generateRefreshToken(user.getId());
 
+        List<TagDto> tags = tagService.getTagsByUserId(user.getId());
+
         return new LoginResponse(
                 accessToken, refreshToken,
                 user.getId(), user.getEmail(),
                 user.getMajor(), user.getSecondMajor(),
                 user.getGrade(), user.getEnrollmentStatus(),
-                List.of()
+                tags
         );
     }
 }


### PR DESCRIPTION
## 🔧 작업 내용
로그인 응답에 사용자 커스텀 태그 목록 포함

- `TagRepository` / `TagJpaRepository` / `TagRepositoryImpl`에 `findAllByUserId()` 추가
- `TagService.getTagsByUserId()` 추가
- `AuthService.login()`에서 `List.of()` 하드코딩 → 실제 태그 목록 조회로 수정

## 🔍 동작 방식
1. 로그인 성공 후 `tagService.getTagsByUserId(user.getId())` 호출
2. 해당 사용자의 태그 목록 조회
3. `LoginResponse`의 `tags` 필드에 담아 응답

## 💡 설계 근거
- `TagService`에 `getTagsByUserId()`를 추가한 이유: `AuthService`가 `TagJpaRepository`를 직접 참조하면 레이어 경계 위반이므로 서비스 계층을 통해 접근

## ✅ 체크리스트
- [x] 로그인 응답에 태그 목록 정상 반환 확인
- [x] 태그 없는 사용자 로그인 시 빈 배열 반환 확인

## 🔗 연관 이슈
closes #47

## 비고
- 원래 `bug/be-noticeview-36` 브랜치에 포함되어 있던 커밋이나, 해당 브랜치에 관련 없는 커밋이 혼재되어 폐기됨
- 필요한 커밋만 cherry-pick하여 `fix/be-misc-bugs-47` 신규 브랜치로 분리 후 머지함
- 금일 내로 보고서 작성하여 상황 설명 예정