### PR TITLE
[FIX] 누락된 기능 및 부수적인 문제해결

### DIFF
--- a/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
+++ b/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
@@ -28,7 +28,7 @@ public class AlertHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "notice_id", nullable = false)
+    @Column(name = "notice_id", nullable = false, unique = true)
     private Long noticeId;
 
     @Column(nullable = false, length = 20)

--- a/backend/src/main/java/org/cathori/backend/user/api/UserController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/UserController.java
@@ -1,4 +1,29 @@
 package org.cathori.backend.user.api;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.security.CustomUserDetails;
+import org.cathori.backend.user.api.dto.UpdateDeviceTokenRequest;
+import org.cathori.backend.user.application.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @PutMapping("/device-token")
+    public ResponseEntity<Void> updateDeviceToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UpdateDeviceTokenRequest request) {
+        userService.updateDeviceToken(userDetails.getUserId(), request.deviceToken());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
@@ -16,6 +16,7 @@ import org.cathori.backend.user.domain.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -57,6 +58,7 @@ public class AuthService {
         return new RegisterResponse(saved.getId(), saved.getEmail());
     }
 
+    @Transactional
     public LoginResponse login(LoginRequest request) {
         User user = userService.findByEmail(request.email())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
@@ -82,6 +84,7 @@ public class AuthService {
         );
     }
 
+    @Transactional
     public ReissueResponse reissue(ReissueRequest request) {
         RefreshToken stored = refreshTokenRepository.findByToken(request.refreshToken())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID));

--- a/backend/src/main/java/org/cathori/backend/user/application/UserService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/UserService.java
@@ -1,5 +1,7 @@
 package org.cathori.backend.user.application;
 
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.user.UserErrorCode;
 import org.cathori.backend.user.api.dto.RegisterRequest;
 import org.cathori.backend.user.domain.User;
 import org.cathori.backend.user.domain.UserRepository;
@@ -36,5 +38,12 @@ public class UserService {
                         request.major1(), request.major2(),
                         request.grade(), request.status())
         );
+    }
+
+    @Transactional
+    public void updateDeviceToken(Long userId, String deviceToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        user.updateDeviceToken(deviceToken);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/user/domain/User.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/User.java
@@ -44,6 +44,10 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    public void updateDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
+
     public static User create(String email, String encodedPassword,
                               String major, String secondMajor,
                               int grade, String enrollmentStatus) {

--- a/backend/src/main/java/org/cathori/backend/user/domain/User.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/User.java
@@ -39,6 +39,9 @@ public class User {
     private String deviceToken;
 
     @Column(nullable = false)
+    private int dailyAlertLimit = 1;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     public static User create(String email, String encodedPassword,


### PR DESCRIPTION
## 🔧 작업 내용

- `PUT /api/users/device-token` 엔드포인트 구현
- `User` 엔티티에 `dailyAlertLimit` 컬럼 및 `updateDeviceToken()` 메서드 추가
- `AlertHistory.noticeId`에 unique 제약 추가

---

## 🔍 동작 방식

```mermaid
graph TD
    A([클라이언트]) -->|PUT /api/users/device-token| B[JwtFilter]
    B -->|userId 추출| C[UserController]
    C --> D[UserService.updateDeviceToken]
    D -->|userId로 조회| E[(DB)]
    E -->|없음| F([404 USER_NOT_FOUND])
    E -->|있음| G[user.updateDeviceToken]
```

## 💡 설계 근거

**204 No Content 선택**  
클라이언트가 이미 토큰 값을 알고 있고 "저장됐다"는 확인만 필요하므로 바디 없이 204로 응답했다.

**`AlertHistory.noticeId`에 unique 제약 추가**  
동일 공지에 대한 중복 발송을 DB 레벨에서 보장하기 위함. 운영스펙에 명시된 제약 조건이었는데 엔티티에 누락되어 있어 이번에 함께 반영했다.

**`updateDeviceToken()`을 엔티티 메서드로 분리**  
필드를 직접 setter로 노출하지 않고 의도를 드러내는 메서드로 감쌌다.

---

## ✅ 체크리스트

- [x] 인증 없는 요청 시 401 확인
- [x] 존재하지 않는 userId로 요청 시 404 확인
- [x] deviceToken 비어있을 때 400 확인
- [x] 정상 요청 시 204 확인
- [x] 재호출 시 토큰 덮어쓰기 확인

---

## 🔗 연관 이슈

closes #76 