### PR TITLE
[Chore] FE 측 요구사항 반영

### DIFF
--- a/backend/src/main/java/org/cathori/backend/bookmark/api/dto/BookmarkToggleResponse.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/api/dto/BookmarkToggleResponse.java
@@ -1,3 +1,3 @@
 package org.cathori.backend.bookmark.api.dto;
 
-public record BookmarkToggleResponse(Long noticeId, boolean isBookmarked) {}
+public record BookmarkToggleResponse(String noticeId, boolean isBookmarked) {}

--- a/backend/src/main/java/org/cathori/backend/bookmark/application/BookmarkService.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/application/BookmarkService.java
@@ -25,10 +25,10 @@ public class BookmarkService {
 
         if (bookmarkRepository.existsByUserIdAndNoticeId(userId, noticeId)) {
             bookmarkRepository.deleteByUserIdAndNoticeId(userId, noticeId);
-            return new BookmarkToggleResponse(noticeId, false);
+            return new BookmarkToggleResponse(String.valueOf(noticeId), false);
         }
 
         bookmarkRepository.save(Bookmark.create(userId, noticeId));
-        return new BookmarkToggleResponse(noticeId, true);
+        return new BookmarkToggleResponse(String.valueOf(noticeId), true);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
@@ -1,6 +1,7 @@
 package org.cathori.backend.notice.api.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record NoticeDetailResponse(
         Long noticeId,
@@ -13,5 +14,6 @@ public record NoticeDetailResponse(
         String url,
         boolean isBookmarked,
         Integer dDay,
+        List<String> tags,
         String deadlineAt
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
@@ -14,6 +14,7 @@ public record NoticeDetailResponse(
         String url,
         boolean isBookmarked,
         Integer dDay,
+        Long viewCount,
         List<String> tags,
         String deadlineAt
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record NoticeDetailResponse(
-        Long noticeId,
+        String noticeId,
         String category,
         String title,
         String department,

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
@@ -12,5 +12,6 @@ public record NoticeDetailResponse(
         String aiSummaryStatus,
         String url,
         boolean isBookmarked,
-        Integer dDay
+        Integer dDay,
+        String deadlineAt
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -27,6 +27,7 @@ public record NoticeFeedItem(
         String department,
         LocalDate publishedAt,
         String aiSummary,
+        String aiSummaryStatus,
         String url,
         Integer dDay,
         boolean isBookmarked

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -22,7 +22,7 @@ import java.util.List;
  * </pre>
  */
 public record NoticeFeedItem(
-        Long noticeId,
+        String noticeId,
         String category,
         String title,
         String department,

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -31,6 +31,7 @@ public record NoticeFeedItem(
         String aiSummaryStatus,
         String url,
         Integer dDay,
+        Long viewCount,
         boolean isBookmarked,
         List<String> tags,
         String deadlineAt

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -1,6 +1,7 @@
 package org.cathori.backend.notice.api.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * 피드 목록의 단일 공지 카드 DTO. 클라이언트가 카드 UI를 렌더링하는 데 필요한 모든 필드를 담으며,
@@ -30,5 +31,6 @@ public record NoticeFeedItem(
         String aiSummaryStatus,
         String url,
         Integer dDay,
-        boolean isBookmarked
+        boolean isBookmarked,
+        List<String> tags
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -32,5 +32,6 @@ public record NoticeFeedItem(
         String url,
         Integer dDay,
         boolean isBookmarked,
-        List<String> tags
+        List<String> tags,
+        String deadlineAt
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
  * dDay는 오늘 기준 마감일까지 남은 일수(양수=남음, 음수=초과, null=마감일 없는 공지).
  */
 public record NoticeSearchItem(
-        @Schema(example = "1") Long noticeId,
+        @Schema(example = "1") String noticeId,
         @Schema(example = "장학") String category,
         @Schema(example = "2026학년도 1학기 국가장학금 신청 안내") String title,
         @Schema(example = "학생지원팀") String department,

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -126,10 +126,11 @@ public class NoticeFeedService {
         Integer dDay = notice.getDeadlineAt() != null
                 ? (int) ChronoUnit.DAYS.between(LocalDate.now(), notice.getDeadlineAt())
                 : null;
+        String deadlineAt = notice.getDeadlineAt() != null ? notice.getDeadlineAt().toString() : null;
         return new NoticeDetailResponse(
                 notice.getId(), category, notice.getTitle(), notice.getDepartment(),
                 notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
-                notice.getUrl(), isBookmarked, dDay
+                notice.getUrl(), isBookmarked, dDay, deadlineAt
         );
     }
 
@@ -142,12 +143,13 @@ public class NoticeFeedService {
                 ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
                 : null;
         String category = "DEPARTMENT".equals(row.sourceType()) ? null : row.category();
+        String deadlineAt = row.deadlineAt() != null ? row.deadlineAt().toString() : null;
         List<String> tags = queryTags.stream()
                 .filter(t -> row.title().contains(t))
                 .toList();
         return new NoticeFeedItem(
                 String.valueOf(row.id()), category, row.title(), row.department(),
-                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.isBookmarked(), tags
+                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.isBookmarked(), tags, deadlineAt
         );
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -141,7 +141,7 @@ public class NoticeFeedService {
         String category = "DEPARTMENT".equals(row.sourceType()) ? null : row.category();
         return new NoticeFeedItem(
                 String.valueOf(row.id()), category, row.title(), row.department(),
-                row.postedAt(), row.aiSummary(), row.url(), dDay, row.isBookmarked()
+                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.isBookmarked()
         );
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -119,8 +119,7 @@ public class NoticeFeedService {
 
     private NoticeDetailResponse toDetail(Notice notice, boolean isBookmarked) {
         String aiSummary = "SUCCESS".equals(notice.getAiSummaryStatus()) ? notice.getAiSummary() : null;
-        String category = (notice.getCategory() == null || notice.getCategory().isBlank())
-                ? "학과공지" : notice.getCategory();
+        String category = "DEPARTMENT".equals(notice.getSourceType()) ? null : notice.getCategory();
         Integer dDay = notice.getDeadlineAt() != null
                 ? (int) ChronoUnit.DAYS.between(LocalDate.now(), notice.getDeadlineAt())
                 : null;
@@ -139,8 +138,9 @@ public class NoticeFeedService {
         Integer dDay = row.deadlineAt() != null
                 ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
                 : null;
+        String category = "DEPARTMENT".equals(row.sourceType()) ? null : row.category();
         return new NoticeFeedItem(
-                row.id(), row.category(), row.title(), row.department(),
+                String.valueOf(row.id()), category, row.title(), row.department(),
                 row.postedAt(), row.aiSummary(), row.url(), dDay, row.isBookmarked()
         );
     }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -3,6 +3,8 @@ package org.cathori.backend.notice.application;
 import lombok.RequiredArgsConstructor;
 import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
 import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.tag.domain.Tag;
+import org.cathori.backend.tag.domain.TagRepository;
 import org.cathori.backend.notice.api.dto.NoticeFeedItem;
 import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
 import org.cathori.backend.notice.api.dto.NoticeDetailResponse;
@@ -29,6 +31,7 @@ public class NoticeFeedService {
     private final UserRepository userRepository;
     private final NoticeRepository noticeRepository;
     private final BookmarkJpaRepository bookmarkJpaRepository;
+    private final TagRepository tagRepository;
 
     /**
      * 사용자의 전공·복수전공을 자동으로 주입해 개인화된 공지 피드를 구성하는 메인 유스케이스.
@@ -68,7 +71,7 @@ public class NoticeFeedService {
         // 5. DTO 매핑 + 반환
         LocalDate today = LocalDate.now();
         List<NoticeFeedItem> content = pageRows.stream()
-                .map(r -> toItem(r, today))
+                .map(r -> toItem(r, today, tagList))
                 .toList();
 
         return new NoticeFeedResponse(content, page, size, hasNext);
@@ -134,14 +137,17 @@ public class NoticeFeedService {
      * {@code ChronoUnit.DAYS.between(today, deadlineAt)} 기준으로 dDay를 계산한다.
      * 양수 = 마감까지 남은 일수, 음수 = 마감 초과, null = 마감일 없는 공지.
      */
-    private NoticeFeedItem toItem(NoticeRow row, LocalDate today) {
+    private NoticeFeedItem toItem(NoticeRow row, LocalDate today, List<String> queryTags) {
         Integer dDay = row.deadlineAt() != null
                 ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
                 : null;
         String category = "DEPARTMENT".equals(row.sourceType()) ? null : row.category();
+        List<String> tags = queryTags.stream()
+                .filter(t -> row.title().contains(t))
+                .toList();
         return new NoticeFeedItem(
                 String.valueOf(row.id()), category, row.title(), row.department(),
-                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.isBookmarked()
+                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.isBookmarked(), tags
         );
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -117,10 +117,15 @@ public class NoticeFeedService {
 
         boolean isBookmarked = bookmarkJpaRepository.existsByUserIdAndNoticeId(userId, noticeId);
 
-        return toDetail(notice, isBookmarked);
+        List<String> tags = tagRepository.findAllByUserId(userId).stream()
+                .map(Tag::getName)
+                .filter(t -> notice.getTitle().contains(t))
+                .toList();
+
+        return toDetail(notice, isBookmarked, tags);
     }
 
-    private NoticeDetailResponse toDetail(Notice notice, boolean isBookmarked) {
+    private NoticeDetailResponse toDetail(Notice notice, boolean isBookmarked, List<String> tags) {
         String aiSummary = "SUCCESS".equals(notice.getAiSummaryStatus()) ? notice.getAiSummary() : null;
         String category = "DEPARTMENT".equals(notice.getSourceType()) ? null : notice.getCategory();
         Integer dDay = notice.getDeadlineAt() != null
@@ -130,7 +135,7 @@ public class NoticeFeedService {
         return new NoticeDetailResponse(
                 notice.getId(), category, notice.getTitle(), notice.getDepartment(),
                 notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
-                notice.getUrl(), isBookmarked, dDay, deadlineAt
+                notice.getUrl(), isBookmarked, dDay, tags, deadlineAt
         );
     }
 

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -135,7 +135,7 @@ public class NoticeFeedService {
         return new NoticeDetailResponse(
                 notice.getId(), category, notice.getTitle(), notice.getDepartment(),
                 notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
-                notice.getUrl(), isBookmarked, dDay, tags, deadlineAt
+                notice.getUrl(), isBookmarked, dDay, notice.getViewCount(), tags, deadlineAt
         );
     }
 
@@ -154,7 +154,7 @@ public class NoticeFeedService {
                 .toList();
         return new NoticeFeedItem(
                 String.valueOf(row.id()), category, row.title(), row.department(),
-                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.isBookmarked(), tags, deadlineAt
+                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.viewCount(), row.isBookmarked(), tags, deadlineAt
         );
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -104,7 +104,7 @@ public class NoticeFeedService {
                 ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
                 : null;
         return new NoticeSearchItem(
-                row.id(), row.category(), row.title(), row.department(), row.postedAt(), dDay
+                String.valueOf(row.id()), row.category(), row.title(), row.department(), row.postedAt(), dDay
         );
     }
 
@@ -133,7 +133,7 @@ public class NoticeFeedService {
                 : null;
         String deadlineAt = notice.getDeadlineAt() != null ? notice.getDeadlineAt().toString() : null;
         return new NoticeDetailResponse(
-                notice.getId(), category, notice.getTitle(), notice.getDepartment(),
+                String.valueOf(notice.getId()), category, notice.getTitle(), notice.getDepartment(),
                 notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
                 notice.getUrl(), isBookmarked, dDay, notice.getViewCount(), tags, deadlineAt
         );

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
  */
 public record NoticeRow(
         Long id,
+        String sourceType,
         String category,
         String title,
         String department,

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
@@ -17,5 +17,6 @@ public record NoticeRow(
         String aiSummary,
         String aiSummaryStatus,
         String url,
+        Long viewCount,
         boolean isBookmarked
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
@@ -15,6 +15,7 @@ public record NoticeRow(
         LocalDate postedAt,
         LocalDate deadlineAt,
         String aiSummary,
+        String aiSummaryStatus,
         String url,
         boolean isBookmarked
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -31,6 +31,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
             rs.getObject("posted_at", LocalDate.class),
             rs.getObject("deadline_at", LocalDate.class),
             rs.getString("ai_summary"),
+            rs.getString("ai_summary_status"),
             rs.getString("url"),
             rs.getBoolean("is_bookmarked")
     );
@@ -131,7 +132,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         StringBuilder sql = new StringBuilder(
                 "SELECT * FROM (" +
                 "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
-                "       n.ai_summary, n.url, " +
+                "       n.ai_summary, n.ai_summary_status, n.url, " +
                 "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
                 "       1 AS priority " +
                 "FROM notices n " +
@@ -146,7 +147,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         sql.append(
                 " UNION " +
                 "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
-                "       n.ai_summary, n.url, " +
+                "       n.ai_summary, n.ai_summary_status, n.url, " +
                 "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
                 "       2 AS priority " +
                 "FROM notices n " +

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -33,6 +33,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
             rs.getString("ai_summary"),
             rs.getString("ai_summary_status"),
             rs.getString("url"),
+            rs.getLong("view_count"),
             rs.getBoolean("is_bookmarked")
     );
 
@@ -132,7 +133,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         StringBuilder sql = new StringBuilder(
                 "SELECT * FROM (" +
                 "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
-                "       n.ai_summary, n.ai_summary_status, n.url, " +
+                "       n.ai_summary, n.ai_summary_status, n.url, n.view_count, " +
                 "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
                 "       1 AS priority " +
                 "FROM notices n " +
@@ -147,7 +148,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         sql.append(
                 " UNION " +
                 "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
-                "       n.ai_summary, n.ai_summary_status, n.url, " +
+                "       n.ai_summary, n.ai_summary_status, n.url, n.view_count, " +
                 "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
                 "       2 AS priority " +
                 "FROM notices n " +

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -24,6 +24,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
     // DB컬럼 -> 자바객체로 전환
     private static final RowMapper<NoticeRow> ROW_MAPPER = (rs, rowNum) -> new NoticeRow(
             rs.getLong("id"),
+            rs.getString("source_type"),
             rs.getString("category"),
             rs.getString("title"),
             rs.getString("department"),
@@ -129,7 +130,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         // Part1: 태그 매칭 (출처 무관)
         StringBuilder sql = new StringBuilder(
                 "SELECT * FROM (" +
-                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
+                "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
                 "       n.ai_summary, n.url, " +
                 "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
                 "       1 AS priority " +
@@ -144,7 +145,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         // Part2: category 매칭 MAIN, 태그 미매칭
         sql.append(
                 " UNION " +
-                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
+                "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
                 "       n.ai_summary, n.url, " +
                 "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked, " +
                 "       2 AS priority " +


### PR DESCRIPTION
## 🔧 작업 내용
FE 요청 사항에 맞춰 공지 피드/상세/검색/북마크 응답 스펙 수정

- `noticeId` 응답 타입 `Long` → `String` 변환 (피드, 상세, 검색, 북마크 전체)
- `source_type = DEPARTMENT`인 공지의 `category` → `null` 응답으로 변경
- 공지 피드/상세 응답에 `aiSummaryStatus` 추가
- 공지 피드/상세 응답에 사용자 태그 목록(`tags`) 추가 (공지 제목에 포함된 태그만 필터링)
- 공지 피드/상세 응답에 `deadlineAt` (`YYYY-MM-DD`) 추가
- 공지 피드/상세 응답에 `viewCount` 추가

## 🔍 동작 방식
- `noticeId`: `String.valueOf(id)`로 변환 후 응답
- `category`: `source_type`이 `DEPARTMENT`면 `null`, 그 외엔 원본값 응답
- `tags`: 사용자의 태그 목록을 조회한 뒤 공지 제목에 포함된 태그만 필터링하여 응답
- `deadlineAt`: `LocalDate`를 `toString()`으로 변환 후 응답. `null`이면 그대로 `null`

## 💡 설계 근거
- **`tags` 필터링을 서비스 계층에서 처리한 이유**: 태그 매칭은 비즈니스 로직이므로 인프라가 아닌 서비스에서 처리
- **`category`를 `"학과공지"` 대신 `null`로 변경한 이유**: FE 요청. 학과공지 여부는 FE에서 판단하도록 위임

## ✅ 체크리스트
- [x] 피드/상세/검색/북마크 응답에서 `noticeId`가 문자열로 반환되는지 확인
- [x] 학과 공지 조회 시 `category`가 `null`로 반환되는지 확인
- [x] 피드/상세 응답에 `aiSummaryStatus`, `tags`, `deadlineAt`, `viewCount` 포함 확인
- [x] 태그 없는 사용자 피드 조회 시 `tags`가 빈 배열로 반환되는지 확인

## 🔗 연관 이슈
closes #48