### PR TITLE
[FIX] 의도와 다르게 동작하던 버그 수정

### DIFF
--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
@@ -3,6 +3,7 @@ package org.cathori.backend.alert.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cathori.backend.alert.domain.AlertHistory;
+import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.user.domain.User;
@@ -69,6 +70,7 @@ public class AlertService {
     private void dispatchForNotice(Notice notice) {
         List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
                 .stream()
+                .filter(u -> isEligibleForNotice(u, notice))
                 .map(User::getDeviceToken)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
@@ -119,6 +121,20 @@ public class AlertService {
     }
 
     /**
+     * MAIN 공지는 전체 허용, DEPARTMENT 공지는 사용자의 제1·제2전공과 source_id가 일치하는 경우만 허용합니다.
+     */
+    private boolean isEligibleForNotice(User user, Notice notice) {
+        if ("MAIN".equals(notice.getSourceType())) return true;
+        String sourceId = notice.getSourceId();
+        String majorCode = DepartmentSource.findEnumNameByDisplayName(user.getMajor());
+        if (sourceId.equals(majorCode)) return true;
+        String secondMajor = user.getSecondMajor();
+        if (secondMajor == null || "전공심화".equals(secondMajor)) return false;
+        String secondMajorCode = DepartmentSource.findEnumNameByDisplayName(secondMajor);
+        return sourceId.equals(secondMajorCode);
+    }
+
+    /**
      * 실패 이력 하나에 대해 알림 재발송을 시도하고 결과를 갱신합니다.
      *
      * - 원본 공지가 삭제된 경우에는 재시도 없이 조용히 건너뜁니다.
@@ -130,6 +146,7 @@ public class AlertService {
 
         List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
                 .stream()
+                .filter(u -> isEligibleForNotice(u, notice))
                 .map(User::getDeviceToken)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -15,6 +15,7 @@ import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.user.UserErrorCode;
 import org.cathori.backend.user.domain.User;
 import org.cathori.backend.user.domain.UserRepository;
+import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,8 +57,9 @@ public class NoticeFeedService {
                         .toList();
 
         // 3. 쿼리 객체 생성 + 포트 위임
+        String majorCode = DepartmentSource.findEnumNameByDisplayName(user.getMajor());
         NoticeFeedQuery query = new NoticeFeedQuery(
-                userId, user.getMajor(), user.getSecondMajor(),
+                userId, majorCode, resolveSecondMajorCode(user.getSecondMajor()),
                 category, tagList, page, size
         );
 
@@ -82,8 +84,9 @@ public class NoticeFeedService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
+        String majorCode = DepartmentSource.findEnumNameByDisplayName(user.getMajor());
         NoticeSearchQuery query = new NoticeSearchQuery(
-                userId, keyword, user.getMajor(), user.getSecondMajor(), page, size
+                userId, keyword, majorCode, resolveSecondMajorCode(user.getSecondMajor()), page, size
         );
 
         List<NoticeSearchRow> rows = noticeFeedPort.findSearch(query);
@@ -137,6 +140,13 @@ public class NoticeFeedService {
                 notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
                 notice.getUrl(), isBookmarked, dDay, notice.getViewCount(), tags, deadlineAt
         );
+    }
+
+    private String resolveSecondMajorCode(String secondMajor) {
+        if (secondMajor == null || "전공심화".equals(secondMajor)) {
+            return secondMajor;
+        }
+        return DepartmentSource.findEnumNameByDisplayName(secondMajor);
     }
 
     /**

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -129,7 +129,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
     private QueryAndParams buildCase4(NoticeFeedQuery q) {
         List<Object> params = new ArrayList<>();
 
-        // Part1: 태그 매칭 (출처 무관)
+        // Part1: 태그 매칭 — MAIN + 제1전공 + 제2전공(전공심화 제외) 범위 내에서 제목 LIKE 필터
         StringBuilder sql = new StringBuilder(
                 "SELECT * FROM (" +
                 "SELECT n.id, n.source_type, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
@@ -142,6 +142,13 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         );
         params.add(q.userId());
         appendTagLikes(sql, params, q.tags(), "n.title");
+        sql.append(") AND (n.source_type = 'MAIN'");
+        sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+        params.add(q.major());
+        if (q.secondMajor() != null && !"전공심화".equals(q.secondMajor())) {
+            sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
+            params.add(q.secondMajor());
+        }
         sql.append(")");
 
         // Part2: category 매칭 MAIN, 태그 미매칭

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/source/DepartmentSource.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/source/DepartmentSource.java
@@ -83,4 +83,12 @@ public enum DepartmentSource {
 
     public String getCode() { return code; }
     public String getDisplayName() { return displayName; }
+
+    public static String findEnumNameByDisplayName(String displayName) {
+        return java.util.Arrays.stream(values())
+                .filter(d -> d.displayName.equals(displayName))
+                .map(Enum::name)
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
@@ -161,8 +161,8 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     @DisplayName("NF-2: 기본 피드 — MAIN + 전공(CSIE) 공지 포함, 무관 학과 제외")
     void getFeed_case1_defaultFeed() throws Exception {
         saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
-        saveNotice("DEPARTMENT", "컴퓨터정보공학", "학과공지", "csie 학과 공지", TODAY);
-        saveNotice("DEPARTMENT", "경영학과", "학과공지", "business 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "BUSINESS", "학과공지", "business 학과 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA))
@@ -178,8 +178,8 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     @DisplayName("NF-3: secondMajor=전공심화인 유저 — AI 학과 공지 제외")
     void getFeed_case1_excludeJeonGongSimhwa() throws Exception {
         saveNotice("MAIN", null, "장학", "MAIN 공지", TODAY);
-        saveNotice("DEPARTMENT", "컴퓨터정보공학", "학과공지", "csie 학과 공지", TODAY);
-        saveNotice("DEPARTMENT", "인공지능", "학과공지", "ai 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "csie 학과 공지", TODAY);
+        saveNotice("DEPARTMENT", "AI", "학과공지", "ai 학과 공지", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenB))
@@ -227,7 +227,7 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     void getFeed_case3_tagFilter() throws Exception {
         saveNotice("MAIN", null, "장학", "장학금 신청 안내", TODAY);
         saveNotice("MAIN", null, "취업", "일반 공지", TODAY);
-        saveNotice("DEPARTMENT", "컴퓨터정보공학", "학과공지", "장학금 혜택 안내", TODAY);
+        saveNotice("DEPARTMENT", "CSIE", "학과공지", "장학금 혜택 안내", TODAY);
 
         MvcResult result = mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA)


### PR DESCRIPTION
## 🔧 작업 내용

학과 공지 알림 및 피드 조회 시 사용자 전공 기반 필터링 누락 버그 수정.

- `AlertService`: 알림 발송 대상 선정 시 DEPARTMENT 공지는 사용자의 제1·제2전공과 `source_id`가 일치하는 경우만 발송하도록 필터 추가
- `NoticeFeedService`: 피드/검색 쿼리 생성 시 전공명(displayName) → enum name 변환 누락 수정
- `NoticeFeedAdapter` (Case 4): 태그 매칭 범위를 전체 공지가 아닌 사용자 전공 범위 내로 제한
- `DepartmentSource`: displayName → enum name 역방향 조회 유틸 메서드 `findEnumNameByDisplayName()` 추가

---

## 🔍 동작 방식

**알림 발송 필터링**
```
태그 매칭 사용자 조회
  └─ isEligibleForNotice() 필터
       ├─ MAIN 공지 → 전체 허용
       └─ DEPARTMENT 공지
            ├─ source_id == 제1전공 code → 허용
            ├─ secondMajor == null || "전공심화" → 차단
            └─ source_id == 제2전공 code → 허용
```

**전공명 변환 흐름**
```
user.getMajor() → "컴퓨터정보공학" (displayName)
  └─ DepartmentSource.findEnumNameByDisplayName()
       └─ "CSIE" (enum name = source_id)
```

---

## 💡 설계 근거

**왜 displayName → enum name 변환이 필요한가**
DB의 `notice.source_id`에는 `DepartmentSource`의 enum name(예: `CSIE`)이 저장되어 있다. 반면 `users.major`에는 사용자가 가입 시 입력한 displayName(예: `컴퓨터정보공학`)이 저장된다. 두 값을 직접 비교하면 항상 불일치하므로, 서비스 레이어에서 조회 전에 변환이 필요하다.

**isEligibleForNotice()를 AlertService 내부에 둔 이유**
알림 발송 범위 판단은 알림 도메인의 책임으로 봤다. 크롤링 인프라 레이어의 `DepartmentSource`를 application 레이어에서 참조하는 것이 계층 위반처럼 보일 수 있으나, `DepartmentSource`가 사실상 정적 매핑 테이블 역할을 하므로 현 시점에서는 허용 범위로 판단했다.

**Case 4 태그 필터 범위 수정**
기존 구현은 태그 매칭을 전체 공지(`notice` 테이블 전체)에서 수행했다. 운영 명세상 태그 필터도 사용자 전공 범위 내에서만 동작해야 하므로, MAIN + 제1전공 + 제2전공(전공심화 제외) 조건을 WHERE절에 추가했다.

---

## ✅ 체크리스트

- [x] `DepartmentSource.findEnumNameByDisplayName()` — displayName 불일치 시 null 반환 확인
- [x] 테스트 픽스처 `saveNotice()` 호출 시 `source_id`를 enum name으로 수정 (CSIE, BUSINESS, AI)
- [x] `전공심화` secondMajor 케이스 필터 동작 확인
- [x] 정기 발송(`dispatchAlerts`)과 재시도(`retryFailedAlerts`) 양쪽에 필터 적용 확인

---

## 🔗 연관 이슈

closes #68 