### PR TITLE
[FIX] 공지 응답 DTO에서 dDay 제거

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeDetailResponse.java
@@ -13,7 +13,6 @@ public record NoticeDetailResponse(
         String aiSummaryStatus,
         String url,
         boolean isBookmarked,
-        Integer dDay,
         Long viewCount,
         List<String> tags,
         String deadlineAt

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedItem.java
@@ -4,22 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- * 피드 목록의 단일 공지 카드 DTO. 클라이언트가 카드 UI를 렌더링하는 데 필요한 모든 필드를 담으며,
- * dDay는 마감일 기준 남은 일수(양수=남음, 0=당일, 음수=지남)로 계산되어 내려온다.
- *
- * <pre>
- * {
- *   "noticeId": 42,
- *   "category": "장학",
- *   "title": "2026학년도 1학기 교내 장학금 신청 안내",
- *   "department": "학생처",
- *   "publishedAt": "2026-05-01",
- *   "aiSummary": "교내 장학금 신청 기간은 5/10~5/20이며 성적 3.0 이상 대상입니다.",
- *   "url": "https://...",
- *   "dDay": 5,
- *   "isBookmarked": false
- * }
- * </pre>
+ * Notice card item for the feed response.
  */
 public record NoticeFeedItem(
         String noticeId,
@@ -30,7 +15,6 @@ public record NoticeFeedItem(
         String aiSummary,
         String aiSummaryStatus,
         String url,
-        Integer dDay,
         Long viewCount,
         boolean isBookmarked,
         List<String> tags,

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeFeedResponse.java
@@ -2,31 +2,8 @@ package org.cathori.backend.notice.api.dto;
 
 import java.util.List;
 
-
 /**
- * 공지사항 피드 페이지 응답 DTO. 사용자가 피드 화면에서 공지 목록을 스크롤할 때 반환되며,
- * 각 항목에는 AI 요약·D-Day·북마크 여부가 포함되어 클라이언트가 별도 요청 없이 카드 UI를 렌더링할 수 있다.
- *
- * <pre>
- * {
- *   "content": [
- *     {
- *       "noticeId": 42,
- *       "category": "장학",
- *       "title": "2026학년도 1학기 교내 장학금 신청 안내",
- *       "department": "학생처",
- *       "publishedAt": "2026-05-01",
- *       "aiSummary": "교내 장학금 신청 기간은 5/10~5/20이며 성적 3.0 이상 대상입니다.",
- *       "url": "https://...",
- *       "dDay": -3,
- *       "isBookmarked": false
- *     }
- *   ],
- *   "page": 0,
- *   "size": 20,
- *   "hasNext": true
- * }
- * </pre>
+ * Paged notice feed response.
  */
 public record NoticeFeedResponse(
         List<NoticeFeedItem> content,

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 /**
- * 공지 키워드 검색 결과 목록의 단건 항목.
- *
- * 사용자가 검색어를 입력했을 때 결과 목록에 표시되는 카드 한 장에 해당한다.
- * dDay는 오늘 기준 마감일까지 남은 일수(양수=남음, 음수=초과, null=마감일 없는 공지).
+ * Notice search result item.
  */
 public record NoticeSearchItem(
         @Schema(example = "1") String noticeId,
@@ -15,5 +12,5 @@ public record NoticeSearchItem(
         @Schema(example = "2026학년도 1학기 국가장학금 신청 안내") String title,
         @Schema(example = "학생지원팀") String department,
         @Schema(example = "2026-03-28") LocalDate publishedAt,
-        @Schema(example = "3") Integer dDay
+        @Schema(example = "2026-04-30") String deadlineAt
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -19,8 +19,6 @@ import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -71,9 +69,8 @@ public class NoticeFeedService {
 
 
         // 5. DTO 매핑 + 반환
-        LocalDate today = LocalDate.now();
         List<NoticeFeedItem> content = pageRows.stream()
-                .map(r -> toItem(r, today, tagList))
+                .map(r -> toItem(r, tagList))
                 .toList();
 
         return new NoticeFeedResponse(content, page, size, hasNext);
@@ -94,20 +91,17 @@ public class NoticeFeedService {
         boolean hasNext = rows.size() > size;
         List<NoticeSearchRow> pageRows = hasNext ? rows.subList(0, size) : rows;
 
-        LocalDate today = LocalDate.now();
         List<NoticeSearchItem> content = pageRows.stream()
-                .map(r -> toSearchItem(r, today))
+                .map(this::toSearchItem)
                 .toList();
 
         return new NoticeSearchResponse(content, page, size, hasNext);
     }
 
-    private NoticeSearchItem toSearchItem(NoticeSearchRow row, LocalDate today) {
-        Integer dDay = row.deadlineAt() != null
-                ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
-                : null;
+    private NoticeSearchItem toSearchItem(NoticeSearchRow row) {
+        String deadlineAt = row.deadlineAt() != null ? row.deadlineAt().toString() : null;
         return new NoticeSearchItem(
-                String.valueOf(row.id()), row.category(), row.title(), row.department(), row.postedAt(), dDay
+                String.valueOf(row.id()), row.category(), row.title(), row.department(), row.postedAt(), deadlineAt
         );
     }
 
@@ -131,14 +125,11 @@ public class NoticeFeedService {
     private NoticeDetailResponse toDetail(Notice notice, boolean isBookmarked, List<String> tags) {
         String aiSummary = "SUCCESS".equals(notice.getAiSummaryStatus()) ? notice.getAiSummary() : null;
         String category = "DEPARTMENT".equals(notice.getSourceType()) ? null : notice.getCategory();
-        Integer dDay = notice.getDeadlineAt() != null
-                ? (int) ChronoUnit.DAYS.between(LocalDate.now(), notice.getDeadlineAt())
-                : null;
         String deadlineAt = notice.getDeadlineAt() != null ? notice.getDeadlineAt().toString() : null;
         return new NoticeDetailResponse(
                 String.valueOf(notice.getId()), category, notice.getTitle(), notice.getDepartment(),
                 notice.getPostedAt(), aiSummary, notice.getAiSummaryStatus(),
-                notice.getUrl(), isBookmarked, dDay, notice.getViewCount(), tags, deadlineAt
+                notice.getUrl(), isBookmarked, notice.getViewCount(), tags, deadlineAt
         );
     }
 
@@ -149,14 +140,7 @@ public class NoticeFeedService {
         return DepartmentSource.findEnumNameByDisplayName(secondMajor);
     }
 
-    /**
-     * {@code ChronoUnit.DAYS.between(today, deadlineAt)} 기준으로 dDay를 계산한다.
-     * 양수 = 마감까지 남은 일수, 음수 = 마감 초과, null = 마감일 없는 공지.
-     */
-    private NoticeFeedItem toItem(NoticeRow row, LocalDate today, List<String> queryTags) {
-        Integer dDay = row.deadlineAt() != null
-                ? (int) ChronoUnit.DAYS.between(today, row.deadlineAt())
-                : null;
+    private NoticeFeedItem toItem(NoticeRow row, List<String> queryTags) {
         String category = "DEPARTMENT".equals(row.sourceType()) ? null : row.category();
         String deadlineAt = row.deadlineAt() != null ? row.deadlineAt().toString() : null;
         List<String> tags = queryTags.stream()
@@ -164,7 +148,7 @@ public class NoticeFeedService {
                 .toList();
         return new NoticeFeedItem(
                 String.valueOf(row.id()), category, row.title(), row.department(),
-                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), dDay, row.viewCount(), row.isBookmarked(), tags, deadlineAt
+                row.postedAt(), row.aiSummary(), row.aiSummaryStatus(), row.url(), row.viewCount(), row.isBookmarked(), tags, deadlineAt
         );
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeRow.java
@@ -3,8 +3,7 @@ package org.cathori.backend.notice.application;
 import java.time.LocalDate;
 
 /**
- * 인프라에서 application 레이어로 올라오는 공지 단건 조회 결과. NoticeFeedQuery가 "무엇을 가져올지"를 정의하는 입력이라면,
- * NoticeRow는 DB에서 읽어온 raw 결과이며, dDay 계산 등 가공은 이 객체를 받은 서비스에서 처리한다.
+ * Raw notice feed row from the database.
  */
 public record NoticeRow(
         Long id,

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchRow.java
@@ -3,11 +3,7 @@ package org.cathori.backend.notice.application;
 import java.time.LocalDate;
 
 /**
- * 공지 검색 쿼리의 DB 조회 원본 행(Row).
- *
- * 인프라 계층이 SQL 결과를 담아 서비스로 전달하는 내부 전달 객체다.
- * 서비스 계층에서 deadlineAt을 기준으로 dDay를 계산한 뒤 NoticeSearchItem DTO로 변환된다.
- * deadlineAt이 null이면 마감 기한이 없는 공지다.
+ * Raw notice search row from the database.
  */
 public record NoticeSearchRow(
         Long id,

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
@@ -181,31 +181,33 @@ class NoticeDetailIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("ND-8: deadlineAt 있는 공지 조회 시 dDay 반환")
-    void getDetail_dDay_returned() throws Exception {
+    @DisplayName("ND-8: deadlineAt 있는 공지 조회 시 dDay 없이 deadlineAt 반환")
+    void getDetail_deadlineAt_returned_withoutDday() throws Exception {
         Notice futureNotice = saveNoticeWithSummary(LocalDate.now().plusDays(10));
         Notice pastNotice   = saveNoticeWithSummary(LocalDate.now().minusDays(3));
 
         mockMvc.perform(get("/api/notices/" + futureNotice.getId())
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.dDay").value(greaterThan(0)));
+                .andExpect(jsonPath("$.dDay").doesNotExist())
+                .andExpect(jsonPath("$.deadlineAt").value(futureNotice.getDeadlineAt().toString()));
 
         mockMvc.perform(get("/api/notices/" + pastNotice.getId())
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.dDay").value(lessThan(0)));
+                .andExpect(jsonPath("$.dDay").doesNotExist())
+                .andExpect(jsonPath("$.deadlineAt").value(pastNotice.getDeadlineAt().toString()));
     }
 
     @Test
-    @DisplayName("ND-9: deadlineAt 없는 공지 조회 시 dDay=null 반환")
-    void getDetail_dDay_null() throws Exception {
+    @DisplayName("ND-9: deadlineAt 없는 공지 조회 시 dDay 미반환")
+    void getDetail_dDay_notReturned() throws Exception {
         Notice notice = saveNotice("장학", "테스트 공지", LocalDate.now());
 
         mockMvc.perform(get("/api/notices/" + notice.getId())
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.dDay").value(nullValue()));
+                .andExpect(jsonPath("$.dDay").doesNotExist());
     }
 
     @Test

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
@@ -326,36 +326,40 @@ class NoticeFeedIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("NF-13: deadlineAt 없는 공지 → dDay=null")
-    void getFeed_dDay_null() throws Exception {
+    @DisplayName("NF-13: deadlineAt 없는 공지 -> dDay 미반환")
+    void getFeed_dDay_notReturned() throws Exception {
         saveNotice("MAIN", null, "장학", "공지", TODAY);
 
         mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].dDay").value(nullValue()));
+                .andExpect(jsonPath("$.content[0].dDay").doesNotExist());
     }
 
     @Test
-    @DisplayName("NF-14: deadlineAt 미래 → dDay > 0")
-    void getFeed_dDay_positive() throws Exception {
-        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, TODAY.plusDays(30));
+    @DisplayName("NF-14: deadlineAt 미래 -> dDay 없이 deadlineAt 반환")
+    void getFeed_deadlineAt_future_withoutDday() throws Exception {
+        LocalDate deadline = TODAY.plusDays(30);
+        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, deadline);
 
         mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].dDay").value(greaterThan(0)));
+                .andExpect(jsonPath("$.content[0].dDay").doesNotExist())
+                .andExpect(jsonPath("$.content[0].deadlineAt").value(deadline.toString()));
     }
 
     @Test
-    @DisplayName("NF-15: deadlineAt 과거 → dDay < 0")
-    void getFeed_dDay_negative() throws Exception {
-        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, TODAY.minusDays(5));
+    @DisplayName("NF-15: deadlineAt 과거 -> dDay 없이 deadlineAt 반환")
+    void getFeed_deadlineAt_past_withoutDday() throws Exception {
+        LocalDate deadline = TODAY.minusDays(5);
+        saveNoticeWithSummary("MAIN", null, "장학", "공지", TODAY, deadline);
 
         mockMvc.perform(get("/api/notices")
                         .header("Authorization", "Bearer " + tokenA))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].dDay").value(lessThan(0)));
+                .andExpect(jsonPath("$.content[0].dDay").doesNotExist())
+                .andExpect(jsonPath("$.content[0].deadlineAt").value(deadline.toString()));
     }
 
     @Test

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
@@ -252,20 +252,21 @@ class NoticeSearchIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("NS-12: deadline 있는 공지는 dDay 정수 반환")
-    void ns12_dDayPresent() throws Exception {
+    @DisplayName("NS-12: deadline 있는 공지는 dDay 없이 deadlineAt 반환")
+    void ns12_deadlineAtPresentWithoutDday() throws Exception {
         LocalDate future = LocalDate.now().plusDays(5);
         saveNoticeWithDeadline("MAIN", null, "국가장학금 마감 안내", LocalDate.now(), future);
 
         mockMvc.perform(get("/api/notices/search").param("q", "국가장학금")
                         .header("Authorization", "Bearer " + tokenA))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].dDay").value(5));
+                .andExpect(jsonPath("$.content[0].dDay").doesNotExist())
+                .andExpect(jsonPath("$.content[0].deadlineAt").value(future.toString()));
     }
 
     @Test
-    @DisplayName("NS-13: deadline 없는 공지는 dDay=null")
-    void ns13_dDayNull() throws Exception {
+    @DisplayName("NS-13: deadline 없는 공지는 dDay 미반환")
+    void ns13_dDayNotReturned() throws Exception {
         saveNotice("MAIN", null, "국가장학금 안내", LocalDate.now());
 
         mockMvc.perform(get("/api/notices/search").param("q", "국가장학금")


### PR DESCRIPTION
## 🔧 작업 내용

공지 상세 / 피드 / 검색 응답에서 `dDay` 필드를 제거하고 D-day 계산 책임을 프론트엔드로 이전했습니다.

- `NoticeDetailResponse` — `Integer dDay` 필드 제거
- `NoticeFeedItem` — `Integer dDay` 필드 제거
- `NoticeSearchItem` — `Integer dDay` 필드 제거 → `String deadlineAt` 추가
- `NoticeFeedService` — `ChronoUnit` 기반 dDay 계산 로직 및 import 제거
- 통합 테스트 3종 — `dDay` 값 검증 → `doesNotExist()` + `deadlineAt` 값 검증으로 변경

## 🔍 동작 방식

**변경 전**
```
백엔드: deadlineAt 조회 → ChronoUnit.DAYS.between(today, deadlineAt) → dDay 계산 → 응답 포함
프론트: dDay 값을 그대로 렌더링
```

**변경 후**
```
백엔드: deadlineAt 조회 → deadlineAt 그대로 응답 포함
프론트: DeadlineBadge 컴포넌트에서 deadlineAt 기준으로 D-day 직접 계산 후 렌더링
```

## 💡 설계 근거

- **D-day는 조회 시각 기준의 계산값이다.**
  백엔드가 응답 시점에 계산한 dDay를 내려줄 경우 응답을 캐싱하면 값이 stale해지는 문제가 생긴다. 프론트에서 렌더링 시점에 계산하면 항상 현재 날짜 기준의 정확한 값이 보장된다.

- **`deadlineAt`을 `String`으로 내려주는 이유.**
  `LocalDate` 그대로 직렬화하면 Jackson이 `[2026, 4, 30]` 배열 형태로 내릴 수 있어 프론트 파싱이 복잡해진다. `toString()`으로 `"2026-04-30"` 포맷을 고정해 프론트가 별도 변환 없이 바로 사용할 수 있도록 했다. 기존 `NoticeDetailResponse`의 `deadlineAt`도 같은 방식이라 일관성을 맞췄다.

- **`doesNotExist()` 어서션을 선택한 이유.**
  `nullValue()`는 키는 존재하되 값이 null인 경우를 검증한다. 이번 변경의 의도는 키 자체를 응답에서 없애는 것이므로 `doesNotExist()`로 JSON 바디에 `"dDay"` 키가 아예 포함되지 않음을 명시적으로 검증했다.

## ✅ 체크리스트

- [ ] 세 DTO record의 필드 순서와 서비스 생성자 호출 순서가 일치하는지 확인
- [ ] `NoticeFeedService`에 `ChronoUnit` import 및 계산 코드가 남아있지 않은지 확인
- [ ] 프로젝트 전체에서 `dDay` 잔여 참조가 없는지 확인 (컨트롤러 `@Schema`, OpenAPI 스펙 파일 포함)
- [ ] `testClasses` 빌드 성공으로 컴파일 이상 없음 확인

## 🔗 연관 이슈

closes #