### PR TITLE
[FEAT] 알림 발송 재설계

### DIFF
--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
@@ -3,22 +3,18 @@ package org.cathori.backend.alert.application;
 import org.cathori.backend.alert.domain.AlertHistory;
 
 import java.util.List;
-import java.util.Set;
 
-/**
- * 알림 발송 이력 저장소의 기능 명세입니다.
- *
- * AlertService가 이력을 조회하거나 저장할 때 사용하는 창구입니다.
- * 실제 데이터베이스 접근은 AlertHistoryRepositoryImpl이 담당합니다.
- */
 public interface AlertHistoryRepository {
 
-    /** 지금까지 알림을 발송한 적 있는 공지사항 ID 목록을 반환합니다. (중복 발송 방지에 사용) */
-    Set<Long> findAllSentNoticeIds();
+    void saveAll(List<AlertHistory> logs);
 
-    /** 발송에 실패했고 재시도 횟수가 3회 미만인 이력 목록을 반환합니다. */
     List<AlertHistory> findFailedForRetry();
 
-    /** 알림 발송 이력을 저장하거나 갱신합니다. */
-    AlertHistory save(AlertHistory history);
+    AlertHistory save(AlertHistory log);
+
+    void markSuccessForUsers(Long noticeId, List<Long> userIds);
+
+    void markFailedForUsers(Long noticeId, List<Long> userIds);
+
+    void incrementRetryForUsers(Long noticeId, List<Long> userIds);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertResultWriter.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertResultWriter.java
@@ -1,0 +1,43 @@
+package org.cathori.backend.alert.application;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AlertResultWriter {
+
+    private final AlertHistoryRepository alertHistoryRepository;
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public void persistDispatchResult(Notice notice, List<Long> successIds, List<Long> failedIds) {
+        alertHistoryRepository.markSuccessForUsers(notice.getId(), successIds);
+        alertHistoryRepository.markFailedForUsers(notice.getId(), failedIds);
+        notice.markAlertDispatched();
+        noticeRepository.save(notice);
+    }
+
+    @Transactional
+    public void persistDispatchFailure(Notice notice, List<Long> allUserIds) {
+        alertHistoryRepository.markFailedForUsers(notice.getId(), allUserIds);
+        notice.markAlertDispatched();
+        noticeRepository.save(notice);
+    }
+
+    @Transactional
+    public void persistRetryResult(Long noticeId, List<Long> successIds, List<Long> failedIds) {
+        alertHistoryRepository.markSuccessForUsers(noticeId, successIds);
+        alertHistoryRepository.incrementRetryForUsers(noticeId, failedIds);
+    }
+
+    @Transactional
+    public void persistRetryFailure(Long noticeId, List<Long> userIds) {
+        alertHistoryRepository.incrementRetryForUsers(noticeId, userIds);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
@@ -11,118 +11,118 @@ import org.cathori.backend.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-/**
- * 공지사항 푸시 알림 발송을 담당하는 서비스입니다.
- *
- * 주요 역할:
- *   1. 아직 알림을 보내지 않은 새 공지를 찾아 관심 태그가 일치하는 사용자에게 앱 푸시 알림을 보냅니다.
- *   2. 발송에 실패한 알림을 주기적으로 재시도합니다. (최대 3회)
- *   3. 모든 발송 시도의 결과(성공 / 부분 성공 / 실패)를 이력으로 기록합니다.
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlertService {
 
     private final AlertHistoryRepository alertHistoryRepository;
+    private final AlertResultWriter alertResultWriter;
     private final NoticeRepository noticeRepository;
     private final UserRepository userRepository;
     private final FcmPort fcmPort;
 
-    /**
-     * 새 공지에 대한 푸시 알림을 일괄 발송합니다.
-     *
-     * 동작 순서:
-     *   1. 이미 알림을 보낸 공지 목록을 조회합니다.
-     *   2. 아직 한 번도 알림을 보내지 않은 공지만 추려냅니다.
-     *   3. 각 공지의 제목과 일치하는 태그를 등록한 사용자에게 푸시 알림을 발송합니다.
-     *
-     * 이 메서드는 스케줄러에 의해 주기적으로 자동 실행됩니다.
-     */
     public void dispatchAlerts() {
-        Set<Long> sentIds = alertHistoryRepository.findAllSentNoticeIds();
-        List<Notice> unsentNotices = sentIds.isEmpty()
-                ? noticeRepository.findAll()
-                : noticeRepository.findUnsentNotices(sentIds);
-
+        List<Notice> unsentNotices = noticeRepository.findByAlertDispatchedFalse();
         if (unsentNotices.isEmpty()) {
             log.info("미발송 공지 없음");
             return;
         }
-
         log.info("미발송 공지 {}건 발송 시작", unsentNotices.size());
         for (Notice notice : unsentNotices) {
             dispatchForNotice(notice);
         }
     }
 
-    /**
-     * 공지 하나에 대해 알림 수신 대상자를 추려 푸시 알림을 발송하고 결과를 저장합니다.
-     *
-     * - 공지 제목의 키워드와 일치하는 태그를 등록한 사용자만 발송 대상이 됩니다.
-     * - 기기 토큰이 없는 사용자(앱 미설치 또는 알림 비허용)는 발송 대상에서 제외됩니다.
-     * - 발송 도중 오류가 발생해도 다른 공지의 발송에는 영향을 주지 않습니다.
-     */
     private void dispatchForNotice(Notice notice) {
-        List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
-                .stream()
-                .filter(u -> isEligibleForNotice(u, notice))
-                .map(User::getDeviceToken)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+        List<UserToken> targets = buildTargets(notice);
 
-        if (tokens.isEmpty()) return;
+        if (targets.isEmpty()) {
+            notice.markAlertDispatched();
+            noticeRepository.save(notice);
+            return;
+        }
 
+        // PENDING row 일괄 INSERT
+        List<AlertHistory> pendingLogs = targets.stream()
+                .map(t -> AlertHistory.create(t.userId(), notice.getId()))
+                .toList();
+        alertHistoryRepository.saveAll(pendingLogs);
+
+        // FCM HTTP 호출 — @Transactional 범위 밖
+        List<UserFcmResult> results;
         try {
-            FcmBatchResult result = fcmPort.sendMulticast(tokens, "Cathori 새 공지", notice.getTitle(), notice.getId());
-            alertHistoryRepository.save(toAlertHistory(notice.getId(), result));
-            log.info("FCM 발송 완료. noticeId={}, success={}, fail={}",
-                    notice.getId(), result.successCount(), result.failureCount());
+            results = fcmPort.sendMulticast(targets, "Cathori 새 공지", notice.getTitle(), notice.getId());
         } catch (Exception e) {
             log.error("FCM 발송 실패. noticeId={}", notice.getId(), e);
-            alertHistoryRepository.save(AlertHistory.failed(notice.getId()));
+            List<Long> allUserIds = targets.stream().map(UserToken::userId).toList();
+            alertResultWriter.persistDispatchFailure(notice, allUserIds);
+            return;
         }
+
+        List<Long> successIds = results.stream().filter(UserFcmResult::success).map(UserFcmResult::userId).toList();
+        List<Long> failedIds = results.stream().filter(r -> !r.success()).map(UserFcmResult::userId).toList();
+        alertResultWriter.persistDispatchResult(notice, successIds, failedIds);
+        log.info("FCM 발송 완료. noticeId={}, success={}, fail={}", notice.getId(), successIds.size(), failedIds.size());
     }
 
-    /**
-     * 발송 결과를 이력 상태로 변환합니다.
-     *
-     * - 전원 수신 성공  → SUCCESS (성공)
-     * - 일부만 수신 성공 → PARTIAL_SUCCESS (부분 성공)
-     * - 전원 수신 실패  → FAILED (실패)
-     */
-    private AlertHistory toAlertHistory(Long noticeId, FcmBatchResult result) {
-        if (result.failureCount() == 0) return AlertHistory.success(noticeId);
-        if (result.successCount() > 0) return AlertHistory.partialSuccess(noticeId);
-        return AlertHistory.failed(noticeId);
-    }
-
-    /**
-     * 이전에 실패한 알림 발송을 재시도합니다.
-     *
-     * - FAILED 상태이고 재시도 횟수가 3회 미만인 이력만 대상으로 합니다.
-     * - 재시도에 성공하면 해당 이력의 상태가 SUCCESS로 변경됩니다.
-     * - 재시도에도 실패하면 재시도 횟수가 1 증가하며, 3회 소진 시 더 이상 재시도하지 않습니다.
-     *
-     * 이 메서드는 스케줄러에 의해 주기적으로 자동 실행됩니다.
-     */
     public void retryFailedAlerts() {
-        List<AlertHistory> failedList = alertHistoryRepository.findFailedForRetry();
-        if (failedList.isEmpty()) return;
+        List<AlertHistory> failedLogs = alertHistoryRepository.findFailedForRetry();
+        if (failedLogs.isEmpty()) return;
 
-        log.info("FCM 재시도 {}건", failedList.size());
-        for (AlertHistory history : failedList) {
-            retryAlert(history);
+        log.info("FCM 재시도 {}건", failedLogs.size());
+
+        Map<Long, List<AlertHistory>> byNotice = failedLogs.stream()
+                .collect(Collectors.groupingBy(AlertHistory::getNoticeId));
+
+        for (Map.Entry<Long, List<AlertHistory>> entry : byNotice.entrySet()) {
+            retryForNotice(entry.getKey(), entry.getValue());
         }
     }
 
-    /**
-     * MAIN 공지는 전체 허용, DEPARTMENT 공지는 사용자의 제1·제2전공과 source_id가 일치하는 경우만 허용합니다.
-     */
+    private void retryForNotice(Long noticeId, List<AlertHistory> logs) {
+        Notice notice = noticeRepository.findById(noticeId).orElse(null);
+        if (notice == null) return;
+
+        List<UserToken> targets = logs.stream()
+                .map(l -> {
+                    User user = userRepository.findById(l.getUserId()).orElse(null);
+                    if (user == null || user.getDeviceToken() == null) return null;
+                    return new UserToken(l.getUserId(), user.getDeviceToken());
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (targets.isEmpty()) return;
+
+        List<UserFcmResult> results;
+        try {
+            results = fcmPort.sendMulticast(targets, "Cathori 새 공지", notice.getTitle(), noticeId);
+        } catch (Exception e) {
+            log.error("FCM 재시도 실패. noticeId={}", noticeId, e);
+            List<Long> userIds = targets.stream().map(UserToken::userId).toList();
+            alertResultWriter.persistRetryFailure(noticeId, userIds);
+            return;
+        }
+
+        List<Long> successIds = results.stream().filter(UserFcmResult::success).map(UserFcmResult::userId).toList();
+        List<Long> failedIds = results.stream().filter(r -> !r.success()).map(UserFcmResult::userId).toList();
+        alertResultWriter.persistRetryResult(noticeId, successIds, failedIds);
+    }
+
+    private List<UserToken> buildTargets(Notice notice) {
+        return userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
+                .stream()
+                .filter(u -> isEligibleForNotice(u, notice))
+                .filter(u -> u.getDeviceToken() != null)
+                .map(u -> new UserToken(u.getId(), u.getDeviceToken()))
+                .toList();
+    }
+
     private boolean isEligibleForNotice(User user, Notice notice) {
         if ("MAIN".equals(notice.getSourceType())) return true;
         String sourceId = notice.getSourceId();
@@ -132,39 +132,5 @@ public class AlertService {
         if (secondMajor == null || "전공심화".equals(secondMajor)) return false;
         String secondMajorCode = DepartmentSource.findEnumNameByDisplayName(secondMajor);
         return sourceId.equals(secondMajorCode);
-    }
-
-    /**
-     * 실패 이력 하나에 대해 알림 재발송을 시도하고 결과를 갱신합니다.
-     *
-     * - 원본 공지가 삭제된 경우에는 재시도 없이 조용히 건너뜁니다.
-     * - 재발송 성공 여부에 따라 이력 상태 또는 재시도 횟수가 업데이트됩니다.
-     */
-    private void retryAlert(AlertHistory history) {
-        Notice notice = noticeRepository.findById(history.getNoticeId()).orElse(null);
-        if (notice == null) return;
-
-        List<String> tokens = userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
-                .stream()
-                .filter(u -> isEligibleForNotice(u, notice))
-                .map(User::getDeviceToken)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
-        if (tokens.isEmpty()) return;
-
-        try {
-            FcmBatchResult result = fcmPort.sendMulticast(tokens, "Cathori 새 공지", notice.getTitle(), notice.getId());
-            if (result.failureCount() == 0) {
-                history.markSuccess();
-            } else {
-                history.incrementRetry();
-            }
-        } catch (Exception e) {
-            log.error("FCM 재시도 실패. historyId={}", history.getId(), e);
-            history.incrementRetry();
-        }
-
-        alertHistoryRepository.save(history);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/FcmPort.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/FcmPort.java
@@ -2,22 +2,7 @@ package org.cathori.backend.alert.application;
 
 import java.util.List;
 
-/**
- * 앱 푸시 알림(FCM) 발송 기능의 명세입니다.
- *
- * FCM(Firebase Cloud Messaging)은 앱이 설치된 사용자의 기기에 알림을 전송하는 서비스입니다.
- * 실제 FCM 통신은 FcmAdapter가 담당하며, 이 인터페이스는 그 기능을 추상화합니다.
- */
 public interface FcmPort {
 
-    /**
-     * 여러 사용자에게 동시에 푸시 알림을 발송합니다.
-     *
-     * @param deviceTokens 알림을 받을 사용자 기기 토큰 목록 (앱 설치 시 발급되는 고유 식별자)
-     * @param title        알림 제목
-     * @param body         알림 본문 (공지 제목)
-     * @param noticeId     해당 공지사항 ID (앱에서 공지 상세 화면으로 이동 시 사용)
-     * @return             성공/실패 건수를 담은 발송 결과
-     */
-    FcmBatchResult sendMulticast(List<String> deviceTokens, String title, String body, Long noticeId);
+    List<UserFcmResult> sendMulticast(List<UserToken> targets, String title, String body, Long noticeId);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/UserFcmResult.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/UserFcmResult.java
@@ -1,0 +1,4 @@
+package org.cathori.backend.alert.application;
+
+public record UserFcmResult(Long userId, boolean success) {
+}

--- a/backend/src/main/java/org/cathori/backend/alert/application/UserToken.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/UserToken.java
@@ -1,0 +1,4 @@
+package org.cathori.backend.alert.application;
+
+public record UserToken(Long userId, String token) {
+}

--- a/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
+++ b/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
@@ -7,19 +7,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/**
- * 공지사항 알림 발송 이력을 나타내는 데이터 모델입니다.
- *
- * 알림이 발송될 때마다 이 이력이 생성되며, 발송 결과(성공/부분 성공/실패)와
- * 재시도 횟수가 기록됩니다. 관리자는 이 데이터를 통해 알림 발송 현황을 파악할 수 있습니다.
- *
- * status 값의 의미:
- *   - SUCCESS        : 대상 사용자 전원에게 알림이 정상 전달됨
- *   - PARTIAL_SUCCESS: 일부 사용자에게만 알림이 전달됨
- *   - FAILED         : 대상 사용자 전원에게 알림 전달이 실패함
- */
 @Entity
-@Table(name = "alert_history")
+@Table(name = "alert_history",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "notice_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AlertHistory {
@@ -28,11 +18,17 @@ public class AlertHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "notice_id", nullable = false, unique = true)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "notice_id", nullable = false)
     private Long noticeId;
 
-    @Column(nullable = false, length = 20)
-    private String status;
+    @Column(name = "alarm_status", nullable = false, length = 10)
+    private String alarmStatus;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
 
     @Column(name = "retry_count", nullable = false)
     private int retryCount;
@@ -40,38 +36,26 @@ public class AlertHistory {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
-    public static AlertHistory success(Long noticeId) {
-        return create(noticeId, "SUCCESS");
-    }
-
-    public static AlertHistory partialSuccess(Long noticeId) {
-        return create(noticeId, "PARTIAL_SUCCESS");
-    }
-
-    public static AlertHistory failed(Long noticeId) {
-        return create(noticeId, "FAILED");
-    }
-
-    private static AlertHistory create(Long noticeId, String status) {
-        AlertHistory history = new AlertHistory();
-        history.noticeId = noticeId;
-        history.status = status;
-        history.retryCount = 0;
-        history.createdAt = LocalDateTime.now();
-        history.updatedAt = LocalDateTime.now();
-        return history;
+    public static AlertHistory create(Long userId, Long noticeId) {
+        AlertHistory h = new AlertHistory();
+        h.userId = userId;
+        h.noticeId = noticeId;
+        h.alarmStatus = "PENDING";
+        h.isRead = false;
+        h.retryCount = 0;
+        h.createdAt = LocalDateTime.now();
+        return h;
     }
 
     public void markSuccess() {
-        this.status = "SUCCESS";
-        this.updatedAt = LocalDateTime.now();
+        this.alarmStatus = "SUCCESS";
+    }
+
+    public void markFailed() {
+        this.alarmStatus = "FAILED";
     }
 
     public void incrementRetry() {
         this.retryCount++;
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
@@ -2,18 +2,26 @@ package org.cathori.backend.alert.infra;
 
 import org.cathori.backend.alert.domain.AlertHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Set;
 
 public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, Long> {
 
-    /** 알림 발송 이력이 존재하는 모든 공지사항 ID를 조회합니다. */
-    @Query("SELECT ah.noticeId FROM AlertHistory ah")
-    Set<Long> findAllSentNoticeIds();
-
-    /** 상태가 FAILED이고 재시도 횟수가 3회 미만인 이력을 조회합니다. */
-    @Query("SELECT ah FROM AlertHistory ah WHERE ah.status = 'FAILED' AND ah.retryCount < 3")
+    @Query("SELECT ah FROM AlertHistory ah WHERE ah.alarmStatus = 'FAILED' AND ah.retryCount <= 3")
     List<AlertHistory> findFailedForRetry();
+
+    @Modifying
+    @Query("UPDATE AlertHistory ah SET ah.alarmStatus = 'SUCCESS' WHERE ah.noticeId = :noticeId AND ah.userId IN :userIds")
+    void markSuccessForUsers(@Param("noticeId") Long noticeId, @Param("userIds") List<Long> userIds);
+
+    @Modifying
+    @Query("UPDATE AlertHistory ah SET ah.alarmStatus = 'FAILED' WHERE ah.noticeId = :noticeId AND ah.userId IN :userIds")
+    void markFailedForUsers(@Param("noticeId") Long noticeId, @Param("userIds") List<Long> userIds);
+
+    @Modifying
+    @Query("UPDATE AlertHistory ah SET ah.retryCount = ah.retryCount + 1 WHERE ah.noticeId = :noticeId AND ah.userId IN :userIds")
+    void incrementRetryForUsers(@Param("noticeId") Long noticeId, @Param("userIds") List<Long> userIds);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
@@ -5,14 +5,7 @@ import org.cathori.backend.alert.domain.AlertHistory;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 
-/**
- * AlertHistoryRepository 인터페이스의 실제 구현체입니다.
- *
- * AlertService는 이 클래스를 직접 참조하지 않고 AlertHistoryRepository 인터페이스를 통해 접근합니다.
- * 실제 데이터베이스 쿼리는 AlertHistoryJpaRepository에 위임합니다.
- */
 @Repository
 public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
 
@@ -23,8 +16,8 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     }
 
     @Override
-    public Set<Long> findAllSentNoticeIds() {
-        return jpaRepository.findAllSentNoticeIds();
+    public void saveAll(List<AlertHistory> logs) {
+        jpaRepository.saveAll(logs);
     }
 
     @Override
@@ -33,7 +26,25 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     }
 
     @Override
-    public AlertHistory save(AlertHistory history) {
-        return jpaRepository.save(history);
+    public AlertHistory save(AlertHistory log) {
+        return jpaRepository.save(log);
+    }
+
+    @Override
+    public void markSuccessForUsers(Long noticeId, List<Long> userIds) {
+        if (userIds.isEmpty()) return;
+        jpaRepository.markSuccessForUsers(noticeId, userIds);
+    }
+
+    @Override
+    public void markFailedForUsers(Long noticeId, List<Long> userIds) {
+        if (userIds.isEmpty()) return;
+        jpaRepository.markFailedForUsers(noticeId, userIds);
+    }
+
+    @Override
+    public void incrementRetryForUsers(Long noticeId, List<Long> userIds) {
+        if (userIds.isEmpty()) return;
+        jpaRepository.incrementRetryForUsers(noticeId, userIds);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/alert/infra/FcmAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/FcmAdapter.java
@@ -2,40 +2,39 @@ package org.cathori.backend.alert.infra;
 
 import com.google.firebase.messaging.*;
 import lombok.extern.slf4j.Slf4j;
-import org.cathori.backend.alert.application.FcmBatchResult;
 import org.cathori.backend.alert.application.FcmPort;
+import org.cathori.backend.alert.application.UserFcmResult;
+import org.cathori.backend.alert.application.UserToken;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Google FCM 서버와 실제로 통신하여 푸시 알림을 발송하는 구현체입니다.
- *
- * 여러 사용자에게 동시에 알림을 보내는 멀티캐스트 방식을 사용하며,
- * 알림 본문과 함께 공지사항 ID를 앱에 전달하여 상세 화면으로 이동할 수 있도록 합니다.
- */
 @Slf4j
 @Component
 public class FcmAdapter implements FcmPort {
 
-    /**
-     * 여러 사용자 기기에 동시에 푸시 알림을 발송합니다.
-     *
-     * FCM 서버 오류 발생 시 예외를 던져 AlertService가 실패 이력을 기록하도록 합니다.
-     */
     @Override
-    public FcmBatchResult sendMulticast(List<String> deviceTokens, String title, String body, Long noticeId) {
+    public List<UserFcmResult> sendMulticast(List<UserToken> targets, String title, String body, Long noticeId) {
+        List<String> tokens = targets.stream().map(UserToken::token).toList();
+
         MulticastMessage message = MulticastMessage.builder()
-                .addAllTokens(deviceTokens)
+                .addAllTokens(tokens)
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
                         .build())
                 .putData("noticeId", String.valueOf(noticeId))
                 .build();
+
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
-            return new FcmBatchResult(response.getSuccessCount(), response.getFailureCount());
+            List<SendResponse> responses = response.getResponses();
+            List<UserFcmResult> results = new ArrayList<>(responses.size());
+            for (int i = 0; i < responses.size(); i++) {
+                results.add(new UserFcmResult(targets.get(i).userId(), responses.get(i).isSuccessful()));
+            }
+            return results;
         } catch (FirebaseMessagingException e) {
             throw new RuntimeException("FCM 멀티캐스트 발송 실패", e);
         }

--- a/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
@@ -69,12 +69,19 @@ public class Notice {
     @Column(nullable = false)
     private Long viewCount = 0L;
 
+    @Column(name = "alert_dispatched", nullable = false)
+    private boolean alertDispatched = false;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    public void markAlertDispatched() {
+        this.alertDispatched = true;
     }
 
     public List<String> getImageUrls() {

--- a/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
@@ -26,6 +25,5 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     @Query("SELECT n FROM Notice n WHERE n.aiSummaryStatus IN :statuses ORDER BY n.id ASC")
     List<Notice> findTop15ForSummary(@Param("statuses") List<String> statuses, Pageable pageable);
 
-    @Query("SELECT n FROM Notice n WHERE n.id NOT IN :sentIds")
-    List<Notice> findUnsentNotices(@Param("sentIds") Set<Long> sentIds);
+    List<Notice> findByAlertDispatchedFalse();
 }


### PR DESCRIPTION
## 🔧 작업 내용

알림 발송 이력을 **공지 단위**에서 **사용자-공지 쌍 단위**로 전면 개편했다.

기존에는 공지 하나당 이력 1개를 기록하는 구조였다. 예를 들어 10명에게 알림을 보내서 3명이 실패하면 `PARTIAL_SUCCESS` 하나만 남는 방식이었다. 이 구조에서는 어떤 사용자가 실패했는지 알 수 없어서 재시도 시 이미 성공한 사용자에게도 중복 발송될 가능성이 있었다.

이번 개편으로 사용자별로 이력 행이 생성된다. 10명에게 보내면 10개의 행이 생기고, 각 행이 성공/실패를 개별로 기록한다. 덕분에 재시도 시 실패한 사용자에게만 정확하게 재발송할 수 있게 됐다.

**주요 변경 항목**
- `alert_history` 테이블: 사용자별 이력 행 관리로 전환, `userId` 컬럼 추가, 상태값 단순화(`PENDING / SUCCESS / FAILED`), 읽음 여부(`isRead`) 컬럼 추가
- `notice` 테이블: 알림 발송 완료 여부를 나타내는 `alertDispatched` 컬럼 추가 — 미발송 공지 조회 방식 개선에 사용
- FCM 발송 결과를 사용자별로 처리하도록 내부 로직 전면 수정

---

## 🔍 동작 방식

**정기 발송 흐름 (dispatchAlerts)**
```
아직 알림을 보내지 않은 공지 조회 (alertDispatched = false)
  → 각 공지별로 처리
     1. 공지 제목과 태그가 일치하는 사용자 추출 (전공 조건 + 기기 토큰 보유 여부 확인)
     2. 대상 사용자별 PENDING 이력 일괄 생성
     3. FCM 멀티캐스트 발송
     4. 사용자별 성공 / 실패 분류
     5. 이력 상태 반영 + 공지 발송 완료 처리
```

**재시도 흐름 (retryFailedAlerts)**
```
FAILED 상태이고 재시도 3회 이하인 이력 조회
  → 공지 ID 기준으로 그룹핑
  → 각 그룹별로 처리
     1. 실패 이력의 userId로 사용자 조회 → 기기 토큰 수집
     2. FCM 재발송
     3. 성공 이력은 SUCCESS 처리, 실패 이력은 retryCount +1
```

---

## 💡 설계 근거

**공지 단위 → 사용자-공지 쌍 단위 이력 전환**
기존 구조는 재시도 시점에 발송 실패한 사용자를 특정할 수 없어서, 대상자 전체를 다시 조회해 재발송하는 수밖에 없었다. `(user_id, notice_id)` 쌍 기반으로 이력을 관리하면 실패한 사용자만 정확히 추려서 재시도할 수 있다.

**PENDING row 선삽입 후 FCM 호출**
FCM은 트랜잭션 범위 밖에서 호출해야 하는 외부 HTTP 요청이다. FCM 호출 전에 PENDING 상태로 row를 먼저 저장해두면, 발송 중 예외가 발생하더라도 대상 사용자 목록이 DB에 보존돼 재시도 대상 파악이 가능하다.

**AlertResultWriter 분리**
FCM 결과를 DB에 반영하는 쓰기 로직을 `AlertService`에서 별도 클래스로 분리했다. 알림 이력 반영과 `Notice.markAlertDispatched()` 호출을 하나의 트랜잭션으로 묶기 위해 `NoticeRepository` 접근이 필요했고, 이 책임을 `AlertResultWriter`에 위임했다.

**`NOT IN` 쿼리 → `alertDispatched` 플래그**
기존에는 발송 이력이 있는 모든 공지 ID를 메모리에 올린 뒤 `NOT IN` 조건으로 미발송 공지를 걸러냈다. 이력이 쌓일수록 쿼리가 커지는 구조다. `alertDispatched` 컬럼 인덱스 조회로 대체해 이력 누적에 무관하게 일정한 성능을 유지하도록 했다.

---

## ✅ 체크리스트

> PR 올리기 전 스스로 확인한 항목을 작성

- [x] 로컬 테스트 코드 통과 확인

## 🔗 연관 이슈

closes #80 