### PR TITLE
test: 통합 테스트 notice source_id를 한글 전공명 기준으로 수정

### DIFF
--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
@@ -161,8 +161,8 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     @DisplayName("NF-2: 기본 피드 — MAIN + 전공(CSIE) 공지 포함, 무관 학과 제외")
     void getFeed_case1_defaultFeed() throws Exception {
         saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
-        saveNotice("DEPARTMENT", "CSIE", "학과공지", "csie 학과 공지", TODAY);
-        saveNotice("DEPARTMENT", "BUSINESS", "학과공지", "business 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "컴퓨터정보공학", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "경영학과", "학과공지", "business 학과 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA))
@@ -178,8 +178,8 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     @DisplayName("NF-3: secondMajor=전공심화인 유저 — AI 학과 공지 제외")
     void getFeed_case1_excludeJeonGongSimhwa() throws Exception {
         saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
-        saveNotice("DEPARTMENT", "CSIE", "학과공지", "csie 학과 공지", TODAY);
-        saveNotice("DEPARTMENT", "AI", "학과공지", "ai 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "컴퓨터정보공학", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "인공지능", "학과공지", "ai 학과 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenB))
@@ -227,7 +227,7 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     void getFeed_case3_tagFilter() throws Exception {
         saveNotice("MAIN", null, "장학", "장학금 신청 안내", TODAY);
         saveNotice("MAIN", null, "취업", "일반 공지", TODAY);
-        saveNotice("DEPARTMENT", "CSIE", "학과공지", "장학금 혜택 안내", TODAY);
+        saveNotice("DEPARTMENT", "컴퓨터정보공학", "학과공지", "장학금 혜택 안내", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA)

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
@@ -180,8 +180,8 @@ class NoticeSearchIntegrationTest extends IntegrationTestBase {
     @Test
     @DisplayName("NS-6: 제1전공 학과 공지 제목 매칭이면 결과에 포함")
     void ns6_majorNoticeMatched() throws Exception {
-        // userA의 major = CSIE (컴퓨터정보공학)
-        saveNotice("DEPARTMENT", "CSIE", "컴퓨터정보공학 장학금 안내", LocalDate.now());
+        // userA의 major = 컴퓨터정보공학
+        saveNotice("DEPARTMENT", "컴퓨터정보공학", "컴퓨터정보공학 장학금 안내", LocalDate.now());
 
         mockMvc.perform(get("/api/notices/search").param("q", "장학금")
                         .header("Authorization", "Bearer " + tokenA))
@@ -192,8 +192,8 @@ class NoticeSearchIntegrationTest extends IntegrationTestBase {
     @Test
     @DisplayName("NS-7: 제2전공 학과 공지 매칭 (전공심화 아님)이면 결과에 포함")
     void ns7_secondMajorNoticeMatched() throws Exception {
-        // userA의 secondMajor = AI (인공지능)
-        saveNotice("DEPARTMENT", "AI", "인공지능 장학금 안내", LocalDate.now());
+        // userA의 secondMajor = 인공지능
+        saveNotice("DEPARTMENT", "인공지능", "인공지능 장학금 안내", LocalDate.now());
 
         mockMvc.perform(get("/api/notices/search").param("q", "장학금")
                         .header("Authorization", "Bearer " + tokenA))


### PR DESCRIPTION
## 🔧 작업 내용
#48 작업 이후 프로덕션 코드 변경으로 인해 실패하던 테스트 케이스 5개를 수정함.

- `saveNotice()` 호출 시 `source_id`로 넘기던 enum 상수명(`CSIE`, `AI`, `BUSINESS`)을 학과 표시명(`컴퓨터정보공학`, `인공지능`, `경영학과`)으로 변경

## 🔍 동작 방식
생략

## 💡 설계 근거
#48에서 source_id 저장 방식이 enum 상수명 → 학과 표시명으로 변경됨에 따라, 테스트 픽스처도 동일하게 맞춤. 테스트 로직 자체는 변경 없음.

## ✅ 체크리스트
- [x] 수정한 5개 테스트 케이스 모두 통과 확인
- [x] 기존 통과하던 테스트 케이스 깨지지 않음 확인

## 🔗 연관 이슈
closes #54 