### PR TITLE
[FEAT] 인증 인프라 구축 및 로그인/회원가입 레이아웃 구현 (sprint 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ temp/
 .agents/
 claude.md
 CLAUDE.md
+DESIGN.md
 antigravity.md
 
 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,8 +1,15 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Stack } from 'expo-router';
+import { Stack, useRouter, useSegments } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect, useState } from 'react';
 import 'react-native-reanimated';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { useAuthStore } from '@/src/store/useAuthStore';
+
+// SplashScreen을 수동 제어 — rehydrate 완료 전까지 유지
+SplashScreen.preventAutoHideAsync();
 
 // TanStack Query 클라이언트 설정
 const queryClient = new QueryClient({
@@ -23,7 +30,71 @@ export const unstable_settings = {
   anchor: '(tabs)',
 };
 
+/**
+ * 인증 상태 기반 라우팅 가드
+ *
+ * - accessToken이 있으면 메인(tabs) 진입 허용
+ * - 없으면 로그인 화면으로 리다이렉트
+ * - 로그인 화면에서 토큰이 생기면 메인으로 이동
+ */
+function useProtectedRoute() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    // 현재 경로가 인증 화면(login/register)인지 확인
+    // Expo Router typed routes 캐시 갱신 전까지 string 캐스팅 필요
+    const currentSegment = segments[0] as string;
+    const inAuthGroup = currentSegment === 'login' || currentSegment === 'register';
+
+    if (!accessToken && !inAuthGroup) {
+      // 토큰 없음 + 인증 화면 밖 → 로그인으로
+      router.replace('/login' as never);
+    } else if (accessToken && inAuthGroup) {
+      // 토큰 있음 + 인증 화면 안 → 메인으로
+      router.replace('/(tabs)');
+    }
+  }, [accessToken, segments, router]);
+}
+
 export default function RootLayout() {
+  const [isRehydrated, setIsRehydrated] = useState(false);
+
+  useEffect(() => {
+    // Zustand persist rehydrate 완료 대기
+    // useAuthStore.persist.onFinishHydration은 이미 hydrate 되었으면 즉시 호출 (휴대폰에서 영구 저장소에서 토큰 데이터 불러오게 되었을 때 호출)
+    const unsubscribe = useAuthStore.persist.onFinishHydration(() => {
+      setIsRehydrated(true);
+    });
+
+    // 이미 rehydrate가 완료된 경우를 대비
+    if (useAuthStore.persist.hasHydrated()) {
+      setIsRehydrated(true);
+    }
+
+    return unsubscribe;
+  }, []); // 초기 렌더링 한 번에만
+
+  useEffect(() => {
+    if (isRehydrated) {
+      // rehydrate 완료 후 스플래시 해제
+      SplashScreen.hideAsync();
+    }
+  }, [isRehydrated]);
+
+  // rehydrate 전에는 아무것도 렌더링하지 않음 (SplashScreen이 유지됨)
+  if (!isRehydrated) {
+    return null;
+  }
+
+  return <RootLayoutNav />;
+}
+
+function RootLayoutNav() {
+  // 인증 상태 기반 라우팅 가드 활성화
+  useProtectedRoute();
+
   // SafeAreaProvider — react-native-safe-area-context의 inset 컨텍스트를 트리에 주입.
   // 트리 상단에 Provider가 없으면 useSafeAreaInsets() - SafeAreaView가 inset을 0으로
   // 계산하여 갤럭시(Android)의 OS 네비바 영역을 침범한다.
@@ -35,6 +106,16 @@ export default function RootLayout() {
           {/* 공지 상세 화면 */}
           <Stack.Screen
             name="notice/[id]"
+            options={{ headerShown: false, animation: 'slide_from_right' }}
+          />
+          {/* 인증 화면 — 로그인 */}
+          <Stack.Screen
+            name="login"
+            options={{ headerShown: false, animation: 'fade' }}
+          />
+          {/* 인증 화면 — 회원가입 */}
+          <Stack.Screen
+            name="register"
             options={{ headerShown: false, animation: 'slide_from_right' }}
           />
         </Stack>

--- a/frontend/app/login.tsx
+++ b/frontend/app/login.tsx
@@ -1,0 +1,369 @@
+/**
+ * 로그인 화면
+ * Phase 1 Task 1-2에서 로직 본격 구현
+ * 시나리오: L-1 ~ L-4
+ *
+ * 레이아웃 구조:
+ *  - 상단 40%: DCU Blue 배경 + 블러 장식 + 브랜드 로고
+ *  - 하단 60%: 흰색 Auth Sheet (cornerRadius 24) + 로그인 폼
+ */
+
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import {
+  Dimensions,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+/** 상단 브랜딩 영역 비율 (시안: 353.59 / 884 ≈ 40%) */
+const HEADER_HEIGHT = Math.round(SCREEN_HEIGHT * 0.4);
+
+export default function LoginScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={styles.container}>
+      {/* ── 상단 40%: 브랜딩 영역 (DCU Blue) ── */}
+      <View style={styles.headerSection}>
+        {/* 장식용 블러 원 — 시안의 Background Decorative Element */}
+        <View style={styles.decorCircle} />
+        <View style={styles.decorCircleSmall} />
+
+        {/* 브랜드 아이콘 + 텍스트 */}
+        <View style={styles.brandContainer}>
+          {/* 노란 아이콘 배경 — 시안의 64x64 노란 사각형 */}
+          <View style={styles.iconWrapper}>
+            <Feather name="bell" size={28} color="#00175B" />
+          </View>
+
+          <Text style={styles.logoText}>Cathori</Text>
+          <Text style={styles.taglineText}>
+            관심 공지를 편하게, 놓치지 않고
+          </Text>
+        </View>
+      </View>
+
+      {/* ── 하단 60%: Auth Sheet ── */}
+      <KeyboardAvoidingView
+        style={styles.sheetSection}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* 상단 핸들 — 시안의 Accessibility Notch */}
+        <View style={styles.sheetHandle} />
+
+        <ScrollView
+          style={styles.sheetScroll}
+          contentContainerStyle={[
+            styles.sheetContent,
+            {
+              paddingBottom: 14 + insets.bottom,
+            }
+          ]}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* ── 폼 섹션 ── */}
+          <View style={styles.formSection}>
+            {/* 이메일 입력 — Phase 1에서 EmailField 컴포넌트로 교체 */}
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>UNIVERSITY EMAIL</Text>
+              <View style={styles.inputContainer}>
+                <TextInput
+                  style={styles.textInput}
+                  placeholder="@catholic.ac.kr"
+                  placeholderTextColor="#9CA3AF"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  editable={false} // Phase 1에서 활성화
+                />
+              </View>
+            </View>
+
+            {/* 비밀번호 입력 — Phase 1에서 PasswordField 컴포넌트로 교체 */}
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>PASSWORD</Text>
+              <View style={styles.inputContainer}>
+                <TextInput
+                  style={styles.textInput}
+                  placeholder="••••••••"
+                  placeholderTextColor="#9CA3AF"
+                  secureTextEntry
+                  editable={false} // Phase 1에서 활성화
+                />
+              </View>
+            </View>
+
+            {/* 로그인 CTA 버튼 */}
+            <TouchableOpacity
+              style={styles.loginButton}
+              activeOpacity={0.85}
+              disabled // Phase 1에서 활성화
+            >
+              <Text style={styles.loginButtonText}>로그인</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* ── "또는" 디바이더 ── */}
+          <View style={styles.dividerRow}>
+            <View style={styles.dividerLine} />
+            <View style={styles.dividerTextContainer}>
+              <Text style={styles.dividerText}>또는</Text>
+            </View>
+            <View style={styles.dividerLine} />
+          </View>
+
+          {/* ── 하단 액션 링크 ── */}
+          <View style={styles.actionLinks}>
+            {/* 회원가입 버튼 (아웃라인) */}
+            <TouchableOpacity
+              style={styles.registerButton}
+              activeOpacity={0.7}
+              onPress={() => router.push('/register' as never)}
+            >
+              <Text style={styles.registerButtonText}>회원가입</Text>
+            </TouchableOpacity>
+
+            {/* 게스트 둘러보기 — 시나리오 L-4 "준비 중입니다" 토스트 */}
+            <TouchableOpacity
+              style={styles.guestButton}
+              activeOpacity={0.5}
+            >
+              <Text style={styles.guestButtonText}>게스트로 둘러보기</Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary, // #00288C
+  },
+
+  // ─── 상단 브랜딩 영역 ─────────────────────────────────
+  headerSection: {
+    height: HEADER_HEIGHT,
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  decorCircle: {
+    position: 'absolute',
+    width: 384,
+    height: 384,
+    borderRadius: 9999,
+    backgroundColor: '#00288C',
+    left: -80,
+    bottom: -50,
+    opacity: 0.3,
+  },
+  decorCircleSmall: {
+    position: 'absolute',
+    width: 192,
+    height: 192,
+    borderRadius: 9999,
+    backgroundColor: '#FCC00610',
+    right: -48,
+    top: 80,
+    opacity: 0.5,
+  },
+  brandContainer: {
+    alignItems: 'center',
+  },
+  iconWrapper: {
+    width: 64,
+    height: 64,
+    borderRadius: 16,
+    backgroundColor: '#FCC006', // 시안: Ginkgo Yellow
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 16,
+    // 시안의 그림자 효과
+    ...Platform.select({
+      android: { elevation: 8 }, // Android only
+      ios: {
+        shadowColor: '#1E3A8A',
+        shadowOffset: { width: 0, height: 8 },
+        shadowOpacity: 0.25,
+        shadowRadius: 12,
+      },
+    }),
+  },
+  logoText: {
+    fontFamily: 'Pretendard',
+    fontSize: 36,
+    fontWeight: '900',
+    color: '#FFFFFF',
+    letterSpacing: -1.8,
+    marginBottom: 8,
+  },
+  taglineText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#DBEAFEE5', // 시안: 흰색 90% opacity
+    letterSpacing: -0.35,
+    textAlign: 'center',
+  },
+
+  // ─── 하단 Auth Sheet ──────────────────────────────────
+  sheetSection: {
+    flex: 1,
+    backgroundColor: '#F9F9F9', // 시안: Auth Sheet 배경
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    // 시안의 그림자 효과
+    ...Platform.select({
+      android: { elevation: 16 }, // Android only
+      ios: {
+        shadowColor: '#000000',
+        shadowOffset: { width: 0, height: -12 },
+        shadowOpacity: 0.1,
+        shadowRadius: 35,
+      },
+    }),
+  },
+  sheetHandle: {
+    width: 40,
+    height: 6,
+    borderRadius: 9999,
+    backgroundColor: '#C5C5D433', // 시안: separator 20%
+    alignSelf: 'center',
+    marginTop: 12,
+  },
+  sheetScroll: {
+    flex: 1,
+  },
+  sheetContent: {
+    paddingHorizontal: 32,
+    paddingTop: 28,
+    paddingBottom: 14,
+    justifyContent: 'space-between',
+    flexGrow: 1,
+  },
+
+  // ─── 폼 섹션 ──────────────────────────────────────────
+  formSection: {
+    gap: 16,
+    marginBottom: 16,
+  },
+  inputGroup: {
+    gap: 0, // 라벨이 인풋 위에 겹치는 구조 (layout: none)
+  },
+  inputLabel: {
+    fontFamily: 'Pretendard',
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#444652', // 시안: textSecondary
+    letterSpacing: 1,
+    lineHeight: 15,
+    marginLeft: 4,
+    marginBottom: 4,
+  },
+  inputContainer: {
+    height: 56,
+    borderRadius: 12,
+    backgroundColor: '#F3F3F3', // 시안: Input 배경
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  textInput: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    color: Colors.textPrimary,
+  },
+  loginButton: {
+    height: 56,
+    borderRadius: 12,
+    backgroundColor: Colors.primary, // #00288C
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 16,
+    // 시안의 그림자
+    ...Platform.select({
+      android: { elevation: 6 }, // Android only
+      ios: {
+        shadowColor: '#1E3A8A',
+        shadowOffset: { width: 0, height: 10 },
+        shadowOpacity: 0.2,
+        shadowRadius: 13,
+      },
+    }),
+  },
+  loginButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    lineHeight: 28,
+  },
+
+  // ─── 디바이더 ─────────────────────────────────────────
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 32,
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: '#C5C5D44D', // 시안: 30% 투명도 separator
+  },
+  dividerTextContainer: {
+    paddingHorizontal: 16,
+  },
+  dividerText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#C5C5D4', // 시안: separator 색상
+    letterSpacing: 0.6,
+  },
+
+  // ─── 하단 액션 링크 ───────────────────────────────────
+  actionLinks: {
+    gap: 16,
+  },
+  registerButton: {
+    height: 56,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: Colors.primary, // 시안: DCU Blue 아웃라인
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  registerButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '700',
+    color: Colors.primary,
+    lineHeight: 23,
+  },
+  guestButton: {
+    paddingVertical: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  guestButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#44465299', // 시안: 60% opacity textSecondary
+    lineHeight: 20,
+  },
+});

--- a/frontend/app/register.tsx
+++ b/frontend/app/register.tsx
@@ -1,0 +1,600 @@
+/**
+ * 회원가입 화면
+ * Phase 1 Task 1-3~1-4에서 로직 본격 구현
+ * 시나리오: R-1 ~ R-4
+ *
+ * 레이아웃 구조:
+ *  - TopAppBar: 뒤로 가기 + "회원가입" 타이틀 (blur 배경, absolute)
+ *  - Main: 노란 안내 카드 + 폼 6섹션 (스크롤)
+ *  - BottomNavBar: 이전 + 완료 버튼 (blur 배경, absolute)
+ */
+
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Colors } from '@/src/constants/colors';
+
+/** 학년 옵션 */
+const GRADE_OPTIONS = [1, 2, 3, 4] as const;
+
+/** 재학 상태 옵션 */
+const STATUS_OPTIONS = ['재학', '휴학'] as const;
+
+export default function RegisterScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  // Phase 1에서 실제 상태 관리로 교체
+  const selectedGrade = 1; // 기본 선택: 1학년
+  const selectedStatus = '재학'; // 기본 선택: 재학
+
+  return (
+    <View style={styles.container}>
+      {/* ── TopAppBar (absolute) ── */}
+      <SafeAreaView edges={['top']} style={styles.topAppBar}>
+        <View style={styles.topAppBarContent}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => router.back()}
+          >
+            <Feather name="chevron-left" size={24} color="#00175B" />
+          </TouchableOpacity>
+          <Text style={styles.topAppBarTitle}>회원가입</Text>
+          {/* 오른쪽 빈 공간 (중앙 정렬용) */}
+          <View style={styles.backButton} />
+        </View>
+      </SafeAreaView>
+
+      {/* ── Main (스크롤) ── */}
+      <KeyboardAvoidingView
+        style={styles.mainContainer}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={[
+            styles.scrollContent,
+            {
+              paddingTop: insets.top + 64 + 16,
+              paddingBottom: insets.bottom + 82 + 16
+            }
+          ]}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* 노란 안내 카드 — 시안: Section - Academic Brief */}
+          <View style={styles.briefCard}>
+            <Text style={styles.briefTitle}>
+              가톨릭대 학생 인증 및 회원가입
+            </Text>
+            <Text style={styles.briefSubtitle}>
+              학교 메일 인증을 통해 서비스를 시작하세요.
+            </Text>
+          </View>
+
+          {/* ── 폼 섹션 (gap: 39) ── */}
+          <View style={styles.formContainer}>
+            {/* 1. 학교 이메일 섹션 */}
+            <View style={styles.sectionGroup}>
+              <View style={styles.labelContainer}>
+                <Text style={styles.sectionLabel}>학교 이메일</Text>
+              </View>
+              <View style={styles.emailRow}>
+                <View style={[styles.inputContainer, styles.emailInput]}>
+                  <TextInput
+                    style={styles.textInput}
+                    placeholder="@catholic.ac.kr"
+                    placeholderTextColor="#9CA3AF"
+                    keyboardType="email-address"
+                    autoCapitalize="none"
+                    editable={false} // Phase 1에서 활성화
+                  />
+                </View>
+              </View>
+              {/* 인증번호 전송 버튼 */}
+              <TouchableOpacity
+                style={styles.verifyButton}
+                activeOpacity={0.85}
+                disabled // Phase 1에서 활성화
+              >
+                <Text style={styles.verifyButtonText}>인증번호 전송</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* 2. 인증번호 섹션 */}
+            <View style={styles.sectionGroup}>
+              <View style={styles.labelContainer}>
+                <Text style={styles.sectionLabel}>인증번호</Text>
+              </View>
+              <View style={styles.inputContainer}>
+                <TextInput
+                  style={styles.textInput}
+                  placeholder="인증 번호 6자리 입력"
+                  placeholderTextColor="#9CA3AF"
+                  keyboardType="number-pad"
+                  maxLength={6}
+                  editable={false} // Phase 1에서 활성화
+                />
+                {/* Phase 1에서 타이머 표시 추가 */}
+              </View>
+            </View>
+
+            {/* 3. 비밀번호 섹션 */}
+            <View style={styles.sectionGroup}>
+              <View style={styles.labelContainer}>
+                <Text style={styles.sectionLabel}>비밀번호</Text>
+              </View>
+              {/* 비밀번호 규칙 안내 — Phase 1에서 동적 검증으로 교체 */}
+              <View style={styles.passwordRulesContainer}>
+                <Text style={styles.passwordRule}>
+                  • 8자 이상, 영문·숫자·특수문자 포함
+                </Text>
+              </View>
+              <View style={styles.inputContainer}>
+                <TextInput
+                  style={styles.textInput}
+                  placeholder="비밀번호 입력"
+                  placeholderTextColor="#9CA3AF"
+                  secureTextEntry
+                  editable={false} // Phase 1에서 활성화
+                />
+              </View>
+            </View>
+
+            {/* 4. 전공 선택 섹션 */}
+            <View style={styles.sectionGroup}>
+              {/* 주전공 */}
+              <View style={styles.subsection}>
+                <View style={styles.labelContainer}>
+                  <Text style={styles.sectionLabel}>전공 선택</Text>
+                </View>
+                <TouchableOpacity
+                  style={styles.selectButton}
+                  activeOpacity={0.7}
+                  disabled // Phase 1에서 활성화
+                >
+                  <Text style={styles.selectPlaceholder}>
+                    전공을 선택하세요
+                  </Text>
+                  <Feather name="chevron-down" size={16} color="#757684" />
+                </TouchableOpacity>
+              </View>
+              {/* 복수/부전공 */}
+              <View style={styles.subsection}>
+                <View style={styles.labelContainer}>
+                  <Text style={styles.sectionLabel}>
+                    복수 · 부전공 선택 (선택사항)
+                  </Text>
+                </View>
+                <TouchableOpacity
+                  style={styles.selectButton}
+                  activeOpacity={0.7}
+                  disabled // Phase 1에서 활성화
+                >
+                  <Text style={styles.selectPlaceholder}>
+                    선택안함/미확정시 비워주세요
+                  </Text>
+                  <Feather name="chevron-down" size={16} color="#757684" />
+                </TouchableOpacity>
+                <View style={styles.helperContainer}>
+                  <Text style={styles.helperText}>
+                    추후 마이페이지에서 변경 가능합니다
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            {/* 5. 학년 선택 섹션 — 시안: 4개 pill 버튼 */}
+            <View style={styles.sectionGroup}>
+              <View style={styles.labelContainer}>
+                <Text style={styles.sectionLabel}>학년 선택</Text>
+              </View>
+              <View style={styles.gradeRow}>
+                {GRADE_OPTIONS.map((grade) => {
+                  const isSelected = grade === selectedGrade;
+                  return (
+                    <TouchableOpacity
+                      key={grade}
+                      style={[
+                        styles.gradePill,
+                        isSelected && styles.gradePillSelected,
+                      ]}
+                      activeOpacity={0.7}
+                      disabled // Phase 1에서 활성화
+                    >
+                      <Text
+                        style={[
+                          styles.gradePillText,
+                          isSelected && styles.gradePillTextSelected,
+                        ]}
+                      >
+                        {grade}학년
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+
+            {/* 6. 재학 상태 섹션 — 시안: 토글 (재학 / 휴학) */}
+            <View style={styles.sectionGroup}>
+              <View style={styles.labelContainer}>
+                <Text style={styles.sectionLabel}>재학 상태</Text>
+              </View>
+              <View style={styles.statusToggleContainer}>
+                {STATUS_OPTIONS.map((status) => {
+                  const isSelected = status === selectedStatus;
+                  return (
+                    <TouchableOpacity
+                      key={status}
+                      style={[
+                        styles.statusToggle,
+                        isSelected && styles.statusToggleSelected,
+                      ]}
+                      activeOpacity={0.7}
+                      disabled // Phase 1에서 활성화
+                    >
+                      <Text
+                        style={[
+                          styles.statusToggleText,
+                          isSelected && styles.statusToggleTextSelected,
+                        ]}
+                      >
+                        {status}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      {/* ── BottomNavBar (absolute) ── */}
+      <SafeAreaView edges={['bottom']} style={styles.bottomBar}>
+        <View style={styles.bottomBarContent}>
+          {/* 이전 버튼 */}
+          <TouchableOpacity
+            style={styles.prevButton}
+            activeOpacity={0.7}
+            onPress={() => router.back()}
+          >
+            <Feather name="chevron-left" size={18} color="#444652" />
+            <Text style={styles.prevButtonText}>이전</Text>
+          </TouchableOpacity>
+
+          {/* 완료 버튼 */}
+          <TouchableOpacity
+            style={styles.completeButton}
+            activeOpacity={0.85}
+            disabled // Phase 1에서 활성화
+          >
+            <Text style={styles.completeButtonText}>완료</Text>
+            <Feather name="check" size={18} color="#FFFFFF" />
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9F9F9', // 시안: 메인 배경
+  },
+
+  // ─── TopAppBar ────────────────────────────────────────
+  topAppBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+    backgroundColor: '#FFFFFFCC', // 시안: 80% 흰색 + blur
+  },
+  topAppBarContent: {
+    height: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  topAppBarTitle: {
+    flex: 1,
+    fontFamily: 'Pretendard',
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#00175B',
+    letterSpacing: -0.45,
+    textAlign: 'center',
+  },
+
+  // ─── Main (스크롤) ────────────────────────────────────
+  mainContainer: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingTop: 96, // TopAppBar 높이 (64) + SafeArea + 여유
+    paddingHorizontal: 24,
+    paddingBottom: 144, // BottomNavBar 높이 + 여유
+    gap: 39, // 시안: Main gap
+  },
+
+  // ─── 노란 안내 카드 ───────────────────────────────────
+  briefCard: {
+    backgroundColor: '#FCC006', // 시안: Ginkgo Yellow
+    borderRadius: 16,
+    padding: 24,
+    gap: 8,
+    // 시안의 그림자
+    ...Platform.select({
+      android: { elevation: 2 }, // Android only
+      ios: {
+        shadowColor: '#000000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.05,
+        shadowRadius: 2,
+      },
+    }),
+  },
+  briefTitle: {
+    fontFamily: 'Pretendard',
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#6C5000', // 시안: highlightText 계열
+    lineHeight: 25,
+  },
+  briefSubtitle: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: '#6C5000CC', // 시안: 80% opacity
+    lineHeight: 20,
+  },
+
+  // ─── 폼 컨테이너 ──────────────────────────────────────
+  formContainer: {
+    gap: 39, // 시안: Form gap
+  },
+  sectionGroup: {
+    gap: 16, // 시안: 각 Section 내부 gap
+  },
+  subsection: {
+    gap: 16,
+  },
+  labelContainer: {
+    paddingHorizontal: 4,
+  },
+  sectionLabel: {
+    fontFamily: 'Pretendard',
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#757684', // 시안: 라벨 색상
+    letterSpacing: 1.1,
+    lineHeight: 17,
+  },
+
+  // ─── 인풋 공통 ────────────────────────────────────────
+  inputContainer: {
+    borderRadius: 12,
+    backgroundColor: '#F3F3F3', // 시안: Input 배경
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 17,
+  },
+  textInput: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    color: Colors.textPrimary,
+    padding: 0,
+  },
+  emailRow: {
+    gap: 12,
+  },
+  emailInput: {
+    // 이메일 입력은 전체 너비
+  },
+
+  // ─── 인증번호 전송 버튼 ───────────────────────────────
+  verifyButton: {
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 16,
+    backgroundColor: Colors.primary, // 시안: gradient 간소화
+  },
+  verifyButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+
+  // ─── 비밀번호 규칙 ────────────────────────────────────
+  passwordRulesContainer: {
+    paddingHorizontal: 4,
+  },
+  passwordRule: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    color: '#757684',
+    lineHeight: 18,
+  },
+
+  // ─── 전공 선택 드롭다운 ───────────────────────────────
+  selectButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 12,
+    backgroundColor: '#F3F3F3',
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+  selectPlaceholder: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    color: '#9CA3AF',
+  },
+  helperContainer: {
+    paddingHorizontal: 4,
+  },
+  helperText: {
+    fontFamily: 'Pretendard',
+    fontSize: 11,
+    color: '#9CA3AF',
+    lineHeight: 16,
+  },
+
+  // ─── 학년 pill 버튼 ──────────────────────────────────
+  gradeRow: {
+    flexDirection: 'row',
+    gap: 0,
+  },
+  gradePill: {
+    flex: 1,
+    borderRadius: 12,
+    backgroundColor: '#E2E2E2', // 시안: 미선택 배경
+    paddingVertical: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  gradePillSelected: {
+    backgroundColor: '#00175B', // 시안: 선택 배경 (Dark Blue)
+  },
+  gradePillText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#444652', // 시안: 미선택 텍스트
+  },
+  gradePillTextSelected: {
+    color: '#FFFFFF',
+  },
+
+  // ─── 재학 상태 토글 ──────────────────────────────────
+  statusToggleContainer: {
+    flexDirection: 'row',
+    backgroundColor: '#F3F3F3', // 시안: 토글 배경
+    borderRadius: 16,
+    padding: 4,
+  },
+  statusToggle: {
+    flex: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  statusToggleSelected: {
+    backgroundColor: '#FFFFFF',
+    // 시안의 그림자
+    ...Platform.select({
+      android: { elevation: 1 }, // Android only
+      ios: {
+        shadowColor: '#000000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.05,
+        shadowRadius: 2,
+      },
+    }),
+  },
+  statusToggleText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#757684', // 시안: 미선택 텍스트
+  },
+  statusToggleTextSelected: {
+    color: Colors.textPrimary,
+    fontWeight: '700',
+  },
+
+  // ─── BottomNavBar ─────────────────────────────────────
+  bottomBar: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: '#FFFFFFCC', // 시안: 80% 흰색 + blur
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    // 시안의 그림자
+    ...Platform.select({
+      android: { elevation: 12 }, // Android only
+      ios: {
+        shadowColor: '#00175B',
+        shadowOffset: { width: 0, height: -10 },
+        shadowOpacity: 0.06,
+        shadowRadius: 35,
+      },
+    }),
+  },
+  bottomBarContent: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 60,
+    paddingBottom: 32,
+  },
+  prevButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: -1,
+    paddingVertical: 8,
+    paddingHorizontal: 32,
+  },
+  prevButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#444652',
+  },
+  completeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: -1,
+    backgroundColor: Colors.primary,
+    borderRadius: 16,
+    paddingVertical: 8,
+    paddingHorizontal: 32,
+    // 시안의 그림자
+    ...Platform.select({
+      android: { elevation: 6 }, // Android only
+      ios: {
+        shadowColor: '#00288C',
+        shadowOffset: { width: 0, height: 10 },
+        shadowOpacity: 0.2,
+        shadowRadius: 13,
+      },
+    }),
+  },
+  completeButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+});

--- a/frontend/app/register.tsx
+++ b/frontend/app/register.tsx
@@ -389,7 +389,7 @@ const styles = StyleSheet.create({
   sectionLabel: {
     fontFamily: 'Pretendard',
     fontSize: 11,
-    fontWeight: '600',
+    fontWeight: '700',
     color: '#757684', // 시안: 라벨 색상
     letterSpacing: 1.1,
     lineHeight: 17,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,11 +1,14 @@
 /**
  * Axios 인스턴스 + 인터셉터 설정
  * Sprint 1: 인증 없이 기본 요청만 처리
- * Sprint 2: JWT 토큰 인터셉터 추가 예정
+ * Sprint 2: JWT 토큰 인터셉터 활성화
  */
 
 import axios from 'axios';
+import { router } from 'expo-router';
+
 import { API_BASE_URL, API_TIMEOUT } from '@/src/constants/api';
+import { useAuthStore } from '@/src/store/useAuthStore';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -18,9 +21,12 @@ const apiClient = axios.create({
 // ─── 요청 인터셉터 ─────────────────────────────────────────────────
 apiClient.interceptors.request.use(
   (config) => {
-    // TODO Sprint 2: JWT 액세스 토큰 헤더 추가
-    // const token = useAuthStore.getState().accessToken;
-    // if (token) config.headers.Authorization = `Bearer ${token}`;
+    // JWT 액세스 토큰 자동 주입
+    // accessToken이 null이면 헤더를 추가하지 않음 (인증 불필요 API에도 안전)
+    const token = useAuthStore.getState().accessToken;
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     return config;
   },
   (error) => Promise.reject(error),
@@ -30,7 +36,19 @@ apiClient.interceptors.request.use(
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    // TODO Sprint 2: 401 → 토큰 갱신 후 재시도 로직 추가
+    // 401 Unauthorized → 토큰 클리어 + 로그인 화면 리다이렉트
+    // 1차 MVP: refreshToken 갱신 미구현, 단순 로그아웃 처리
+    // (트랩 #9: accessToken 만료 + refreshToken 유효 케이스는 추후에 재검토)
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      const { accessToken } = useAuthStore.getState();
+
+      // 이미 인증 토큰이 있었는데 401을 받은 경우에만 로그아웃 처리
+      // (인증 불필요 API의 401은 무시 — 로그인/회원가입 API의 비밀번호 오답 등)
+      if (accessToken) {
+        useAuthStore.getState().clearAuth();
+        router.replace('/login' as never);
+      }
+    }
     return Promise.reject(error);
   },
 );

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,74 @@
+/**
+ * 인증 서비스 레이어 — /api/auth/* fetcher 4종
+ *
+ * 엔드포인트:
+ *   POST /api/auth/login         — 이메일/비밀번호 로그인, JWT + 사용자 정보 반환
+ *   POST /api/auth/register      — 회원가입 (JWT 미포함!)
+ *   POST /api/auth/email/send    — 이메일 인증번호 발송
+ *   POST /api/auth/email/verify  — 이메일 인증번호 검증
+ *
+ * 주의:
+ *   - 인증 API 4종은 모두 공개 엔드포인트 (JWT 불필요)
+ *   - 회원가입 응답에 JWT가 없으므로 가입 후 자동 로그인은
+ *     프론트에서 동일 자격증명으로 login을 별도 호출해야 함 (트랩 #7)
+ */
+
+import apiClient from '@/src/services/api';
+import type {
+  EmailSendRequest,
+  EmailSendResponse,
+  EmailVerifyRequest,
+  EmailVerifyResponse,
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
+  RegisterResponse,
+} from '@/src/types/auth';
+
+/**
+ * 로그인 — JWT + 사용자 정보 + 태그 한 번에 반환
+ */
+export async function login(req: LoginRequest): Promise<LoginResponse> {
+  const { data } = await apiClient.post<LoginResponse>(
+    '/api/auth/login',
+    req,
+  );
+  return data;
+}
+
+/**
+ * 회원가입 — JWT 미포함 응답. 가입 후 자동 로그인은 login 별도 호출 필요
+ */
+export async function register(req: RegisterRequest): Promise<RegisterResponse> {
+  const { data } = await apiClient.post<RegisterResponse>(
+    '/api/auth/register',
+    req,
+  );
+  return data;
+}
+
+/**
+ * 이메일 인증번호 발송 — 6자리 인증번호를 이메일로 전송 (유효 3분)
+ */
+export async function sendVerificationEmail(
+  req: EmailSendRequest,
+): Promise<EmailSendResponse> {
+  const { data } = await apiClient.post<EmailSendResponse>(
+    '/api/auth/email/send',
+    req,
+  );
+  return data;
+}
+
+/**
+ * 이메일 인증번호 검증 — 성공 시 백엔드에 "인증 완료" 상태 기록
+ */
+export async function verifyEmail(
+  req: EmailVerifyRequest,
+): Promise<EmailVerifyResponse> {
+  const { data } = await apiClient.post<EmailVerifyResponse>(
+    '/api/auth/email/verify',
+    req,
+  );
+  return data;
+}

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -59,7 +59,7 @@ const INITIAL_STATE = {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
-      ...INITIAL_STATE,
+      ...INITIAL_STATE, // 스토어 처음 켜졌을 시 세팅용 초기값
 
       setAuth: (response) =>
         set({

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,88 @@
+/**
+ * 인증 상태 Zustand 스토어 (AsyncStorage 영속화)
+ *
+ * 정책:
+ *  - accessToken + refreshToken을 영속 저장 (앱 재실행 시 자동 로그인 기반)
+ *  - user 정보 + tags도 영속 저장 (로그인 응답 한 번으로 채움, 별도 조회 불필요)
+ *  - clearAuth() 호출 시 토큰·사용자·태그 모두 초기화 (로그아웃)
+ *
+ * 영속화:
+ *  - zustand/middleware persist + createJSONStorage(() => AsyncStorage)
+ *  - 키: 'cathori-auth'
+ *  - 앱 재시작 후 자동 rehydrate
+ *
+ * 패턴 참고: useSearchHistoryStore.ts
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import type { AuthUser, LoginResponse, UserTag } from '@/src/types/auth';
+
+interface AuthState {
+  /** JWT 액세스 토큰 (1시간 유효) */
+  accessToken: string | null;
+  /** JWT 리프레시 토큰 (30일 유효) */
+  refreshToken: string | null;
+  /** 사용자 프로필 정보 */
+  user: AuthUser | null;
+  /** 사용자 태그 목록 */
+  tags: UserTag[];
+
+  /**
+   * 로그인 성공 시 호출 — 토큰 + 사용자 정보 + 태그를 한 번에 세팅
+   * LoginResponse를 그대로 받아 필요한 필드를 추출
+   */
+  setAuth: (response: LoginResponse) => void;
+
+  /**
+   * 로그아웃 시 호출 — 토큰·사용자·태그 모두 초기화
+   * AsyncStorage에서도 자동으로 삭제됨 (persist 미들웨어)
+   */
+  clearAuth: () => void;
+
+  /**
+   * 태그 목록 갱신 — 태그 추가/삭제 후 클라이언트 낙관적 갱신용
+   */
+  updateTags: (tags: UserTag[]) => void;
+}
+
+/** 초기 상태 (로그아웃 상태) */
+const INITIAL_STATE = {
+  accessToken: null,
+  refreshToken: null,
+  user: null,
+  tags: [] as UserTag[],
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      ...INITIAL_STATE,
+
+      setAuth: (response) =>
+        set({
+          accessToken: response.accessToken,
+          refreshToken: response.refreshToken,
+          user: {
+            userId: response.userId,
+            email: response.email,
+            major: response.major,
+            secondMajor: response.secondMajor,
+            grade: response.grade,
+            enrollmentStatus: response.enrollmentStatus,
+          },
+          tags: response.tags,
+        }),
+
+      clearAuth: () => set({ ...INITIAL_STATE }),
+
+      updateTags: (tags) => set({ tags }),
+    }),
+    {
+      name: 'cathori-auth', // 저장소 안의 아이템의 이름
+      storage: createJSONStorage(() => AsyncStorage), // AsyncStorage에 저장
+    },
+  ),
+);

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,101 @@
+/**
+ * Cathori 인증 도메인 타입 정의
+ * 백엔드 API 명세 기반
+ */
+
+// ─── 사용자 태그 ──────────────────────────────────────────────────────
+
+/** 사용자 태그 — 로그인 응답에 포함되는 태그 정보 */
+export interface UserTag {
+  tagId: number;
+  tagName: string;
+}
+
+// ─── 로그인 ──────────────────────────────────────────────────────────
+
+/** 로그인 요청 */
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+/**
+ * 로그인 응답
+ * JWT 2종 + 사용자 정보 + 태그 한 번에 반환
+ */
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  userId: number;
+  email: string;
+  /** 주전공 */
+  major: string;
+  /** 복수/부전공 (없으면 null) */
+  secondMajor: string | null;
+  /** 학년 (1~4) */
+  grade: number;
+  /** 재학 상태 */
+  enrollmentStatus: string;
+  /** 사용자가 등록한 태그 목록 */
+  tags: UserTag[];
+}
+
+// ─── 회원가입 ────────────────────────────────────────────────────────
+
+/** 회원가입 요청 */
+export interface RegisterRequest {
+  email: string;
+  password: string;
+  /** 주전공 */
+  major1: string;
+  /** 복수/부전공 (없으면 null) */
+  major2: string | null;
+  /** 학년 (1~4) */
+  grade: number;
+  /** 재학 상태 (재학 / 휴학) */
+  status: string;
+}
+
+/** 회원가입 응답 — JWT 미포함! 가입 후 자동 로그인은 프론트에서 login 별도 호출 */
+export interface RegisterResponse {
+  userId: number;
+  email: string;
+}
+
+// ─── 이메일 인증 ─────────────────────────────────────────────────────
+
+/** 이메일 인증번호 발송 요청 */
+export interface EmailSendRequest {
+  email: string;
+}
+
+/** 이메일 인증번호 발송 응답 */
+export interface EmailSendResponse {
+  email: string;
+}
+
+/** 이메일 인증번호 검증 요청 */
+export interface EmailVerifyRequest {
+  email: string;
+  code: string;
+}
+
+/** 이메일 인증번호 검증 응답 */
+export interface EmailVerifyResponse {
+  email: string;
+}
+
+// ─── 인증 스토어용 사용자 정보 ────────────────────────────────────────
+
+/**
+ * useAuthStore에 저장되는 사용자 프로필 정보
+ * LoginResponse에서 토큰·태그를 제외한 순수 사용자 정보
+ */
+export interface AuthUser {
+  userId: number;
+  email: string;
+  major: string;
+  secondMajor: string | null;
+  grade: number;
+  enrollmentStatus: string;
+}


### PR DESCRIPTION
# 📖 작업 배경

Sprint 1에서 모든 API 요청은 인증 없이 Mock 데이터 기반으로 동작했으며, `src/services/api.ts`의 JWT 인터셉터는 TODO 주석 상태로 남아 있었다. Sprint 2의 후속 작업—실 API 전환, 즐겨찾기 mutation, 알림/설정 화면—은 JWT 토큰 라이프사이클이 동작해야 진행 가능하다.

본 PR은 **인증 인프라를 한 번에 정착**시켜 모든 후속 Phase의 게이트를 해제하는 것이 목적이며, 다음 네 가지 공백을 채운다.

1. **`useAuthStore` 미존재** — 토큰·유저 정보를 앱 전역에서 관리할 Zustand 스토어 부재
2. **`src/services/auth.ts` 미존재** — 로그인·회원가입·이메일 인증 fetcher 부재
3. **인터셉터 비활성** — `api.ts`의 JWT 주입 및 401 처리가 TODO 주석 상태
4. **라우팅 가드 부재** — `app/_layout.tsx`에 토큰 기반 화면 분기 없음

로그인·회원가입 화면 레이아웃도 본 PR에 포함된다. 폼 로직은 Phase 1에서 훅과 연결 예정이며, 현재는 `editable={false}` / `disabled` 상태.

- #51 

<br>

## 🔧 작업 내용

### 신규 파일

- `src/types/auth.ts` — 인증 도메인 타입 8종 (`LoginRequest/Response`, `RegisterRequest/Response`, `EmailSendRequest/Response`, `EmailVerifyRequest/Response`, `AuthUser`, `UserTag`)
- `src/services/auth.ts` — 인증 fetcher 4종 (`login`, `register`, `sendVerificationEmail`, `verifyEmail`)
- `src/store/useAuthStore.ts` — Zustand + AsyncStorage persist. 상태: `accessToken`, `refreshToken`, `user`, `tags`. 액션: `setAuth`, `clearAuth`, `updateTags`
- `app/login.tsx` — 이메일/비밀번호 인풋 + 로그인 CTA + 회원가입 아웃라인 + 게스트 링크
- `app/register.tsx` — TopAppBar + 노란 안내 카드 + 폼 6섹션(이메일/인증번호/비밀번호/전공/학년/재학상태) + BottomNavBar(이전/완료)

### 수정 파일

- `src/services/api.ts` — JWT 요청 인터셉터 활성화 + 401 응답 인터셉터 (토큰 클리어 + 로그인 리다이렉트)
- `app/_layout.tsx` — SplashScreen 수동 제어 + persist rehydrate 대기 + `useProtectedRoute` 인증 라우팅 가드 + login/register `Stack.Screen` 등록
- `.gitignore` — 무시 파일 추가

<br>

## 🔍 동작 방식

### 인증 fetcher 경계

```
POST /api/auth/login              ──→  login(req: LoginRequest)
  { accessToken, refreshToken,          → useAuthStore.setAuth
    userId, email, major, ... }         → 메인 화면 이동

POST /api/auth/register           ──→  register(req: RegisterRequest)
  { userId, email }                     → login 별도 호출 (트랩7 #50)

POST /api/auth/email/send         ──→  sendVerificationEmail(req)
  { email }                             → 인증번호 입력 단계로 전환

POST /api/auth/email/verify       ──→  verifyEmail(req)
  { email }                             → 회원가입 폼 제출 허용
```

### 앱 진입 시 라우팅 가드 흐름

```
앱 시작
  └─ SplashScreen.preventAutoHideAsync()
       └─ useAuthStore rehydrate 대기
            ├─ accessToken 존재 → 메인 탭
            └─ accessToken 없음 → /login
                  └─ SplashScreen.hideAsync()
```

persist rehydrate가 완료되기 전에 화면이 전환되면 로그인 화면이 순간 보였다가 메인으로 튀는 깜빡임이 발생한다. `SplashScreen` 수동 제어로 rehydrate 완료 후에만 UI를 노출하여 이를 방지했다.

### JWT 인터셉터 401 처리 기준

```
요청 전  accessToken 있음 → Authorization 헤더 주입
         accessToken 없음 → 헤더 없이 그대로 전송

응답 후  401 수신 + accessToken 보유 → clearAuth + /login 리다이렉트
         401 수신 + accessToken 없음  → 그대로 reject (로그인/회원가입 API)
```

accessToken 보유 여부로 분기하는 이유는 인증이 필요 없는 API(`/login`, `/register`)의 자격증명 오류 401과, 세션이 만료된 401을 구분하기 위해서다. 토큰 없이 받은 401을 세션 만료로 처리하면 로그인 화면 진입 자체가 불가능해지는 무한 루프가 발생한다.

### Sprint 2 인증 활성화 후 전환 흐름

```
Sprint 1 (이전)                          Sprint 2 Phase 1 (이후)
────────────────────                    ──────────────────────────────
api.ts 인터셉터 TODO 주석               api.ts 인터셉터 활성 ← 본 PR
useAuthStore 미존재                     useAuthStore 신설   ← 본 PR
login.tsx 플레이스홀더                  useLogin 훅 연결    ← Phase 1
register.tsx 플레이스홀더              useRegister 훅 연결  ← Phase 1
```

훅 연결은 Phase 1에서 단순히 `disabled` 제거 + mutation 훅 연결만 하면 되도록, 폼 컴포넌트 구조를 미리 분리해 두었다.

<br>

## 💡 설계 근거

- **refreshToken 갱신을 1차 MVP에서 구현하지 않은 이유**: 
  - 갱신 엔드포인트가 아직 백엔드에서 확정되지 않았다. 
  - 검증된 적 없는 갱신 로직을 메인에 두면 *실제 동작 여부*가 미스터리로 남는다. 
  - 401 시 단순 로그아웃으로 처리하고, 이후에 갱신 API 확정 후 재검토하는 것이 낫다.

- **회원가입 후 `login` 별도 호출 (__트랩 7__)**: 
  - 백엔드 `/api/auth/register` 응답에는 JWT가 포함되지 않는다(`{ userId, email }` 만 반환). 
  - 가입 완료 즉시 자동 로그인하려면 `login` API를 별도 호출해야 한다. 
  - Phase 1 구현 시 이 순서를 누락하면 가입 후 로그인 화면으로 튀는 UX가 발생한다.

- **`useAuthStore`에 Zustand persist + AsyncStorage를 선택한 이유**: 
  - Sprint 1의 `useSearchHistoryStore`와 동일한 영속화 패턴을 따른다. 
  - 앱 재시작 후 토큰이 날아가면 매번 재로그인을 요구하는 불량 UX가 된다. 
  - rehydrate 완료 전 라우팅 가드가 동작하지 않도록 `_layout.tsx`에서 `hasHydrated`를 구독한다.

- **로그인·회원가입 화면을 레이아웃만 먼저 구현한 이유**: 
  - 인터셉터 비활성 상태에서 mutation을 연결해봤자 즉시 401 반환이다. 
  - 호출이 검증된 적 없는 코드를 메인에 두는 것보다, 라우팅 에러를 방지할 화면만 먼저 만들고 Phase 1에서 로직을 붙이는 것이 더 명확하다.

- **`useProtectedRoute`를 `_layout.tsx`에 두는 이유**: 
  - Expo Router의 파일 기반 라우팅에서 전역 가드를 두려면 루트 레이아웃이 유일한 단일 지점이다. 
  - 각 탭 화면에 분산 배치하면 신규 화면 추가 시 누락 위험이 생긴다.

<br>

## ✅ 체크리스트

- [x] `npx tsc --noEmit` 통과
- [x] `npx expo start` 실행 확인
- [x] 인증 타입 8종 정의 (`src/types/auth.ts`)
- [x] 인증 fetcher 4종 작성 (`login` / `register` / `sendVerificationEmail` / `verifyEmail`)
- [x] `useAuthStore` Zustand persist — `setAuth` / `clearAuth` / `updateTags` 액션
- [x] `api.ts` 요청 인터셉터 JWT 주입 활성화
- [x] `api.ts` 응답 인터셉터 401 분기 (accessToken 보유 시에만 로그아웃)
- [x] `_layout.tsx` SplashScreen 수동 제어 + rehydrate 대기 + `useProtectedRoute`
- [x] `login.tsx` 레이아웃 — pencil.dev 시안 b1GlJs 기반, 실기기 렌더링 확인
- [x] `register.tsx` 레이아웃 — pencil.dev 시안 VswbY 기반, 실기기 렌더링 확인
- [ ] `useLogin` mutation 훅 연결 — Phase 1
- [ ] `useRegister` + `useEmailVerification` 훅 연결 — Phase 1
- [ ] 가입 후 `login` 별도 호출 자동 로그인 (__트랩7__) — Phase 1
- [ ] Pretendard 폰트 로드(`expo-font`) 또는 시스템 폰트 폴백 확인 — Phase 1

<br>

## 🔗 연관 이슈

- #50  (TASK 진행상황 파악용)