### PR TITLE
[FIX] 엑세스 토큰 갱신로직 부재

### DIFF
--- a/backend/src/main/java/org/cathori/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/cathori/backend/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/login",
+                                "/api/auth/reissue",
                                 "/api/auth/register",
                                 "/api/auth/email/send",
                                 "/api/auth/email/verify",

--- a/backend/src/main/java/org/cathori/backend/user/UserErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/user/UserErrorCode.java
@@ -9,7 +9,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_VERIFY_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "USER_VERIFY_CODE_EXPIRED", "인증번호가 만료되었습니다"),
     USER_NOT_VERIFIED(HttpStatus.FORBIDDEN, "USER_NOT_VERIFIED", "이메일 인증이 완료되지 않았습니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "존재하지 않는 사용자입니다"),
-    USER_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER_INVALID_PASSWORD", "비밀번호가 올바르지 않습니다");
+    USER_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER_INVALID_PASSWORD", "비밀번호가 올바르지 않습니다"),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_INVALID", "유효하지 않거나 만료된 리프레시 토큰입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/org/cathori/backend/user/api/AuthController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/AuthController.java
@@ -6,10 +6,8 @@ import org.cathori.backend.user.application.AuthService;
 import org.cathori.backend.user.application.EmailVerificationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/api/auth")
@@ -46,5 +44,10 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ReissueResponse> reissue(@RequestBody @Valid ReissueRequest request) {
+        return ResponseEntity.ok(authService.reissue(request));
     }
 }

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/ReissueRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/ReissueRequest.java
@@ -1,0 +1,7 @@
+package org.cathori.backend.user.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+        @NotBlank String refreshToken
+) {}

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/ReissueResponse.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/ReissueResponse.java
@@ -1,0 +1,6 @@
+package org.cathori.backend.user.api.dto;
+
+public record ReissueResponse(
+        String accessToken,
+        String refreshToken
+) {}

--- a/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
@@ -9,7 +9,11 @@ import org.cathori.backend.user.api.dto.LoginRequest;
 import org.cathori.backend.user.api.dto.LoginResponse;
 import org.cathori.backend.user.api.dto.RegisterRequest;
 import org.cathori.backend.user.api.dto.RegisterResponse;
+import org.cathori.backend.user.api.dto.ReissueRequest;
+import org.cathori.backend.user.api.dto.ReissueResponse;
+import org.cathori.backend.user.domain.RefreshToken;
 import org.cathori.backend.user.domain.User;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -23,14 +27,20 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final TagService tagService;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.refresh-token-expiry}")
+    private long refreshTokenExpiry;
 
     public AuthService(VerifiedEmailStore verifiedEmailStore, UserService userService,
-                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil, TagService tagService) {
+                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil, TagService tagService,
+                       RefreshTokenRepository refreshTokenRepository) {
         this.verifiedEmailStore = verifiedEmailStore;
         this.userService = userService;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil = jwtUtil;
         this.tagService = tagService;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     public RegisterResponse register(RegisterRequest request) {
@@ -56,16 +66,37 @@ public class AuthService {
         }
 
         String accessToken = jwtUtil.generateAccessToken(user.getId());
-        String refreshToken = jwtUtil.generateRefreshToken(user.getId());
+        String refreshTokenValue = jwtUtil.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.save(RefreshToken.create(user.getId(), refreshTokenValue, refreshTokenExpiry));
 
         List<TagDto> tags = tagService.getTagsByUserId(user.getId());
 
         return new LoginResponse(
-                accessToken, refreshToken,
+                accessToken, refreshTokenValue,
                 user.getId(), user.getEmail(),
                 user.getMajor(), user.getSecondMajor(),
                 user.getGrade(), user.getEnrollmentStatus(),
                 tags
         );
+    }
+
+    public ReissueResponse reissue(ReissueRequest request) {
+        RefreshToken stored = refreshTokenRepository.findByToken(request.refreshToken())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID));
+
+        if (stored.isExpired()) {
+            refreshTokenRepository.deleteByUserId(stored.getUserId());
+            throw new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        String newAccessToken = jwtUtil.generateAccessToken(stored.getUserId());
+        String newRefreshTokenValue = jwtUtil.generateRefreshToken(stored.getUserId());
+
+        refreshTokenRepository.deleteByUserId(stored.getUserId());
+        refreshTokenRepository.save(RefreshToken.create(stored.getUserId(), newRefreshTokenValue, refreshTokenExpiry));
+
+        return new ReissueResponse(newAccessToken, newRefreshTokenValue);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/user/application/RefreshTokenRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.cathori.backend.user.application;
+
+import org.cathori.backend.user.domain.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void save(RefreshToken refreshToken);
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByUserId(Long userId);
+}

--- a/backend/src/main/java/org/cathori/backend/user/domain/RefreshToken.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/RefreshToken.java
@@ -1,0 +1,48 @@
+package org.cathori.backend.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static RefreshToken create(Long userId, String token, long expiryMs) {
+        RefreshToken rt = new RefreshToken();
+        rt.userId = userId;
+        rt.token = token;
+        rt.expiresAt = LocalDateTime.now().plusSeconds(expiryMs / 1000);
+        return rt;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/RefreshTokenJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/RefreshTokenJpaRepository.java
@@ -1,0 +1,11 @@
+package org.cathori.backend.user.infra;
+
+import org.cathori.backend.user.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByUserId(Long userId);
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/RefreshTokenRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,32 @@
+package org.cathori.backend.user.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.user.application.RefreshTokenRepository;
+import org.cathori.backend.user.domain.RefreshToken;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+    private final RefreshTokenJpaRepository jpaRepository;
+
+    @Override
+    public void save(RefreshToken refreshToken) {
+        jpaRepository.save(refreshToken);
+    }
+
+    @Override
+    public Optional<RefreshToken> findByToken(String token) {
+        return jpaRepository.findByToken(token);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        jpaRepository.deleteByUserId(userId);
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용

RefreshToken 기반 AccessToken 재발급 기능을 구현했다.

- `POST /api/auth/reissue` 엔드포인트 추가
- `refresh_tokens` 테이블 신규 생성 및 `RefreshToken` 엔티티 추가
- 로그인 시 RefreshToken을 DB에 저장하도록 `AuthService.login()` 수정
- Refresh Token Rotation 방식 적용 (재발급 시 기존 토큰 폐기 + 신규 토큰 발급)

---

## 🔍 동작 방식

```
POST /api/auth/reissue { refreshToken }
        ↓
DB에서 토큰 조회
        ↓ 없으면 401
만료 여부 확인 (expiresAt 비교)
        ↓ 만료됐으면 DB에서 삭제 후 401
새 AccessToken + 새 RefreshToken 생성
        ↓
기존 토큰 삭제 → 새 토큰 저장
        ↓
{ accessToken, refreshToken } 응답
```

---

## 💡 설계 근거

**RefreshToken을 DB에 저장하기로 결정한 이유**

기존 설계에서는 RefreshToken을 DB에 저장하지 않는 방향이었다. 로그아웃 빈도가 낮고, 캠퍼스 내부 서비스 특성상 복잡도 감소가 타당하다는 판단이었다.

그러나 재발급 기능을 구현하는 시점에서 DB 저장 없이는 아래 두 가지를 처리할 방법이 없다.

- 탈취된 RefreshToken을 서버에서 무효화할 수단이 없음
- 동일 사용자의 중복 로그인 세션을 통제할 수단이 없음

결국 "재발급 기능 = DB 저장 필수"라는 결론이다. 재발급 없이 발급만 하던 기존 구조에서는 저장이 불필요했지만, 재발급을 지원하는 순간 저장이 전제 조건이 된다.

**Refresh Token Rotation을 적용한 이유**

재발급 시 기존 RefreshToken을 폐기하고 새 토큰을 발급한다. 이렇게 하면 탈취된 토큰으로 재발급을 시도하더라도, 정상 사용자가 먼저 재발급을 받았다면 탈취된 토큰은 이미 무효 상태가 된다. 구현 비용 대비 보안 이득이 명확해서 선택했다.

**`isExpired()`를 도메인 객체에 넣은 이유**

만료 판단 로직(`LocalDateTime.now().isAfter(expiresAt)`)을 서비스 레이어에 두면, RefreshToken이 쓰이는 곳마다 같은 조건을 반복 작성해야 한다. 만료 여부는 RefreshToken 자체의 상태이므로 도메인 객체가 직접 판단하는 것이 맞다고 봤다.

---

## ✅ 체크리스트

- [x] `/api/auth/reissue` SecurityConfig 허용 경로에 추가됨
- [x] 만료된 토큰으로 요청 시 DB 정리 후 401 반환 확인
- [x] 로그인 시 기존 RefreshToken 삭제 후 새 토큰 저장 (중복 방지)
- [x] `REFRESH_TOKEN_INVALID` 에러코드 `UserErrorCode`에 추가됨
- [x] `refresh_tokens` 테이블 DDL 반영 필요 여부 확인

---

## 🔗 연관 이슈

closes #71 