### PR TITLE
[FEAT] 설정 및 관심키워드 화면 구현 및 메인화면 태그 데이터 동기화 (sprint 2)

### DIFF
--- a/backend/src/main/java/org/cathori/backend/tag/api/TagController.java
+++ b/backend/src/main/java/org/cathori/backend/tag/api/TagController.java
@@ -10,6 +10,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/tags")
 public class TagController {
@@ -18,6 +22,13 @@ public class TagController {
 
     public TagController(TagService tagService) {
         this.tagService = tagService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TagDto>> getTags(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<TagDto> response = tagService.getTagsByUserId(userDetails.getUserId());
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -130,46 +130,34 @@ export default function HomeScreen() {
   // 즐겨찾기 토글 mutation
   const { mutate: toggleBookmarkMutate } = useToggleBookmark();
 
-  const handleToggleBookmark = React.useCallback(
-    (noticeId: string) => {
-      toggleBookmarkMutate(noticeId);
-    },
-    [toggleBookmarkMutate]
-  );
+  const handleToggleBookmark = (noticeId: string) => {
+    toggleBookmarkMutate(noticeId);
+  };
 
   // FlatList renderItem — 인라인 화살표 함수 방지 (Global Rules)
-  const renderNoticeCard = React.useCallback(
-    ({ item }: { item: Notice }) => (
-      <NoticeCard notice={item} onToggleBookmark={handleToggleBookmark} />
-    ),
-    [handleToggleBookmark]
+  const renderNoticeCard = ({ item }: { item: Notice }) => (
+    <NoticeCard notice={item} onToggleBookmark={handleToggleBookmark} />
   );
 
   // FlatList keyExtractor
-  const keyExtractor = React.useCallback((item: Notice) => item.id, []);
+  const keyExtractor = (item: Notice) => item.id;
 
   // FlatList getItemLayout (성능 최적화)
-  const getItemLayout = React.useCallback(
-    (_: unknown, index: number) => ({
-      length: ESTIMATED_CARD_HEIGHT,
-      offset: ESTIMATED_CARD_HEIGHT * index,
-      index,
-    }),
-    []
-  );
+  const getItemLayout = (_: unknown, index: number) => ({
+    length: ESTIMATED_CARD_HEIGHT,
+    offset: ESTIMATED_CARD_HEIGHT * index,
+    index,
+  });
   
   // 리스트 빈 상태
-  const ListEmpty = React.useCallback(
-    () =>
-      isLoading ? (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={Colors.primary} />
-        </View>
-      ) : (
-        <EmptyState message="조건에 맞는 공지가 없습니다." />
-      ),
-    [isLoading]
-  );
+  const ListEmpty = () =>
+    isLoading ? (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={Colors.primary} />
+      </View>
+    ) : (
+      <EmptyState message="조건에 맞는 공지가 없습니다." />
+    );
 
   // 무한 스크롤 추가 로드
   const handleLoadMore = () => {
@@ -179,14 +167,14 @@ export default function HomeScreen() {
   };
 
   // 푸터 로딩바 컴포넌트
-  const ListFooter = React.useCallback(() => {
+  const ListFooter = () => {
     if (!isFetchingNextPage) return null;
     return (
       <View style={styles.footerLoading}>
         <ActivityIndicator size="small" color={Colors.primary} />
       </View>
     );
-  }, [isFetchingNextPage]);
+  };
 
   return (
     <View style={styles.screen}>

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -14,15 +14,17 @@
  *
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   ActivityIndicator,
   FlatList,
+  RefreshControl,
   StyleSheet,
   View,
 } from 'react-native';
+import { useRouter } from 'expo-router';
 
-import { CATEGORY_TABS, TAG_LIST } from '@/src/constants/categories';
+import { CATEGORY_TABS } from '@/src/constants/categories';
 import { Colors } from '@/src/constants/colors';
 import {
   CategoryTab,
@@ -32,8 +34,10 @@ import {
   useNotices,
   useToggleBookmark,
 } from '@/src/features/notices';
+import { useRefreshTags } from '@/src/features/settings/hooks';
 import { EmptyState, MainHeader } from '@/src/shared/components';
 import { useNoticeFilterStore } from '@/src/store/useNoticeFilterStore';
+import { useAuthStore } from '@/src/store/useAuthStore';
 import type { Notice } from '@/src/types/api';
 
 /** FlatList getItemLayout — 고정 높이 추정값 (성능 최적화) */
@@ -41,11 +45,29 @@ const ESTIMATED_CARD_HEIGHT = 200;
 
 // ─── 리스트 헤더 별도 컴포넌트 ────────────────────────────────────────
 function FeedHeaderComponent() {
+  const router = useRouter();
+
   // HomeScreen에서 props로 받지 않고 직접 구독 — 재마운트 원인 제거
   const selectedCategory = useNoticeFilterStore((s) => s.selectedCategory);
   const selectedTag = useNoticeFilterStore((s) => s.selectedTag);
   const toggleCategory = useNoticeFilterStore((s) => s.toggleCategory);
   const toggleTag = useNoticeFilterStore((s) => s.toggleTag);
+
+  // Zustand 사용자 정의 태그 리스트 가져옴
+  const userTags = useAuthStore((s) => s.tags);
+  const tagNames = React.useMemo(() => userTags.map((t) => t.tagName), [userTags]);
+
+  // 만약 선택된 태그가 현재 사용자의 태그 목록에 존재하지 않게 되었다면(키워드 화면에서 삭제 등), 필터를 초기화
+  useEffect(() => {
+    if (selectedTag && !tagNames.includes(selectedTag)) {
+      // selectedTag를 강제로 해제(null)하기 위해 toggleTag 호출
+      toggleTag(selectedTag);
+    }
+  }, [selectedTag, tagNames, toggleTag]);
+
+  const handleAddPress = () => {
+    router.push('/settings/keywords' as never);
+  };
 
   return (
     <View>
@@ -58,11 +80,12 @@ function FeedHeaderComponent() {
         onSelect={toggleCategory}
       />
 
-      {/* 소분류 태그 칩 — 독립 동작, 대분류와 무관 */}
+      {/* 소분류 태그 칩 — 독립 동작, 대분류와 무관. 사용자 정의 태그 적용 및 플러스 버튼 탑재 */}
       <TagChipList
-        tags={TAG_LIST}
+        tags={tagNames}
         selectedTag={selectedTag}
         onSelect={toggleTag}
+        onAddPress={handleAddPress}
       />
     </View>
   );
@@ -84,10 +107,19 @@ export default function HomeScreen() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    refetch,
+    isRefetching,
   } = useNotices({
     category: selectedCategory,
     tag: selectedTag,
   });
+
+  const { refreshTags, isRefreshing: isRefreshingTags } = useRefreshTags();
+
+  const handleRefresh = async () => {
+    // 공지사항 데이터와 태그 데이터를 동시에 새로고침합니다.
+    await Promise.all([refetch(), refreshTags()]);
+  };
 
   const notices = data?.pages.flatMap((page) => page.content) ?? [];
 
@@ -98,27 +130,36 @@ export default function HomeScreen() {
   // 즐겨찾기 토글 mutation
   const { mutate: toggleBookmarkMutate } = useToggleBookmark();
 
-  const handleToggleBookmark = (noticeId: string) => {
-    toggleBookmarkMutate(noticeId);
-  };
+  const handleToggleBookmark = React.useCallback(
+    (noticeId: string) => {
+      toggleBookmarkMutate(noticeId);
+    },
+    [toggleBookmarkMutate]
+  );
 
   // FlatList renderItem — 인라인 화살표 함수 방지 (Global Rules)
-  const renderNoticeCard = ({ item }: { item: Notice }) => (
-    <NoticeCard notice={item} onToggleBookmark={handleToggleBookmark} />
+  const renderNoticeCard = React.useCallback(
+    ({ item }: { item: Notice }) => (
+      <NoticeCard notice={item} onToggleBookmark={handleToggleBookmark} />
+    ),
+    [handleToggleBookmark]
   );
 
   // FlatList keyExtractor
-  const keyExtractor = (item: Notice) => item.id;
+  const keyExtractor = React.useCallback((item: Notice) => item.id, []);
 
   // FlatList getItemLayout (성능 최적화)
-  const getItemLayout = (_: unknown, index: number) => ({
+  const getItemLayout = React.useCallback(
+    (_: unknown, index: number) => ({
       length: ESTIMATED_CARD_HEIGHT,
       offset: ESTIMATED_CARD_HEIGHT * index,
       index,
-    });
+    }),
+    []
+  );
   
   // 리스트 빈 상태
-  const ListEmpty = 
+  const ListEmpty = React.useCallback(
     () =>
       isLoading ? (
         <View style={styles.loadingContainer}>
@@ -126,7 +167,9 @@ export default function HomeScreen() {
         </View>
       ) : (
         <EmptyState message="조건에 맞는 공지가 없습니다." />
-      );
+      ),
+    [isLoading]
+  );
 
   // 무한 스크롤 추가 로드
   const handleLoadMore = () => {
@@ -136,14 +179,14 @@ export default function HomeScreen() {
   };
 
   // 푸터 로딩바 컴포넌트
-  const ListFooter = () => {
+  const ListFooter = React.useCallback(() => {
     if (!isFetchingNextPage) return null;
     return (
       <View style={styles.footerLoading}>
         <ActivityIndicator size="small" color={Colors.primary} />
       </View>
     );
-  };
+  }, [isFetchingNextPage]);
 
   return (
     <View style={styles.screen}>
@@ -176,6 +219,13 @@ export default function HomeScreen() {
         onEndReachedThreshold={0.5} // 리스트 하단에서 50% 만큼 남았을 때 onEndReached 트리거
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefetching || isRefreshingTags}
+            onRefresh={handleRefresh}
+            colors={[Colors.primary]}
+          />
+        }
       />
     </View>
   );

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -14,6 +14,7 @@
  *
  */
 
+import { useRouter } from 'expo-router';
 import React, { useEffect } from 'react';
 import {
   ActivityIndicator,
@@ -22,7 +23,6 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { useRouter } from 'expo-router';
 
 import { CATEGORY_TABS } from '@/src/constants/categories';
 import { Colors } from '@/src/constants/colors';
@@ -36,8 +36,8 @@ import {
 } from '@/src/features/notices';
 import { useRefreshTags } from '@/src/features/settings/hooks';
 import { EmptyState, MainHeader } from '@/src/shared/components';
-import { useNoticeFilterStore } from '@/src/store/useNoticeFilterStore';
 import { useAuthStore } from '@/src/store/useAuthStore';
+import { useNoticeFilterStore } from '@/src/store/useNoticeFilterStore';
 import type { Notice } from '@/src/types/api';
 
 /** FlatList getItemLayout — 고정 높이 추정값 (성능 최적화) */
@@ -55,7 +55,7 @@ function FeedHeaderComponent() {
 
   // Zustand 사용자 정의 태그 리스트 가져옴
   const userTags = useAuthStore((s) => s.tags);
-  const tagNames = React.useMemo(() => userTags.map((t) => t.tagName), [userTags]);
+  const tagNames = userTags.map((t) => t.tagName);
 
   // 만약 선택된 태그가 현재 사용자의 태그 목록에 존재하지 않게 되었다면(키워드 화면에서 삭제 등), 필터를 초기화
   useEffect(() => {
@@ -91,7 +91,7 @@ function FeedHeaderComponent() {
   );
 }
 
-const FeedHeader = React.memo(FeedHeaderComponent);
+const FeedHeader = FeedHeaderComponent;
 
 // ─── 메인 화면 ────────────────────────────────────────────────────────
 

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -25,7 +25,7 @@
 
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   AppState,
@@ -83,19 +83,20 @@ export default function SettingsScreen() {
   const appStateRef = useRef(AppState.currentState);
 
   /** OS 알림 권한 확인 */
-  const checkNotificationPermission = useCallback(async () => {
-    if (!getPermissionsAsync) {
-      // expo-notifications 미설치 → 권한 확인 불가, 배너 숨김
-      setNotificationPermitted(true);
-      return;
-    }
-    try {
-      const { status } = await getPermissionsAsync();
-      setNotificationPermitted(status === 'granted'); // 알람 허용이 돼 있으면 true 아니라면 false
-    } catch {
-      setNotificationPermitted(true);
-    }
-  }, []);
+  /** OS 알림 권한 확인 */
+const checkNotificationPermission = async () => {
+  if (!getPermissionsAsync) {
+    // expo-notifications 미설치 → 권한 확인 불가, 배너 숨김
+    setNotificationPermitted(true);
+    return;
+  }
+  try {
+    const { status } = await getPermissionsAsync();
+    setNotificationPermitted(status === 'granted'); // 알람 허용이 돼 있으면 true 아니라면 false
+  } catch {
+    setNotificationPermitted(true);
+  }
+};
 
   // 화면 진입 시 + 포그라운드 복귀 시 권한 재확인 (트랩 10 주의: 리스너 1회만 등록)
   useEffect(() => {

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -130,7 +130,7 @@ export default function SettingsScreen() {
   };
 
   const handleToggleKeywordNotification = () => {
-    showToast('현재는 설정한 모든 키워드에 대해서 알림을 수신합니다. (추후 개선 예정)');
+    showToast('현재는 설정한 모든 관심 태그에 대해서 알림을 수신합니다. (추후 개선 예정)');
   };
 
   const handleToggleEventNotification = () => {
@@ -255,7 +255,7 @@ export default function SettingsScreen() {
               <View style={styles.settingsRowLeft}>
                 <Feather name="tag" size={18} color={Colors.primary} />
                 <Text style={styles.settingsRowText}>
-                  관심 공지 키워드 설정
+                  관심 공지 태그 설정
                 </Text>
               </View>
               <Feather name="chevron-right" size={18} color={Colors.textSecondary} />
@@ -271,7 +271,7 @@ export default function SettingsScreen() {
             <View style={styles.settingsRow}>
               <View style={styles.settingsRowLeft}>
                 <Feather name="bell" size={18} color={Colors.primary} />
-                <Text style={styles.settingsRowText}>키워드 알림 수신</Text>
+                <Text style={styles.settingsRowText}>관심 태그 알림 수신</Text>
               </View>
               <Switch
                 value={false}

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -1,34 +1,582 @@
 /**
- * 설정 화면 — Sprint 2에서 구현 예정
+ * 설정 화면 — app/(tabs)/settings.tsx
+ *
+ * 구조:
+ * ┌─ MainHeader ────────────────────────────┐
+ * │ 🏫 Cathori                          🔔  │
+ * ├─────────────────────────────────────────┤
+ * │ 프로필 섹션 (아이콘 + 이름 + 이메일 + 학과)  │
+ * ├─ 알림 배너 (조건부: OS 권한 비활성 시) ─────┤
+ * │ ⚠ 알림 권한이 비활성화되어 있습니다         │
+ * │     [ 권한 설정으로 이동 ]                │
+ * ├─ 공지 설정 ─────────────────────────────┤
+ * │ 📋 관심 공지 키워드 설정            >    │
+ * ├─ 알림 설정 ─────────────────────────────┤
+ * │ 🔔 키워드 알림 수신           [토글]     │
+ * │ 📢 이벤트 알림 수신           [토글]     │
+ * │ ⚙ 시스템 알림 설정              >       │
+ * ├─ 기타 ──────────────────────────────────┤
+ * │ 📱 버전 정보                    v0.1.0-beta   │
+ * │ 🚪 로그아웃                             │
+ * ├─────────────────────────────────────────┤
+ * │ © 2026 가톨릭대학교 팀 회광반조. 모든 권리 보유. │
+ * └─────────────────────────────────────────┘
  */
 
-import { StyleSheet, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  AppState,
+  Linking,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  ToastAndroid,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import { Colors } from '@/src/constants/colors';
+import { MainHeader } from '@/src/shared/components';
+import { useAuthStore } from '@/src/store/useAuthStore';
+
+// ─── 상수 ──────────────────────────────────────────────────────────
+
+const APP_VERSION = '0.1.0-beta';
+
+// ─── 알림 권한 확인 유틸 (expo-notifications) ────────────────────────
+// expo-notifications 미설치 시 fallback 처리
+let getPermissionsAsync: (() => Promise<{ status: string }>) | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  // expo-notifications가 설치돼 있으면 권한 확인 함수를 가져옴
+  const Notifications = require('expo-notifications');
+  getPermissionsAsync = Notifications.getPermissionsAsync;
+} catch {
+  // expo-notifications가 설치되지 않은 환경TODO:
+  // TODO: expo-notifications가 설치되지 않은 환경일 때 알림 권한을 자동으로 granted로 설정하는 로직 추가
+}
+
+// ─── 토스트 유틸 ─────────────────────────────────────────────────────
+function showToast(message: string) {
+  if (Platform.OS === 'android') {
+    // Android only
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  }
+}
+
+// ─── 설정 화면 ──────────────────────────────────────────────────────
 
 export default function SettingsScreen() {
+  const router = useRouter();
+
+  // ── Zustand 사용자 정보 ──
+  const user = useAuthStore((s) => s.user);
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  // ── 알림 권한 상태 ──
+  const [notificationPermitted, setNotificationPermitted] = useState(true);
+  const appStateRef = useRef(AppState.currentState);
+
+  /** OS 알림 권한 확인 */
+  const checkNotificationPermission = useCallback(async () => {
+    if (!getPermissionsAsync) {
+      // expo-notifications 미설치 → 권한 확인 불가, 배너 숨김
+      setNotificationPermitted(true);
+      return;
+    }
+    try {
+      const { status } = await getPermissionsAsync();
+      setNotificationPermitted(status === 'granted'); // 알람 허용이 돼 있으면 true 아니라면 false
+    } catch {
+      setNotificationPermitted(true);
+    }
+  }, []);
+
+  // 화면 진입 시 + 포그라운드 복귀 시 권한 재확인 (트랩 10 주의: 리스너 1회만 등록)
+  useEffect(() => {
+    checkNotificationPermission();
+
+    // AppState가 바뀔 때마다 이 리스너로 등록한 이 함수가 실행됨 (active, background, inactive, unknown)
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      // 조건: 이전 상태가 background나 inactive였고
+      // 다음 상태가 active(앱으로 돌아옴)일 때만
+      if (
+        appStateRef.current.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        checkNotificationPermission();
+      }
+      appStateRef.current = nextAppState;
+    });
+
+    return () => subscription.remove(); // cleanup — 중복 등록 방지
+  }, [checkNotificationPermission]);
+
+  // ── 핸들러 ──
+
+  /** 관심 공지 키워드 설정 화면 이동 */
+  const handleKeywordSettings = () => {
+    router.push('/settings/keywords' as never);
+  };
+
+  /** 1차 MVP 비활성 기능 이벤트들 (토스트) */
+  const handleToggleProfileEdit = () => {
+    showToast('프로필 편집 기능은 추후 구현 예정입니다');
+  };
+
+  const handleToggleKeywordNotification = () => {
+    showToast('현재는 설정한 모든 키워드에 대해서 알림을 수신합니다. (추후 개선 예정)');
+  };
+
+  const handleToggleEventNotification = () => {
+    showToast('추후 이벤트 알람 구현 예정입니다');
+  };
+
+  /** 시스템 알림 설정 — OS 설정으로 외부 진입 */
+  const handleSystemNotification = () => {
+    Linking.openSettings();
+  };
+
+  /** 알림 권한 배너 → OS 설정 이동 */
+  const handleGoToPermissionSettings = () => {
+    Linking.openSettings();
+  };
+
+  /** 로그아웃 — 확인 다이얼로그 → clearAuth → 로그인 화면 이동 */
+  const handleLogout = () => {
+    Alert.alert(
+      '로그아웃',
+      '정말 로그아웃 하시겠습니까?',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '로그아웃',
+          style: 'destructive',
+          onPress: () => {
+            clearAuth();
+            router.replace('/login');
+          },
+        },
+      ],
+    );
+  };
+
+  // ── 프로필 표시 정보 파생 ──
+  // TODO: const displayImage = ''; 추후에 구현 예정
+  const displayName = '가톨릭대 학생' // user?.email?.split('@')[0] ?? '사용자';
+  const displayEmail = user?.email ?? '';
+  const displayMajor = user?.major ?? '';
+
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.placeholder}>
-        <Text style={styles.text}>설정 화면 — Sprint 2에서 구현 예정</Text>
-      </View>
-    </SafeAreaView>
+    <View style={styles.screen}>
+      {/* 상단 헤더 — 메인과 동일 */}
+      <MainHeader />
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── 프로필 섹션 ── */}
+        <View style={styles.profileCard}>
+          {/* TODO: 프로필 아이콘 추후에 구현 예정 */}
+          <View style={styles.profileIconWrapper}>
+            <Feather name="user" size={24} color={Colors.primary} />
+          </View>
+
+          {/* 프로필 정보 */}
+          <View style={styles.profileInfo}>
+            <View style={styles.profileNameRow}>
+              <Text style={styles.profileName}>{displayName}</Text>
+            </View>
+
+            <Text style={styles.profileEmail}>{displayEmail}</Text>
+
+            {/* 학과 뱃지 */}
+            {displayMajor.length > 0 && (
+              <View style={styles.majorBadge}>
+                <Text style={styles.majorBadgeText}>{displayMajor}</Text>
+              </View>
+            )}
+          </View>
+
+          {/* TODO: 프로필 옆 편집 기능 추후에 구현 예정 */}
+          <TouchableOpacity onPress={handleToggleProfileEdit}>
+            <Feather name="edit" size={24} color={Colors.primary} />
+          </TouchableOpacity>
+        </View>
+
+        {/* ── 알림 권한 배너 (조건부) ── */}
+        {!notificationPermitted && (
+          <View style={styles.alertBanner}>
+            <View style={styles.alertBannerContent}>
+              {/* 아이콘 */}
+              <View style={styles.alertIconWrapper}>
+                <Feather name="bell-off" size={16} color="#BA1A1A" />
+              </View>
+
+              {/* 텍스트 */}
+              <View style={styles.alertTextSection}>
+                <Text style={styles.alertTitle}>
+                  알림 권한이 비활성화되어 있습니다
+                </Text>
+                <Text style={styles.alertDescription}>
+                  공지 알림을 받으려면 설정에서 허용해주세요.
+                </Text>
+              </View>
+            </View>
+
+            {/* 권한 설정 버튼 */}
+            <TouchableOpacity
+              style={styles.alertButton}
+              onPress={handleGoToPermissionSettings}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.alertButtonText}>권한 설정으로 이동</Text>
+              <Feather name="external-link" size={13} color="#FFFFFF" />
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* ── 공지 설정 섹션 ── */}
+        <View style={styles.sectionGroup}>
+          <Text style={styles.sectionTitle}>공지 설정</Text>
+          <View style={styles.sectionCard}>
+            <TouchableOpacity
+              style={styles.settingsRow}
+              onPress={handleKeywordSettings}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingsRowLeft}>
+                <Feather name="tag" size={18} color={Colors.primary} />
+                <Text style={styles.settingsRowText}>
+                  관심 공지 키워드 설정
+                </Text>
+              </View>
+              <Feather name="chevron-right" size={18} color={Colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* ── 알림 설정 섹션 ── */}
+        <View style={styles.sectionGroup}>
+          <Text style={styles.sectionTitle}>알림 설정</Text>
+          <View style={styles.sectionCard}>
+            {/* 키워드 알림 수신 */}
+            <View style={styles.settingsRow}>
+              <View style={styles.settingsRowLeft}>
+                <Feather name="bell" size={18} color={Colors.primary} />
+                <Text style={styles.settingsRowText}>키워드 알림 수신</Text>
+              </View>
+              <Switch
+                value={false}
+                onValueChange={handleToggleKeywordNotification}
+                trackColor={{ false: Colors.divider, true: Colors.primary }}
+                thumbColor="#FFFFFF"
+              />
+            </View>
+
+            <View style={styles.divider} />
+
+            {/* 이벤트 알림 수신 */}
+            <View style={styles.settingsRow}>
+              <View style={styles.settingsRowLeft}>
+                <Feather name="calendar" size={18} color={Colors.primary} />
+                <Text style={styles.settingsRowText}>이벤트 알림 수신</Text>
+              </View>
+              <Switch
+                value={false}
+                onValueChange={handleToggleEventNotification}
+                trackColor={{ false: Colors.divider, true: Colors.primary }}
+                thumbColor="#FFFFFF"
+              />
+            </View>
+
+            <View style={styles.divider} />
+
+            {/* 시스템 알림 설정 */}
+            <TouchableOpacity
+              style={styles.settingsRow}
+              onPress={handleSystemNotification}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingsRowLeft}>
+                <Feather name="settings" size={18} color={Colors.primary} />
+                <Text style={styles.settingsRowText}>시스템 알림 설정</Text>
+              </View>
+              <Feather name="chevron-right" size={18} color={Colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* ── 기타 섹션 ── */}
+        <View style={styles.sectionGroup}>
+          <Text style={styles.sectionTitle}>기타</Text>
+          <View style={styles.sectionCard}>
+            {/* 버전 정보 */}
+            <View style={[styles.settingsRow, styles.settingsRowBorder]}>
+              <View style={styles.settingsRowLeft}>
+                <Feather name="info" size={18} color={Colors.primary} />
+                <Text style={styles.settingsRowText}>버전 정보</Text>
+              </View>
+              <Text style={styles.versionText}>v{APP_VERSION}</Text>
+            </View>
+
+            {/* 로그아웃 */}
+            <TouchableOpacity
+              style={styles.settingsRow}
+              onPress={handleLogout}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingsRowLeft}>
+                <Feather name="log-out" size={18} color="#BA1A1A" />
+                <Text style={styles.logoutText}>로그아웃</Text>
+              </View>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* ── 푸터 ── */}
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            © 2026 가톨릭대학교 팀 회광반조. 모든 권리 보유.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
   );
 }
 
+// ─── 스타일 ────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
-    backgroundColor: Colors.background,
+    backgroundColor: '#F9F9F9',
   },
-  placeholder: {
+  scrollView: {
     flex: 1,
+  },
+  scrollContent: {
+    paddingTop: 24,
+    paddingHorizontal: 24,
+    paddingBottom: 128, // 하단 탭바 + 여유
+    gap: 32,
+  },
+
+  // ─── 프로필 카드 ───
+  profileCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 24,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 24,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: 'rgba(197, 197, 212, 0.3)',
+    // shadow
+    ...Platform.select({
+      android: { elevation: 1 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.05,
+        shadowRadius: 1.75,
+      },
+    }),
+  },
+  profileIconWrapper: {
+    width: 44,
+    height: 44,
+    borderRadius: 9999,
+    backgroundColor: 'rgba(221, 225, 255, 0.2)',
+    borderWidth: 4,
+    borderColor: '#FFFFFF',
     justifyContent: 'center',
     alignItems: 'center',
   },
-  text: {
+  profileInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  profileNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  profileName: {
+    fontFamily: 'Pretendard',
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    letterSpacing: -0.45,
+  },
+  profileEmail: {
+    fontFamily: 'Pretendard',
+    fontSize: 13,
+    fontWeight: '400',
     color: Colors.textSecondary,
-    fontSize: 16,
+  },
+  majorBadge: {
+    alignSelf: 'flex-start',
+    backgroundColor: Colors.accent,
+    borderRadius: 9999,
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+    marginTop: 8,
+  },
+  majorBadgeText: {
+    fontFamily: 'Pretendard',
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#6C5000',
+    letterSpacing: 0.55,
+  },
+
+  // ─── 알림 배너 ───
+  alertBanner: {
+    backgroundColor: 'rgba(255, 218, 214, 0.4)',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(186, 26, 26, 0.1)',
+    padding: 20,
+    gap: 16,
+  },
+  alertBannerContent: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  alertIconWrapper: {
+    width: 32,
+    height: 32,
+    borderRadius: 12,
+    backgroundColor: 'rgba(186, 26, 26, 0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  alertTextSection: {
+    flex: 1,
+    gap: 4,
+  },
+  alertTitle: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#93000A',
+    lineHeight: 22,
+  },
+  alertDescription: {
+    fontFamily: 'Pretendard',
+    fontSize: 13,
+    fontWeight: '400',
+    color: 'rgba(147, 0, 10, 0.7)',
+    lineHeight: 20,
+  },
+  alertButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: '#00175B',
+    borderRadius: 12,
+    paddingVertical: 12,
+  },
+  alertButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+
+  // ─── 섹션 그룹 ───
+  sectionGroup: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '700',
+    color: Colors.textSecondary,
+    letterSpacing: 0.96,
+    paddingHorizontal: 4,
+  },
+  sectionCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(226, 226, 226, 0.2)',
+    overflow: 'hidden',
+    // shadow
+    ...Platform.select({
+      android: { elevation: 1 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.02,
+        shadowRadius: 10.5,
+      },
+    }),
+  },
+
+  // ─── 설정 행 ───
+  settingsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+  },
+  settingsRowBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(226, 226, 226, 0.2)',
+  },
+  settingsRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  settingsRowText: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '500',
+    color: Colors.textPrimary,
+    letterSpacing: -0.375,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: 'rgba(226, 226, 226, 0.2)',
+    marginHorizontal: 16,
+  },
+  versionText: {
+    fontFamily: 'Pretendard',
+    fontSize: 13,
+    fontWeight: '500',
+    color: Colors.textSecondary,
+  },
+  logoutText: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '500',
+    color: '#BA1A1A',
+    letterSpacing: -0.375,
+  },
+
+  // ─── 푸터 ───
+  footer: {
+    alignItems: 'center',
+    paddingTop: 15,
+    opacity: 0.6,
+  },
+  footerText: {
+    fontFamily: 'Pretendard',
+    fontSize: 11,
+    fontWeight: '500',
+    color: Colors.textSecondary,
+    letterSpacing: 0.275,
+    textAlign: 'center',
+    lineHeight: 16,
   },
 });

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -118,6 +118,11 @@ function RootLayoutNav() {
             name="register"
             options={{ headerShown: false, animation: 'slide_from_right' }}
           />
+          {/* 설정 — 관심 키워드 화면 */}
+          <Stack.Screen
+            name="settings/keywords"
+            options={{ headerShown: false, animation: 'slide_from_right' }}
+          />
         </Stack>
         {/* Android only: 상태바 스타일 */}
         <StatusBar style="light" backgroundColor="transparent" translucent />

--- a/frontend/app/settings/keywords.tsx
+++ b/frontend/app/settings/keywords.tsx
@@ -1,0 +1,363 @@
+/**
+ * 관심 공지 키워드 설정 화면 — app/settings/keywords.tsx
+ *
+ * 구조:
+ * ┌─ SubHeader ──────────────────────────────┐
+ * │ ←     관심 공지 키워드 설정              │
+ * ├──────────────────────────────────────────┤
+ * │ 관심 공지 키워드 설정 (대 타이틀)          │
+ * │ 설정된 키워드가 포함된 공지사항이 등록되면   │
+ * │ 알림을 받습니다.                         │
+ * ├──────────────────────────────────────────┤
+ * │ 새 키워드 추가                           │
+ * │ [🔍 키워드 입력...         ] [추가]      │
+ * ├──────────────────────────────────────────┤
+ * │ 등록된 키워드                            │
+ * │ [국가장학금 ×] [해외연수 ×] [인턴 ×]     │
+ * ├──────────────────────────────────────────┤
+ * │ 추천 키워드 (1차 MVP 제외)               │
+ * └──────────────────────────────────────────┘
+ *
+ * 정책:
+ *  - 추가/삭제 즉시 서버 반영 (별도 저장 버튼 없음)
+ *  - 낙관적 업데이트 적용
+ *  - 태그 최대 20개
+ */
+
+import { Feather } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  ToastAndroid,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import {
+  extractTagErrorCode,
+  getTagErrorMessage,
+  useCreateTag,
+  useDeleteTag,
+} from '@/src/features/settings/hooks';
+import { SubHeader } from '@/src/shared/components';
+import { useAuthStore } from '@/src/store/useAuthStore';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// ─── 토스트 유틸 ─────────────────────────────────────────────────────
+
+function showToast(message: string) {
+  if (Platform.OS === 'android') {
+    // Android only
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  }
+}
+
+// ─── 관심 키워드 설정 화면 ──────────────────────────────────────────
+
+export default function KeywordSettingsScreen() {
+  const tags = useAuthStore((s) => s.tags);
+  const insets = useSafeAreaInsets();
+
+  const [inputValue, setInputValue] = useState('');
+
+  const createTagMutation = useCreateTag();
+  const deleteTagMutation = useDeleteTag();
+
+  /** 태그 추가 */
+  const handleAddTag = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed.length === 0) return;
+
+    // 클라이언트 중복 체크 (서버에서도 409 반환하지만, 불필요한 네트워크 요청 방지)
+    if (tags.some((tag) => tag.tagName === trimmed)) {
+      showToast('이미 등록된 태그입니다');
+      return;
+    }
+
+    createTagMutation.mutate(trimmed, {
+      onSuccess: () => {
+        setInputValue('');
+      },
+      onError: (error) => {
+        const code = extractTagErrorCode(error);
+        if (code) {
+          showToast(getTagErrorMessage(code));
+        } else {
+          showToast('태그 추가에 실패했습니다');
+        }
+      },
+    });
+  };
+
+  /** 태그 삭제 */
+  const handleDeleteTag = (tagId: number) => {
+    deleteTagMutation.mutate(tagId, {
+      onError: (error) => {
+        const code = extractTagErrorCode(error);
+        if (code) {
+          showToast(getTagErrorMessage(code));
+        } else {
+          showToast('태그 삭제에 실패했습니다');
+        }
+      },
+    });
+  };
+
+  /** 입력란 제출 (키보드 완료 버튼) */
+  const handleSubmitEditing = () => {
+    handleAddTag();
+  };
+
+  return (
+    <View style={styles.screen}>
+      {/* 헤더 — 뒤로가기 + 타이틀 */}
+      <SubHeader title="관심 공지 키워드 설정" />
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={[styles.scrollContent,
+          {
+            paddingTop: insets.top + 64 + 16,
+            paddingBottom: insets.bottom + 82 + 16
+          }
+        ]}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* ── 페이지 타이틀 + 안내 ── */}
+        <View style={styles.pageTitleSection}>
+          <Text style={styles.pageTitle}>관심 공지 키워드 설정</Text>
+          <Text style={styles.pageDescription}>
+            설정된 키워드가 포함된 공지사항이 등록되면 알림을 받습니다.
+          </Text>
+        </View>
+
+        {/* ── 새 키워드 추가 섹션 ── */}
+        <View style={styles.addSection}>
+          <Text style={styles.sectionLabel}>새 키워드 추가</Text>
+          <View style={styles.inputRow}>
+            <View style={styles.inputWrapper}>
+              <Feather name="search" size={16} color={Colors.textSecondary} />
+              <TextInput
+                style={styles.textInput}
+                placeholder="키워드 입력 (예: 장학, 공모전)"
+                placeholderTextColor={Colors.textSecondary}
+                value={inputValue}
+                onChangeText={setInputValue}
+                onSubmitEditing={handleSubmitEditing}
+                returnKeyType="done"
+                maxLength={20}
+              />
+            </View>
+            <TouchableOpacity
+              style={[
+                styles.addButton,
+                inputValue.trim().length === 0 && styles.addButtonDisabled,
+              ]}
+              onPress={handleAddTag}
+              activeOpacity={0.85}
+              disabled={inputValue.trim().length === 0}
+            >
+              <Text style={styles.addButtonText}>추가</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* ── 등록된 키워드 섹션 ── */}
+        <View style={styles.registeredSection}>
+          <Text style={styles.sectionLabel}>등록된 키워드</Text>
+          {tags.length > 0 ? (
+            <View style={styles.chipContainer}>
+              {tags.map((tag) => (
+                <View key={tag.tagId} style={styles.chip}>
+                  <Text style={styles.chipText}>{tag.tagName}</Text>
+                  <TouchableOpacity
+                    onPress={() => handleDeleteTag(tag.tagId)}
+                    hitSlop={8}
+                  >
+                    <Feather name="x" size={14} color={Colors.primary} />
+                  </TouchableOpacity>
+                </View>
+              ))}
+            </View>
+          ) : (
+            <View style={styles.emptyChipContainer}>
+              <Feather name="tag" size={24} color={Colors.separator} />
+              <Text style={styles.emptyChipText}>
+                등록된 키워드가 없습니다
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {/* ── 추천 키워드 섹션 (1차 MVP 제외) ── */}
+        {/* TODO(2차 MVP): 추천 키워드 섹션 구현 */}
+        {/* <View style={styles.recommendedSection}>
+          <Text style={styles.sectionLabel}>추천 키워드</Text>
+          <Text style={styles.recommendedDescription}>
+            다른 학생들이 많이 등록한 키워드입니다.
+          </Text>
+        </View> */}
+      </ScrollView>
+    </View>
+  );
+}
+
+// ─── 스타일 ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#F9F9F9',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingTop: 80, // SubHeader 높이 (64) + 여유
+    paddingHorizontal: 16,
+    paddingBottom: 128,
+    gap: 24,
+  },
+
+  // ─── 페이지 타이틀 ───
+  pageTitleSection: {
+    paddingHorizontal: 8,
+    gap: 7,
+  },
+  pageTitle: {
+    fontFamily: 'Pretendard',
+    fontSize: 24,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    letterSpacing: -0.6,
+  },
+  pageDescription: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    lineHeight: 20,
+  },
+
+  // ─── 새 키워드 추가 ───
+  addSection: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    padding: 20,
+    gap: 12,
+    // shadow
+    ...Platform.select({
+      android: { elevation: 1 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.04,
+        shadowRadius: 7,
+      },
+    }),
+  },
+  sectionLabel: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+    letterSpacing: -0.35,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  inputWrapper: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#F5F5F5',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: Colors.divider,
+  },
+  textInput: {
+    flex: 1,
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textPrimary,
+    padding: 0,
+  },
+  addButton: {
+    backgroundColor: Colors.primary,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  addButtonDisabled: {
+    opacity: 0.4,
+  },
+  addButtonText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+
+  // ─── 등록된 키워드 ───
+  registeredSection: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    padding: 20,
+    gap: 16,
+    // shadow
+    ...Platform.select({
+      android: { elevation: 1 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.04,
+        shadowRadius: 7,
+      },
+    }),
+  },
+  chipContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#DDE1FF',
+    borderRadius: 9999,
+    paddingVertical: 6,
+    paddingLeft: 12,
+    paddingRight: 8,
+  },
+  chipText: {
+    fontFamily: 'Pretendard',
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.primary,
+  },
+  emptyChipContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 20,
+    gap: 8,
+  },
+  emptyChipText: {
+    fontFamily: 'Pretendard',
+    fontSize: 13,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+  },
+});

--- a/frontend/app/settings/keywords.tsx
+++ b/frontend/app/settings/keywords.tsx
@@ -28,6 +28,7 @@ import { Feather } from '@expo/vector-icons';
 import React, { useState } from 'react';
 import {
   Platform,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -43,6 +44,7 @@ import {
   getTagErrorMessage,
   useCreateTag,
   useDeleteTag,
+  useRefreshTags,
 } from '@/src/features/settings/hooks';
 import { SubHeader } from '@/src/shared/components';
 import { useAuthStore } from '@/src/store/useAuthStore';
@@ -67,6 +69,17 @@ export default function KeywordSettingsScreen() {
 
   const createTagMutation = useCreateTag();
   const deleteTagMutation = useDeleteTag();
+  const { refreshTags, isRefreshing } = useRefreshTags();
+
+  /** 최신 태그 목록 새로고침 (Pull-to-Refresh) */
+  const handleRefresh = async () => {
+    const { success } = await refreshTags();
+    if (success) {
+      showToast('관심 키워드 목록이 갱신되었습니다');
+    } else {
+      showToast('키워드 목록을 가져오지 못했습니다. 네트워크 상태를 확인해주세요.');
+    }
+  };
 
   /** 태그 추가 */
   const handleAddTag = () => {
@@ -128,6 +141,13 @@ export default function KeywordSettingsScreen() {
         ]}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            colors={[Colors.primary]}
+          />
+        }
       >
         {/* ── 페이지 타이틀 + 안내 ── */}
         <View style={styles.pageTitleSection}>

--- a/frontend/src/constants/colors.ts
+++ b/frontend/src/constants/colors.ts
@@ -34,7 +34,7 @@ export const Colors = {
   /** 대분류 태그 텍스트 (미선택) */
   tabText: '#44465299',   // 60% opacity
   /** 소분류 태그 배경 */
-  chipBg: '#F5F6FA',
+  chipBg: '#E8EDF5',
   /** 소분류 태그 텍스트 */
   chipText: '#444652B2',  // 70% opacity
 

--- a/frontend/src/features/notices/components/AiSummarySection.tsx
+++ b/frontend/src/features/notices/components/AiSummarySection.tsx
@@ -47,7 +47,7 @@ function AiSummarySectionComponent({
   );
 }
 
-export const AiSummarySection = React.memo(AiSummarySectionComponent);
+export const AiSummarySection = AiSummarySectionComponent;
 
 // ─── SUCCESS: 요약 텍스트 ──────────────────────────────────────────────
 

--- a/frontend/src/features/notices/components/TagChipList.tsx
+++ b/frontend/src/features/notices/components/TagChipList.tsx
@@ -1,10 +1,3 @@
-/**
- * TagChip — 소분류 태그 칩 컴포넌트
- * 시안: #F5F6FA 배경, #444652B2 텍스트
- * padding [6, 12], borderRadius 9999, fontSize 12, fontWeight 500
- * 수평 스크롤 리스트에서 사용
- */
-
 import React from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -17,9 +10,11 @@ interface TagChipListProps {
   selectedTag: string | null;
   /** 태그 토글 콜백 — 같은 값 다시 탭 시 해제(null) */
   onSelect: (tag: string) => void;
+  /** 키워드 추가(+) 버튼 클릭 콜백 */
+  onAddPress?: () => void;
 }
 
-function TagChipListComponent({ tags, selectedTag, onSelect }: TagChipListProps) {
+function TagChipListComponent({ tags, selectedTag, onSelect, onAddPress }: TagChipListProps) {
   return (
     <View style={styles.wrapper}>
       <ScrollView
@@ -32,12 +27,23 @@ function TagChipListComponent({ tags, selectedTag, onSelect }: TagChipListProps)
           return (
             <ChipButton
               key={tag}
-              label={tag}
+              label={'#' + tag}
               isSelected={isSelected}
               onPress={() => onSelect(tag)}
             />
           );
         })}
+
+        {/* 사용자 정의 태그가 있든 없든 항상 노출되는 '+' 설정 추가 버튼 */}
+        {onAddPress && (
+          <TouchableOpacity
+            style={styles.addButton}
+            onPress={onAddPress}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.chipText}>{'+태그'}</Text>
+          </TouchableOpacity>
+        )}
       </ScrollView>
     </View>
   );
@@ -104,5 +110,13 @@ const styles = StyleSheet.create({
   },
   chipTextSelected: {
     color: '#FFFFFF',
+  },
+  addButton: {
+    backgroundColor: Colors.chipBg,
+    borderRadius: 9999,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/frontend/src/features/settings/hooks/index.ts
+++ b/frontend/src/features/settings/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useCreateTag, useDeleteTag, extractTagErrorCode, getTagErrorMessage } from './useTags';

--- a/frontend/src/features/settings/hooks/index.ts
+++ b/frontend/src/features/settings/hooks/index.ts
@@ -1,1 +1,1 @@
-export { useCreateTag, useDeleteTag, extractTagErrorCode, getTagErrorMessage } from './useTags';
+export { useCreateTag, useDeleteTag, useRefreshTags, extractTagErrorCode, getTagErrorMessage } from './useTags';

--- a/frontend/src/features/settings/hooks/useTags.ts
+++ b/frontend/src/features/settings/hooks/useTags.ts
@@ -11,6 +11,7 @@
  *  - useAuthStore.tags를 단일 진실 원천(Single Source of Truth)으로 사용
  */
 
+import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 
 import {
@@ -18,6 +19,7 @@ import {
   deleteTag,
   extractTagErrorCode,
   getTagErrorMessage,
+  getTags,
 } from '@/src/services/tags';
 import { useAuthStore } from '@/src/store/useAuthStore';
 import type { UserTag } from '@/src/types/auth';
@@ -99,6 +101,28 @@ export function useDeleteTag() {
       }
     },
   });
+}
+
+// ─── 태그 새로고침 훅 ──────────────────────────────────────────────
+
+export function useRefreshTags() {
+  const updateTags = useAuthStore((s) => s.updateTags);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const refreshTags = async () => {
+    setIsRefreshing(true);
+    try {
+      const latestTags = await getTags();
+      updateTags(latestTags);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error };
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  return { refreshTags, isRefreshing };
 }
 
 // ─── 에러 유틸 re-export ─────────────────────────────────────────

--- a/frontend/src/features/settings/hooks/useTags.ts
+++ b/frontend/src/features/settings/hooks/useTags.ts
@@ -1,0 +1,106 @@
+/**
+ * useTags — 태그 추가/삭제 TanStack Query mutation 훅
+ *
+ * 동작 흐름:
+ *  - useCreateTag: POST /api/tags → 낙관적 업데이트 → useAuthStore.updateTags
+ *  - useDeleteTag: DELETE /api/tags/{tagId} → 낙관적 업데이트 → useAuthStore.updateTags
+ *
+ * 정책:
+ *  - 별도 "저장" 버튼 없음 — 추가/삭제 즉시 서버 반영 (낙관적 업데이트)
+ *  - 실패 시 롤백 — 이전 태그 목록으로 복원
+ *  - useAuthStore.tags를 단일 진실 원천(Single Source of Truth)으로 사용
+ */
+
+import { useMutation } from '@tanstack/react-query';
+
+import {
+  createTag,
+  deleteTag,
+  extractTagErrorCode,
+  getTagErrorMessage,
+} from '@/src/services/tags';
+import { useAuthStore } from '@/src/store/useAuthStore';
+import type { UserTag } from '@/src/types/auth';
+
+// ─── 태그 추가 훅 ────────────────────────────────────────────────
+
+interface CreateTagContext {
+  /** 낙관적 업데이트 전 태그 목록 */
+  previousTags: UserTag[];
+}
+
+export function useCreateTag() {
+  const tags = useAuthStore((s) => s.tags);
+  const updateTags = useAuthStore((s) => s.updateTags);
+
+  return useMutation({
+    mutationFn: createTag,
+
+    onMutate: (tagName): CreateTagContext => {
+      const previousTags = [...tags];
+
+      // 낙관적 업데이트 — 임시 tagId로 즉시 UI 반영
+      const optimisticTag: UserTag = {
+        tagId: -Date.now(), // 음수 임시 ID (서버 응답으로 교체됨)
+        tagName,
+      };
+      updateTags([...tags, optimisticTag]);
+
+      return { previousTags };
+    },
+
+    onSuccess: (data) => {
+      // 서버 응답의 진짜 tagId로 교체
+      const currentTags = useAuthStore.getState().tags;
+      const updatedTags = currentTags.map((tag) =>
+        tag.tagId < 0 && tag.tagName === data.tagName
+          ? { tagId: data.tagId, tagName: data.tagName }
+          : tag,
+      );
+      updateTags(updatedTags);
+    },
+
+    onError: (_error, _tagName, context) => {
+      // 롤백
+      if (context) {
+        updateTags(context.previousTags);
+      }
+    },
+  });
+}
+
+// ─── 태그 삭제 훅 ────────────────────────────────────────────────
+
+interface DeleteTagContext {
+  /** 낙관적 업데이트 전 태그 목록 */
+  previousTags: UserTag[];
+}
+
+export function useDeleteTag() {
+  const tags = useAuthStore((s) => s.tags);
+  const updateTags = useAuthStore((s) => s.updateTags);
+
+  return useMutation({
+    mutationFn: deleteTag,
+
+    onMutate: (tagId): DeleteTagContext => {
+      const previousTags = [...tags];
+
+      // 낙관적 삭제 — 즉시 UI에서 제거
+      updateTags(tags.filter((tag) => tag.tagId !== tagId));
+
+      return { previousTags };
+    },
+
+    onError: (_error, _tagId, context) => {
+      // 롤백
+      if (context) {
+        updateTags(context.previousTags);
+      }
+    },
+  });
+}
+
+// ─── 에러 유틸 re-export ─────────────────────────────────────────
+
+export { extractTagErrorCode, getTagErrorMessage };

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -17,6 +17,8 @@ import apiClient from './api';
 
 // ─── 타입 ──────────────────────────────────────────────────────────
 
+import type { UserTag } from '@/src/types/auth';
+
 /** 태그 생성 요청 */
 interface CreateTagRequest {
   tagName: string;
@@ -85,4 +87,13 @@ export async function createTag(tagName: string): Promise<CreateTagResponse> {
  */
 export async function deleteTag(tagId: number): Promise<void> {
   await apiClient.delete(`/api/tags/${tagId}`);
+}
+
+/**
+ * 태그 목록 전체 조회
+ * GET /api/tags
+ */
+export async function getTags(): Promise<UserTag[]> {
+  const { data } = await apiClient.get<UserTag[]>('/api/tags');
+  return data;
 }

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -1,0 +1,88 @@
+/**
+ * 태그 관리 API fetcher
+ *
+ * 백엔드 API 명세:
+ *  - POST /api/tags { tagName } → { tagId, tagName }
+ *  - DELETE /api/tags/{tagId} → 200 (본문 없음)
+ *
+ * TODO: 태그 정책 협의 더 필요
+ * 
+ * 정책:
+ *  - 사용자당 최대 20개
+ *  - tagName: 1~20자, 한글/영문/숫자만 허용
+ *  - 중복 태그: 409 TAG_DUPLICATE
+ */
+
+import apiClient from './api';
+
+// ─── 타입 ──────────────────────────────────────────────────────────
+
+/** 태그 생성 요청 */
+interface CreateTagRequest {
+  tagName: string;
+}
+
+/** 태그 생성 응답 */
+export interface CreateTagResponse {
+  tagId: number;
+  tagName: string;
+}
+
+// ─── 에러 코드 ────────────────────────────────────────────────────
+
+export type TagErrorCode =
+  | 'INVALID_INPUT'
+  | 'TAG_LIMIT_EXCEEDED'
+  | 'TAG_DUPLICATE'
+  | 'TAG_NOT_FOUND';
+
+/** 에러 응답에서 코드 추출 */
+export function extractTagErrorCode(error: unknown): TagErrorCode | null {
+  if (
+    error != null &&
+    typeof error === 'object' &&
+    'response' in error
+  ) {
+    const axiosError = error as { response?: { data?: { code?: string } } };
+    const code = axiosError.response?.data?.code;
+    if (code === 'INVALID_INPUT') return 'INVALID_INPUT';
+    if (code === 'TAG_LIMIT_EXCEEDED') return 'TAG_LIMIT_EXCEEDED';
+    if (code === 'TAG_DUPLICATE') return 'TAG_DUPLICATE';
+    if (code === 'TAG_NOT_FOUND') return 'TAG_NOT_FOUND';
+  }
+  return null;
+}
+
+/** 에러 코드 → 한글 메시지 매핑 */
+export function getTagErrorMessage(code: TagErrorCode): string {
+  switch (code) {
+    case 'INVALID_INPUT':
+      return '태그명이 올바르지 않습니다 (1~20자, 한글/영문/숫자만)';
+    case 'TAG_LIMIT_EXCEEDED':
+      return '태그 개수 한도(20개)를 초과했습니다';
+    case 'TAG_DUPLICATE':
+      return '이미 등록된 태그입니다';
+    case 'TAG_NOT_FOUND':
+      return '태그를 찾을 수 없습니다';
+  }
+}
+
+// ─── API 호출 ─────────────────────────────────────────────────────
+
+/**
+ * 태그 생성
+ * POST /api/tags
+ */
+export async function createTag(tagName: string): Promise<CreateTagResponse> {
+  const body: CreateTagRequest = { tagName };
+  const { data } = await apiClient.post<CreateTagResponse>('/api/tags', body);
+  return data;
+}
+
+/**
+ * 태그 삭제
+ * DELETE /api/tags/{tagId}
+ */
+export async function deleteTag(tagId: number): Promise<void> {
+  await apiClient.delete(`/api/tags/${tagId}`);
+}

--- a/frontend/src/shared/components/MainHeader.tsx
+++ b/frontend/src/shared/components/MainHeader.tsx
@@ -44,7 +44,7 @@ function MainHeaderComponent() {
   );
 }
 
-export const MainHeader = React.memo(MainHeaderComponent);
+export const MainHeader = MainHeaderComponent;
 
 const styles = StyleSheet.create({
   container: {

--- a/frontend/src/shared/components/SubHeader.tsx
+++ b/frontend/src/shared/components/SubHeader.tsx
@@ -64,7 +64,7 @@ function SubHeaderComponent({ title, onBack }: SubHeaderProps) {
   );
 }
 
-export const SubHeader = React.memo(SubHeaderComponent);
+export const SubHeader = SubHeaderComponent;
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
# 📖 작업 배경

Sprint 2의 Phase 4 작업으로 설정화면과 관심키워드추가화면을 구현하고 키워드가 메인화면에도 동기화 되도록 상태 관리를 하는 것이 주요한 과제였습니다.

특히 여러 기기에서 동시 접근할 경우 관심 키워드의 동기화 문제가 발생했고 당겨서 새로고침(Pull-to-Refresh) 시의 상태 불일치(공지사항만 갱신되고 태그는 갱신되지 않음)가 관찰되었습니다. 설정 화면 및 관심 공지 키워드 설정 화면이 새롭게 추가됨에 따라, 사용자가 키워드를 변경하고 메인으로 돌아왔을 때 즉각적인 피드백과 동기화가 필수적입니다. 따라서 동기화를 위해서 태그 리스트를 불러오는 엔드포인트도 추가하게 되었습니다.

설상가상으로 `.env` 환경변수 내 미세한 오타로 인해 500 API 서버 에러(`NumberFormatException`)가 발생하여 데이터 로드 자체가 차단되는 실수도 있었습니다.

본 PR은 다음 핵심 작업을 통해 신규 사용자 화면 구축, 백엔드 데이터 서빙, 데이터 동기화, 치명적 버그 해결을 완수합니다:
1. **백엔드 API 및 신규 사용자 화면 구축** — 태그 목록 조회(`GET /api/tags`) API 추가 및 설정/관심 키워드 화면 신규 구현.
2. **Pull-to-Refresh 동기화 파이프라인 구축** — `useRefreshTags` 커스텀 훅을 분리 및 도입하여 서버의 키워드 정보와 공지사항 리스트를 메인 피드에서 동시에 갱신.
3. **`NumberFormatException(NaN)` 핫픽스** - pr에는 올리지 않는 트러블 슈팅

- #67 

<br>

## 🔧 작업 내용

### 수정 파일

- `backend/src/main/java/org/cathori/backend/tag/api/TagController.java` — 사용자 관심 태그 목록을 불러오는 `GET /api/tags` 엔드포인트 신규 추가.
- `app/(tabs)/settings.tsx` — 사용자의 기본 설정, 프로필, 키워드 메뉴 진입 및 알림 권한 등을 관리하는 설정 탭 본체 신규 구현.
- `app/settings/keywords.tsx` — 사용자 관심 태그를 조회, 추가, 삭제할 수 있는 독립 화면 구현.
- `app/(tabs)/index.tsx` — `RefreshControl`을 연동하여 당겨서 새로고침 기능을 구현하고, `useRefreshTags`와 `refetch`를 동시 호출하도록 구성.
- `src/features/settings/hooks/useTags.ts` — `useRefreshTags` 훅을 새롭게 분리하여 메인 피드와 키워드 화면 양쪽에서 공통으로 태그 상태를 갱신할 수 있도록 리팩토링.

<br>

## 🔍 동작 방식

### Pull-to-Refresh 다중 데이터 동기화 흐름

```
사용자 메인 피드 최상단 스와이프 (당겨서 새로고침)
  ├─ handleRefresh() 트리거
  ├─ Promise.all 병렬 실행
  │   ├─ refetch(): 현재 필터 조건(category, tags) 기반 공지사항 1페이지 새로고침
  │   └─ refreshTags(): /api/tags 호출 후 최신 키워드를 useAuthStore에 동기화
  ├─ 모든 비동기 통신 완료 시 RefreshControl 인디케이터 종료
  └─ UI 최신 상태 (공지 목록 + 상단 태그 칩 리스트) 동시 렌더링
```

<br>

## 💡 설계 근거

- **RefreshControl의 책임 확장**: 메인 피드에서는 단순히 공지 리스트만 갱신하는 것이 아니라, 사용자가 타 기기에서 변경했을지도 모르는 '관심 태그' 목록까지 동시에 갱신해야 완전한 데이터 정합성을 갖출 수 있습니다. 따라서 `Promise.all`을 이용해 병렬 동기화를 강제했습니다.
- **환경변수 오타의 도미노 효과 억제**: `size=NaN`과 같은 비정상 페이로드는 Spring Boot 단에서 `NumberFormatException`을 유발하여 백엔드 500 에러를 뿜게 만듭니다. 

<br>

## ✅ 체크리스트

- [x] 백엔드 관심 키워드 조회 API(`GET /api/tags`) 추가 완료
- [x] 설정 화면 및 관심 키워드 설정 화면 구현 완료
- [x] 메인 피드(`index.tsx`) `RefreshControl` 병렬 데이터 갱신 연동 완료
- [x] `useRefreshTags` 훅 분리를 통한 데이터 동기화 모듈화 완료

<br>

## 🔗 연관 이슈

- #50 
