### PR TITLE
[FEAT] FCM 푸시알림 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/cathori-firebase.json

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:testcontainers-postgresql:2.0.5")
+    implementation("com.google.firebase:firebase-admin:9.9.0")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
@@ -5,8 +5,20 @@ import org.cathori.backend.alert.domain.AlertHistory;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * 알림 발송 이력 저장소의 기능 명세입니다.
+ *
+ * AlertService가 이력을 조회하거나 저장할 때 사용하는 창구입니다.
+ * 실제 데이터베이스 접근은 AlertHistoryRepositoryImpl이 담당합니다.
+ */
 public interface AlertHistoryRepository {
+
+    /** 지금까지 알림을 발송한 적 있는 공지사항 ID 목록을 반환합니다. (중복 발송 방지에 사용) */
     Set<Long> findAllSentNoticeIds();
+
+    /** 발송에 실패했고 재시도 횟수가 3회 미만인 이력 목록을 반환합니다. */
     List<AlertHistory> findFailedForRetry();
+
+    /** 알림 발송 이력을 저장하거나 갱신합니다. */
     AlertHistory save(AlertHistory history);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
@@ -1,0 +1,12 @@
+package org.cathori.backend.alert.application;
+
+import org.cathori.backend.alert.domain.AlertHistory;
+
+import java.util.List;
+import java.util.Set;
+
+public interface AlertHistoryRepository {
+    Set<Long> findAllSentNoticeIds();
+    List<AlertHistory> findFailedForRetry();
+    AlertHistory save(AlertHistory history);
+}

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
@@ -1,0 +1,106 @@
+package org.cathori.backend.alert.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cathori.backend.alert.domain.AlertHistory;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.user.domain.User;
+import org.cathori.backend.user.domain.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlertService {
+
+    private final AlertHistoryRepository alertHistoryRepository;
+    private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
+    private final FcmPort fcmPort;
+
+    public void dispatchAlerts() {
+        Set<Long> sentIds = alertHistoryRepository.findAllSentNoticeIds();
+        List<Notice> unsentNotices = sentIds.isEmpty()
+                ? noticeRepository.findAll()
+                : noticeRepository.findUnsentNotices(sentIds);
+
+        if (unsentNotices.isEmpty()) {
+            log.info("미발송 공지 없음");
+            return;
+        }
+
+        log.info("미발송 공지 {}건 발송 시작", unsentNotices.size());
+        for (Notice notice : unsentNotices) {
+            dispatchForNotice(notice);
+        }
+    }
+
+    private void dispatchForNotice(Notice notice) {
+        List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
+                .stream()
+                .map(User::getDeviceToken)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        if (tokens.isEmpty()) return;
+
+        try {
+            FcmBatchResult result = fcmPort.sendMulticast(tokens, "Cathori 새 공지", notice.getTitle(), notice.getId());
+            alertHistoryRepository.save(toAlertHistory(notice.getId(), result));
+            log.info("FCM 발송 완료. noticeId={}, success={}, fail={}",
+                    notice.getId(), result.successCount(), result.failureCount());
+        } catch (Exception e) {
+            log.error("FCM 발송 실패. noticeId={}", notice.getId(), e);
+            alertHistoryRepository.save(AlertHistory.failed(notice.getId()));
+        }
+    }
+
+    private AlertHistory toAlertHistory(Long noticeId, FcmBatchResult result) {
+        if (result.failureCount() == 0) return AlertHistory.success(noticeId);
+        if (result.successCount() > 0) return AlertHistory.partialSuccess(noticeId);
+        return AlertHistory.failed(noticeId);
+    }
+
+    public void retryFailedAlerts() {
+        List<AlertHistory> failedList = alertHistoryRepository.findFailedForRetry();
+        if (failedList.isEmpty()) return;
+
+        log.info("FCM 재시도 {}건", failedList.size());
+        for (AlertHistory history : failedList) {
+            retryAlert(history);
+        }
+    }
+
+    private void retryAlert(AlertHistory history) {
+        Notice notice = noticeRepository.findById(history.getNoticeId()).orElse(null);
+        if (notice == null) return;
+
+        List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
+                .stream()
+                .map(User::getDeviceToken)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        if (tokens.isEmpty()) return;
+
+        try {
+            FcmBatchResult result = fcmPort.sendMulticast(tokens, "Cathori 새 공지", notice.getTitle(), notice.getId());
+            if (result.failureCount() == 0) {
+                history.markSuccess();
+            } else {
+                history.incrementRetry();
+            }
+        } catch (Exception e) {
+            log.error("FCM 재시도 실패. historyId={}", history.getId(), e);
+            history.incrementRetry();
+        }
+
+        alertHistoryRepository.save(history);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
@@ -14,6 +14,14 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * 공지사항 푸시 알림 발송을 담당하는 서비스입니다.
+ *
+ * 주요 역할:
+ *   1. 아직 알림을 보내지 않은 새 공지를 찾아 관심 태그가 일치하는 사용자에게 앱 푸시 알림을 보냅니다.
+ *   2. 발송에 실패한 알림을 주기적으로 재시도합니다. (최대 3회)
+ *   3. 모든 발송 시도의 결과(성공 / 부분 성공 / 실패)를 이력으로 기록합니다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,6 +32,16 @@ public class AlertService {
     private final UserRepository userRepository;
     private final FcmPort fcmPort;
 
+    /**
+     * 새 공지에 대한 푸시 알림을 일괄 발송합니다.
+     *
+     * 동작 순서:
+     *   1. 이미 알림을 보낸 공지 목록을 조회합니다.
+     *   2. 아직 한 번도 알림을 보내지 않은 공지만 추려냅니다.
+     *   3. 각 공지의 제목과 일치하는 태그를 등록한 사용자에게 푸시 알림을 발송합니다.
+     *
+     * 이 메서드는 스케줄러에 의해 주기적으로 자동 실행됩니다.
+     */
     public void dispatchAlerts() {
         Set<Long> sentIds = alertHistoryRepository.findAllSentNoticeIds();
         List<Notice> unsentNotices = sentIds.isEmpty()
@@ -41,6 +59,13 @@ public class AlertService {
         }
     }
 
+    /**
+     * 공지 하나에 대해 알림 수신 대상자를 추려 푸시 알림을 발송하고 결과를 저장합니다.
+     *
+     * - 공지 제목의 키워드와 일치하는 태그를 등록한 사용자만 발송 대상이 됩니다.
+     * - 기기 토큰이 없는 사용자(앱 미설치 또는 알림 비허용)는 발송 대상에서 제외됩니다.
+     * - 발송 도중 오류가 발생해도 다른 공지의 발송에는 영향을 주지 않습니다.
+     */
     private void dispatchForNotice(Notice notice) {
         List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
                 .stream()
@@ -61,12 +86,28 @@ public class AlertService {
         }
     }
 
+    /**
+     * 발송 결과를 이력 상태로 변환합니다.
+     *
+     * - 전원 수신 성공  → SUCCESS (성공)
+     * - 일부만 수신 성공 → PARTIAL_SUCCESS (부분 성공)
+     * - 전원 수신 실패  → FAILED (실패)
+     */
     private AlertHistory toAlertHistory(Long noticeId, FcmBatchResult result) {
         if (result.failureCount() == 0) return AlertHistory.success(noticeId);
         if (result.successCount() > 0) return AlertHistory.partialSuccess(noticeId);
         return AlertHistory.failed(noticeId);
     }
 
+    /**
+     * 이전에 실패한 알림 발송을 재시도합니다.
+     *
+     * - FAILED 상태이고 재시도 횟수가 3회 미만인 이력만 대상으로 합니다.
+     * - 재시도에 성공하면 해당 이력의 상태가 SUCCESS로 변경됩니다.
+     * - 재시도에도 실패하면 재시도 횟수가 1 증가하며, 3회 소진 시 더 이상 재시도하지 않습니다.
+     *
+     * 이 메서드는 스케줄러에 의해 주기적으로 자동 실행됩니다.
+     */
     public void retryFailedAlerts() {
         List<AlertHistory> failedList = alertHistoryRepository.findFailedForRetry();
         if (failedList.isEmpty()) return;
@@ -77,6 +118,12 @@ public class AlertService {
         }
     }
 
+    /**
+     * 실패 이력 하나에 대해 알림 재발송을 시도하고 결과를 갱신합니다.
+     *
+     * - 원본 공지가 삭제된 경우에는 재시도 없이 조용히 건너뜁니다.
+     * - 재발송 성공 여부에 따라 이력 상태 또는 재시도 횟수가 업데이트됩니다.
+     */
     private void retryAlert(AlertHistory history) {
         Notice notice = noticeRepository.findById(history.getNoticeId()).orElse(null);
         if (notice == null) return;

--- a/backend/src/main/java/org/cathori/backend/alert/application/FcmBatchResult.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/FcmBatchResult.java
@@ -1,4 +1,10 @@
 package org.cathori.backend.alert.application;
 
+/**
+ * FCM 일괄 발송 결과를 담는 데이터 객체입니다.
+ *
+ * @param successCount 정상적으로 기기에 전달된 알림 수
+ * @param failureCount 전달에 실패한 알림 수 (기기 토큰 만료, 네트워크 오류 등)
+ */
 public record FcmBatchResult(int successCount, int failureCount) {
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/FcmBatchResult.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/FcmBatchResult.java
@@ -1,0 +1,4 @@
+package org.cathori.backend.alert.application;
+
+public record FcmBatchResult(int successCount, int failureCount) {
+}

--- a/backend/src/main/java/org/cathori/backend/alert/application/FcmPort.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/FcmPort.java
@@ -2,6 +2,22 @@ package org.cathori.backend.alert.application;
 
 import java.util.List;
 
+/**
+ * 앱 푸시 알림(FCM) 발송 기능의 명세입니다.
+ *
+ * FCM(Firebase Cloud Messaging)은 앱이 설치된 사용자의 기기에 알림을 전송하는 서비스입니다.
+ * 실제 FCM 통신은 FcmAdapter가 담당하며, 이 인터페이스는 그 기능을 추상화합니다.
+ */
 public interface FcmPort {
+
+    /**
+     * 여러 사용자에게 동시에 푸시 알림을 발송합니다.
+     *
+     * @param deviceTokens 알림을 받을 사용자 기기 토큰 목록 (앱 설치 시 발급되는 고유 식별자)
+     * @param title        알림 제목
+     * @param body         알림 본문 (공지 제목)
+     * @param noticeId     해당 공지사항 ID (앱에서 공지 상세 화면으로 이동 시 사용)
+     * @return             성공/실패 건수를 담은 발송 결과
+     */
     FcmBatchResult sendMulticast(List<String> deviceTokens, String title, String body, Long noticeId);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/FcmPort.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/FcmPort.java
@@ -1,0 +1,7 @@
+package org.cathori.backend.alert.application;
+
+import java.util.List;
+
+public interface FcmPort {
+    FcmBatchResult sendMulticast(List<String> deviceTokens, String title, String body, Long noticeId);
+}

--- a/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
+++ b/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
@@ -7,6 +7,17 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * 공지사항 알림 발송 이력을 나타내는 데이터 모델입니다.
+ *
+ * 알림이 발송될 때마다 이 이력이 생성되며, 발송 결과(성공/부분 성공/실패)와
+ * 재시도 횟수가 기록됩니다. 관리자는 이 데이터를 통해 알림 발송 현황을 파악할 수 있습니다.
+ *
+ * status 값의 의미:
+ *   - SUCCESS        : 대상 사용자 전원에게 알림이 정상 전달됨
+ *   - PARTIAL_SUCCESS: 일부 사용자에게만 알림이 전달됨
+ *   - FAILED         : 대상 사용자 전원에게 알림 전달이 실패함
+ */
 @Entity
 @Table(name = "alert_history")
 @Getter

--- a/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
+++ b/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
@@ -1,0 +1,66 @@
+package org.cathori.backend.alert.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "alert_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlertHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "notice_id", nullable = false)
+    private Long noticeId;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static AlertHistory success(Long noticeId) {
+        return create(noticeId, "SUCCESS");
+    }
+
+    public static AlertHistory partialSuccess(Long noticeId) {
+        return create(noticeId, "PARTIAL_SUCCESS");
+    }
+
+    public static AlertHistory failed(Long noticeId) {
+        return create(noticeId, "FAILED");
+    }
+
+    private static AlertHistory create(Long noticeId, String status) {
+        AlertHistory history = new AlertHistory();
+        history.noticeId = noticeId;
+        history.status = status;
+        history.retryCount = 0;
+        history.createdAt = LocalDateTime.now();
+        history.updatedAt = LocalDateTime.now();
+        return history;
+    }
+
+    public void markSuccess() {
+        this.status = "SUCCESS";
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void incrementRetry() {
+        this.retryCount++;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
@@ -9,9 +9,11 @@ import java.util.Set;
 
 public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, Long> {
 
+    /** 알림 발송 이력이 존재하는 모든 공지사항 ID를 조회합니다. */
     @Query("SELECT ah.noticeId FROM AlertHistory ah")
     Set<Long> findAllSentNoticeIds();
 
+    /** 상태가 FAILED이고 재시도 횟수가 3회 미만인 이력을 조회합니다. */
     @Query("SELECT ah FROM AlertHistory ah WHERE ah.status = 'FAILED' AND ah.retryCount < 3")
     List<AlertHistory> findFailedForRetry();
 }

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
@@ -1,0 +1,17 @@
+package org.cathori.backend.alert.infra;
+
+import org.cathori.backend.alert.domain.AlertHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Set;
+
+public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, Long> {
+
+    @Query("SELECT ah.noticeId FROM AlertHistory ah")
+    Set<Long> findAllSentNoticeIds();
+
+    @Query("SELECT ah FROM AlertHistory ah WHERE ah.status = 'FAILED' AND ah.retryCount < 3")
+    List<AlertHistory> findFailedForRetry();
+}

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
@@ -1,0 +1,33 @@
+package org.cathori.backend.alert.infra;
+
+import org.cathori.backend.alert.application.AlertHistoryRepository;
+import org.cathori.backend.alert.domain.AlertHistory;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
+
+    private final AlertHistoryJpaRepository jpaRepository;
+
+    public AlertHistoryRepositoryImpl(AlertHistoryJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Set<Long> findAllSentNoticeIds() {
+        return jpaRepository.findAllSentNoticeIds();
+    }
+
+    @Override
+    public List<AlertHistory> findFailedForRetry() {
+        return jpaRepository.findFailedForRetry();
+    }
+
+    @Override
+    public AlertHistory save(AlertHistory history) {
+        return jpaRepository.save(history);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
@@ -7,6 +7,12 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * AlertHistoryRepository 인터페이스의 실제 구현체입니다.
+ *
+ * AlertService는 이 클래스를 직접 참조하지 않고 AlertHistoryRepository 인터페이스를 통해 접근합니다.
+ * 실제 데이터베이스 쿼리는 AlertHistoryJpaRepository에 위임합니다.
+ */
 @Repository
 public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
 

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertRetryScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertRetryScheduler.java
@@ -5,12 +5,19 @@ import org.cathori.backend.alert.application.AlertService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 발송에 실패한 알림을 주기적으로 재시도하는 스케줄러입니다.
+ *
+ * 20분마다 실행되며, FAILED 상태이고 재시도 횟수가 3회 미만인 이력을 대상으로
+ * 알림 재발송을 시도합니다. 3회 모두 실패하면 더 이상 재시도하지 않습니다.
+ */
 @Component
 @RequiredArgsConstructor
 public class AlertRetryScheduler {
 
     private final AlertService alertService;
 
+    /** 20분마다 실패한 알림 발송을 재시도합니다. */
     @Scheduled(cron = "0 0/20 * * * *")
     public void retryFailedAlerts() {
         alertService.retryFailedAlerts();

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertRetryScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertRetryScheduler.java
@@ -1,0 +1,18 @@
+package org.cathori.backend.alert.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.alert.application.AlertService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlertRetryScheduler {
+
+    private final AlertService alertService;
+
+    @Scheduled(cron = "0 0/20 * * * *")
+    public void retryFailedAlerts() {
+        alertService.retryFailedAlerts();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertScheduler.java
@@ -6,6 +6,12 @@ import org.cathori.backend.alert.application.AlertService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 새 공지사항 알림을 정해진 시각에 자동 발송하는 스케줄러입니다.
+ *
+ * 매일 오전 11시에 실행되며, 아직 알림을 보내지 않은 새 공지가 있으면
+ * 관심 태그가 일치하는 사용자에게 푸시 알림을 발송합니다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -13,6 +19,7 @@ public class AlertScheduler {
 
     private final AlertService alertService;
 
+    /** 매일 오전 11시에 새 공지 알림을 일괄 발송합니다. */
     @Scheduled(cron = "0 0 11 * * *")
     public void dispatchAlerts() {
         log.info("알림 발송 스케줄러 시작");

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertScheduler.java
@@ -1,0 +1,21 @@
+package org.cathori.backend.alert.infra;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cathori.backend.alert.application.AlertService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlertScheduler {
+
+    private final AlertService alertService;
+
+    @Scheduled(cron = "0 0 11 * * *")
+    public void dispatchAlerts() {
+        log.info("알림 발송 스케줄러 시작");
+        alertService.dispatchAlerts();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/infra/FcmAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/FcmAdapter.java
@@ -8,10 +8,21 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/**
+ * Google FCM 서버와 실제로 통신하여 푸시 알림을 발송하는 구현체입니다.
+ *
+ * 여러 사용자에게 동시에 알림을 보내는 멀티캐스트 방식을 사용하며,
+ * 알림 본문과 함께 공지사항 ID를 앱에 전달하여 상세 화면으로 이동할 수 있도록 합니다.
+ */
 @Slf4j
 @Component
 public class FcmAdapter implements FcmPort {
 
+    /**
+     * 여러 사용자 기기에 동시에 푸시 알림을 발송합니다.
+     *
+     * FCM 서버 오류 발생 시 예외를 던져 AlertService가 실패 이력을 기록하도록 합니다.
+     */
     @Override
     public FcmBatchResult sendMulticast(List<String> deviceTokens, String title, String body, Long noticeId) {
         MulticastMessage message = MulticastMessage.builder()

--- a/backend/src/main/java/org/cathori/backend/alert/infra/FcmAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/FcmAdapter.java
@@ -1,0 +1,32 @@
+package org.cathori.backend.alert.infra;
+
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.cathori.backend.alert.application.FcmBatchResult;
+import org.cathori.backend.alert.application.FcmPort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class FcmAdapter implements FcmPort {
+
+    @Override
+    public FcmBatchResult sendMulticast(List<String> deviceTokens, String title, String body, Long noticeId) {
+        MulticastMessage message = MulticastMessage.builder()
+                .addAllTokens(deviceTokens)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putData("noticeId", String.valueOf(noticeId))
+                .build();
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            return new FcmBatchResult(response.getSuccessCount(), response.getFailureCount());
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException("FCM 멀티캐스트 발송 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/config/FirebaseConfig.java
+++ b/backend/src/main/java/org/cathori/backend/config/FirebaseConfig.java
@@ -1,0 +1,25 @@
+package org.cathori.backend.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+        ClassPathResource resource = new ClassPathResource("cathori-firebase.json");
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
+                .build();
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
@@ -24,4 +25,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     @Query("SELECT n FROM Notice n WHERE n.aiSummaryStatus IN :statuses ORDER BY n.id ASC")
     List<Notice> findTop15ForSummary(@Param("statuses") List<String> statuses, Pageable pageable);
+
+    @Query("SELECT n FROM Notice n WHERE n.id NOT IN :sentIds")
+    List<Notice> findUnsentNotices(@Param("sentIds") Set<Long> sentIds);
 }

--- a/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
@@ -1,5 +1,6 @@
 package org.cathori.backend.user.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -7,4 +8,5 @@ public interface UserRepository {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
     Optional<User> findById(Long id);
+    List<User> findUsersWithTagMatchingTitle(String title);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
@@ -2,10 +2,16 @@ package org.cathori.backend.user.infra;
 
 import org.cathori.backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+
+    @Query(value = "SELECT DISTINCT u.* FROM users u JOIN user_tag t ON t.user_id = u.id WHERE :title LIKE '%' || t.name || '%'", nativeQuery = true)
+    List<User> findUsersWithTagMatchingTitle(@Param("title") String title);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.cathori.backend.user.domain.User;
 import org.cathori.backend.user.domain.UserRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,5 +34,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Optional<User> findById(Long id) {
         return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<User> findUsersWithTagMatchingTitle(String title) {
+        return jpaRepository.findUsersWithTagMatchingTitle(title);
     }
 }

--- a/backend/src/test/java/org/cathori/backend/alert/application/AlertServiceTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/application/AlertServiceTest.java
@@ -1,0 +1,268 @@
+package org.cathori.backend.alert.application;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.alert.domain.AlertHistory;
+import org.cathori.backend.alert.infra.AlertHistoryJpaRepository;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.tag.infra.TagJpaRepository;
+import org.cathori.backend.tag.domain.Tag;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.domain.User;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("AlertService 통합 테스트")
+class AlertServiceTest extends IntegrationTestBase {
+
+    @Autowired AlertService alertService;
+    @Autowired AlertHistoryJpaRepository alertHistoryJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired TagJpaRepository tagJpaRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @MockitoBean FcmPort fcmPort;
+    @MockitoBean NotificationPort notificationPort;
+
+    @AfterEach
+    void cleanup() {
+        alertHistoryJpaRepository.deleteAll();
+        tagJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+    }
+
+    // --- dispatchAlerts() ---
+
+    @Test
+    @DisplayName("DA-1: FCM 전부 성공 시 SUCCESS 이력 저장")
+    void dispatchAlerts_allSuccess_savesSuccessHistory() {
+        Notice notice = saveNotice("장학금 안내");
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willReturn(new FcmBatchResult(1, 0));
+
+        alertService.dispatchAlerts();
+
+        List<AlertHistory> histories = alertHistoryJpaRepository.findAll();
+        assertThat(histories).hasSize(1);
+        assertThat(histories.getFirst().getStatus()).isEqualTo("SUCCESS");
+        assertThat(histories.getFirst().getNoticeId()).isEqualTo(notice.getId());
+    }
+
+    @Test
+    @DisplayName("DA-2: FCM 일부 실패 시 PARTIAL_SUCCESS 이력 저장")
+    void dispatchAlerts_partialFailure_savesPartialSuccessHistory() {
+        saveNotice("장학금 안내");
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willReturn(new FcmBatchResult(1, 1));
+
+        alertService.dispatchAlerts();
+
+        List<AlertHistory> histories = alertHistoryJpaRepository.findAll();
+        assertThat(histories).hasSize(1);
+        assertThat(histories.getFirst().getStatus()).isEqualTo("PARTIAL_SUCCESS");
+    }
+
+    @Test
+    @DisplayName("DA-3: FCM 전부 실패 시 FAILED 이력 저장")
+    void dispatchAlerts_allFailure_savesFailedHistory() {
+        saveNotice("장학금 안내");
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willReturn(new FcmBatchResult(0, 1));
+
+        alertService.dispatchAlerts();
+
+        List<AlertHistory> histories = alertHistoryJpaRepository.findAll();
+        assertThat(histories).hasSize(1);
+        assertThat(histories.getFirst().getStatus()).isEqualTo("FAILED");
+    }
+
+    @Test
+    @DisplayName("DA-4: 매칭 사용자 없으면 FCM 미호출, 이력 미저장")
+    void dispatchAlerts_noMatchingUser_doesNotSendOrSave() {
+        saveNotice("장학금 안내");
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "취업");  // 공지 제목과 매칭 안 됨
+
+        alertService.dispatchAlerts();
+
+        verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        assertThat(alertHistoryJpaRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("DA-5: 매칭 사용자 있지만 deviceToken=null이면 FCM 미호출, 이력 미저장")
+    void dispatchAlerts_nullDeviceToken_doesNotSendOrSave() {
+        saveNotice("장학금 안내");
+        User user = saveUserWithoutToken("user1@test.com");
+        saveTag(user.getId(), "장학금");
+
+        alertService.dispatchAlerts();
+
+        verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        assertThat(alertHistoryJpaRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("DA-6: 공지 없으면 FCM 미호출")
+    void dispatchAlerts_noNotices_doesNotSend() {
+        alertService.dispatchAlerts();
+
+        verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("DA-7: 모든 공지가 이미 발송됨이면 FCM 미호출")
+    void dispatchAlerts_allAlreadySent_doesNotSend() {
+        Notice notice = saveNotice("장학금 안내");
+        alertHistoryJpaRepository.save(AlertHistory.success(notice.getId()));
+
+        alertService.dispatchAlerts();
+
+        verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("DA-8: FCM 발송 중 예외 발생 시 FAILED 이력 저장")
+    void dispatchAlerts_fcmException_savesFailedHistory() {
+        Notice notice = saveNotice("장학금 안내");
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willThrow(new RuntimeException("FCM 연결 실패"));
+
+        alertService.dispatchAlerts();
+
+        List<AlertHistory> histories = alertHistoryJpaRepository.findAll();
+        assertThat(histories).hasSize(1);
+        assertThat(histories.getFirst().getStatus()).isEqualTo("FAILED");
+        assertThat(histories.getFirst().getNoticeId()).isEqualTo(notice.getId());
+    }
+
+    // --- retryFailedAlerts() ---
+
+    @Test
+    @DisplayName("RA-1: 재시도 FCM 성공 시 status가 SUCCESS로 변경")
+    void retryFailedAlerts_fcmSuccess_updatesStatusToSuccess() {
+        Notice notice = saveNotice("장학금 안내");
+        AlertHistory failed = alertHistoryJpaRepository.save(AlertHistory.failed(notice.getId()));
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willReturn(new FcmBatchResult(1, 0));
+
+        alertService.retryFailedAlerts();
+
+        AlertHistory updated = alertHistoryJpaRepository.findById(failed.getId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("RA-2: 재시도 FCM 실패 시 retryCount 증가")
+    void retryFailedAlerts_fcmFailure_incrementsRetryCount() {
+        Notice notice = saveNotice("장학금 안내");
+        AlertHistory failed = alertHistoryJpaRepository.save(AlertHistory.failed(notice.getId()));
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willReturn(new FcmBatchResult(0, 1));
+
+        alertService.retryFailedAlerts();
+
+        AlertHistory updated = alertHistoryJpaRepository.findById(failed.getId()).orElseThrow();
+        assertThat(updated.getRetryCount()).isEqualTo(1);
+        assertThat(updated.getStatus()).isEqualTo("FAILED");
+    }
+
+    @Test
+    @DisplayName("RA-3: 재시도 중 예외 발생 시 retryCount 증가")
+    void retryFailedAlerts_fcmException_incrementsRetryCount() {
+        Notice notice = saveNotice("장학금 안내");
+        AlertHistory failed = alertHistoryJpaRepository.save(AlertHistory.failed(notice.getId()));
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학금");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willThrow(new RuntimeException("FCM 타임아웃"));
+
+        alertService.retryFailedAlerts();
+
+        AlertHistory updated = alertHistoryJpaRepository.findById(failed.getId()).orElseThrow();
+        assertThat(updated.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("RA-4: 실패 이력의 공지가 DB에 없으면 조용히 스킵")
+    void retryFailedAlerts_noticeNotFound_skipsQuietly() {
+        alertHistoryJpaRepository.save(AlertHistory.failed(999L));
+
+        alertService.retryFailedAlerts();
+
+        verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        AlertHistory history = alertHistoryJpaRepository.findAll().getFirst();
+        assertThat(history.getRetryCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("RA-5: 실패 이력 없으면 FCM 미호출")
+    void retryFailedAlerts_noFailedHistory_doesNotSend() {
+        alertService.retryFailedAlerts();
+
+        verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+    }
+
+    // --- 헬퍼 메서드 ---
+
+    private Notice saveNotice(String title) {
+        CrawledNotice crawled = CrawledNotice.builder()
+                .articleNo("TEST001")
+                .sourceType("MAIN")
+                .sourceId(null)
+                .category("일반")
+                .title(title)
+                .department("공지사항")
+                .postedAt(LocalDate.now().toString())
+                .url("https://example.com/notice/1")
+                .bodyText("")
+                .imageUrls(List.of())
+                .build();
+        return noticeRepository.save(Notice.from(crawled));
+    }
+
+    private User saveUserWithToken(String email, String token) {
+        User user = userJpaRepository.save(
+                User.create(email, "encodedPwd", "컴퓨터정보공학", null, 2, "재학"));
+        jdbcTemplate.update("UPDATE users SET device_token = ? WHERE id = ?", token, user.getId());
+        return user;
+    }
+
+    private User saveUserWithoutToken(String email) {
+        return userJpaRepository.save(
+                User.create(email, "encodedPwd", "컴퓨터정보공학", null, 2, "재학"));
+    }
+
+    private void saveTag(Long userId, String tagName) {
+        tagJpaRepository.save(Tag.create(userId, tagName));
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/alert/domain/AlertHistoryTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/domain/AlertHistoryTest.java
@@ -1,0 +1,64 @@
+package org.cathori.backend.alert.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AlertHistory 단위 테스트")
+class AlertHistoryTest {
+
+    @Test
+    @DisplayName("AH-1: success() → status=SUCCESS, retryCount=0")
+    void success_factory() {
+        AlertHistory history = AlertHistory.success(1L);
+
+        assertThat(history.getStatus()).isEqualTo("SUCCESS");
+        assertThat(history.getRetryCount()).isEqualTo(0);
+        assertThat(history.getNoticeId()).isEqualTo(1L);
+        assertThat(history.getCreatedAt()).isNotNull();
+        assertThat(history.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("AH-2: partialSuccess() → status=PARTIAL_SUCCESS, retryCount=0")
+    void partialSuccess_factory() {
+        AlertHistory history = AlertHistory.partialSuccess(2L);
+
+        assertThat(history.getStatus()).isEqualTo("PARTIAL_SUCCESS");
+        assertThat(history.getRetryCount()).isEqualTo(0);
+        assertThat(history.getNoticeId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("AH-3: failed() → status=FAILED, retryCount=0")
+    void failed_factory() {
+        AlertHistory history = AlertHistory.failed(3L);
+
+        assertThat(history.getStatus()).isEqualTo("FAILED");
+        assertThat(history.getRetryCount()).isEqualTo(0);
+        assertThat(history.getNoticeId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("AH-4: markSuccess() → status가 SUCCESS로 변경됨")
+    void markSuccess_changesStatus() {
+        AlertHistory history = AlertHistory.failed(1L);
+
+        history.markSuccess();
+
+        assertThat(history.getStatus()).isEqualTo("SUCCESS");
+    }
+
+    @Test
+    @DisplayName("AH-5: incrementRetry() → 호출할 때마다 retryCount 1 증가")
+    void incrementRetry_incrementsCount() {
+        AlertHistory history = AlertHistory.failed(1L);
+
+        history.incrementRetry();
+        assertThat(history.getRetryCount()).isEqualTo(1);
+
+        history.incrementRetry();
+        assertThat(history.getRetryCount()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryTest.java
@@ -1,0 +1,97 @@
+package org.cathori.backend.alert.infra;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.alert.domain.AlertHistory;
+import org.cathori.backend.user.application.NotificationPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AlertHistoryRepository 쿼리 테스트")
+class AlertHistoryRepositoryTest extends IntegrationTestBase {
+
+    @Autowired
+    AlertHistoryJpaRepository alertHistoryJpaRepository;
+    @MockitoBean
+    NotificationPort notificationPort;
+
+    @AfterEach
+    void cleanup() {
+        alertHistoryJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("R-1: findAllSentNoticeIds() - 저장된 모든 이력의 noticeId Set 반환")
+    void findAllSentNoticeIds_returnsAllIds() {
+        alertHistoryJpaRepository.save(AlertHistory.success(10L));
+        alertHistoryJpaRepository.save(AlertHistory.failed(20L));
+        alertHistoryJpaRepository.save(AlertHistory.partialSuccess(30L));
+
+        Set<Long> ids = alertHistoryJpaRepository.findAllSentNoticeIds();
+
+        assertThat(ids).containsExactlyInAnyOrder(10L, 20L, 30L);
+    }
+
+    @Test
+    @DisplayName("R-2: findAllSentNoticeIds() - 이력 없으면 빈 Set 반환")
+    void findAllSentNoticeIds_returnsEmptySetWhenNoHistory() {
+        Set<Long> ids = alertHistoryJpaRepository.findAllSentNoticeIds();
+
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R-3: findFailedForRetry() - FAILED이고 retryCount < 3인 이력 반환")
+    void findFailedForRetry_returnsFailedWithinRetryLimit() {
+        AlertHistory retryCount0 = AlertHistory.failed(1L);
+        AlertHistory retryCount1 = AlertHistory.failed(2L);
+        retryCount1.incrementRetry();
+        AlertHistory retryCount2 = AlertHistory.failed(3L);
+        retryCount2.incrementRetry();
+        retryCount2.incrementRetry();
+
+        alertHistoryJpaRepository.save(retryCount0);
+        alertHistoryJpaRepository.save(retryCount1);
+        alertHistoryJpaRepository.save(retryCount2);
+
+        List<AlertHistory> result = alertHistoryJpaRepository.findFailedForRetry();
+
+        assertThat(result).hasSize(3);
+        assertThat(result.stream().map(AlertHistory::getNoticeId))
+                .containsExactlyInAnyOrder(1L, 2L, 3L);
+    }
+
+    @Test
+    @DisplayName("R-4: findFailedForRetry() - SUCCESS, PARTIAL_SUCCESS 이력은 제외")
+    void findFailedForRetry_excludesNonFailedStatuses() {
+        alertHistoryJpaRepository.save(AlertHistory.success(1L));
+        alertHistoryJpaRepository.save(AlertHistory.partialSuccess(2L));
+        alertHistoryJpaRepository.save(AlertHistory.failed(3L));
+
+        List<AlertHistory> result = alertHistoryJpaRepository.findFailedForRetry();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getNoticeId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("R-5: findFailedForRetry() - retryCount=3인 FAILED 이력은 제외 (경계값)")
+    void findFailedForRetry_excludesMaxRetryCount() {
+        AlertHistory maxRetry = AlertHistory.failed(1L);
+        maxRetry.incrementRetry();
+        maxRetry.incrementRetry();
+        maxRetry.incrementRetry();
+        alertHistoryJpaRepository.save(maxRetry);
+
+        List<AlertHistory> result = alertHistoryJpaRepository.findFailedForRetry();
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용
FCM 푸시 알림 기능 구현

- `firebase-admin` 의존성 추가 및 `FirebaseConfig` 설정
- `AlertHistory` 도메인 모델 및 레포지토리 구현
- `FcmPort` / `FcmAdapter` 구현 (멀티캐스트 발송)
- `AlertService` 구현 (신규 공지 알림 발송 + 실패 재시도)
- `AlertScheduler` (매일 11시) / `AlertRetryScheduler` (20분마다) 추가
- `UserRepository`에 태그-제목 매칭 사용자 조회 쿼리 추가
- `NoticeRepository`에 미발송 공지 조회 쿼리 추가
- `AlertServiceTest` / `AlertHistoryTest` / `AlertHistoryRepositoryTest` 테스트 작성

## 🔍 동작 방식
**신규 알림 발송 (`dispatchAlerts`)**
1. `alert_history`에서 이미 발송된 공지 ID 조회
2. 미발송 공지만 추려냄
3. 각 공지 제목과 태그가 일치하는 사용자 조회
4. `device_token`이 null인 사용자 제외
5. FCM 멀티캐스트 발송 → 결과에 따라 `SUCCESS` / `PARTIAL_SUCCESS` / `FAILED` 이력 저장

**실패 재시도 (`retryFailedAlerts`)**
1. `FAILED` 상태이고 `retry_count < 3`인 이력 조회
2. 원본 공지 존재 여부 확인 → 없으면 스킵
3. 재발송 성공 시 `SUCCESS`로 변경, 실패 시 `retry_count` 증가

## 💡 설계 근거
- **`sentIds`가 비어있을 때 `findAll()` 분기 처리**: `NOT IN (:sentIds)`에 빈 Set을 넣으면 DB마다 동작이 달라서 명시적으로 분기
- **재시도 횟수 3회 제한**: 3회 초과 시 더 이상 재시도하지 않아 무한 루프 방지
- **FCM → 기기 전달 실패는 우리 서버 책임 범위 밖**: `alert_history`는 FCM 서버에 요청을 보냈는지 여부만 기록

## ✅ 체크리스트
- [x] `cathori-firebase.json` 파일 로컬 `resources`에 존재 확인
- [x] FCM 멀티캐스트 발송 정상 동작 확인
- [x] 재시도 3회 소진 후 더 이상 재시도 안 하는지 확인
- [x] 전체 테스트 로컬에서 통과 확인

## 🔗 연관 이슈
#46 
