### PR TITLE
[FEAT] 토큰 등록과 푸시 인프라 설정 및 알림 리스트 구현 

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.env
 
 ### STS ###
 .apt_generated
@@ -36,4 +37,4 @@ out/
 ### VS Code ###
 .vscode/
 
-src/main/resources/cathori-firebase.json
+src/main/resources/*.json

--- a/backend/src/main/java/org/cathori/backend/user/api/UserController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/UserController.java
@@ -7,6 +7,7 @@ import org.cathori.backend.user.api.dto.UpdateDeviceTokenRequest;
 import org.cathori.backend.user.application.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +25,13 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UpdateDeviceTokenRequest request) {
         userService.updateDeviceToken(userDetails.getUserId(), request.deviceToken());
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/device-token")
+    public ResponseEntity<Void> clearDeviceToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.clearDeviceToken(userDetails.getUserId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/org/cathori/backend/user/api/dto/UpdateDeviceTokenRequest.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/dto/UpdateDeviceTokenRequest.java
@@ -1,0 +1,15 @@
+package org.cathori.backend.user.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 디바이스 토큰 등록/갱신 요청 바디입니다. (PUT /api/users/device-token)
+ *
+ * 비어 있으면 Bean Validation이 INVALID_INPUT(400)으로 응답합니다.
+ */
+public record UpdateDeviceTokenRequest(
+        @Schema(example = "fcm_device_token_string")
+        @NotBlank
+        String deviceToken
+) {}

--- a/backend/src/main/java/org/cathori/backend/user/application/UserService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/UserService.java
@@ -46,4 +46,11 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         user.updateDeviceToken(deviceToken);
     }
+
+    @Transactional
+    public void clearDeviceToken(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        user.clearDeviceToken();
+    }
 }

--- a/backend/src/main/java/org/cathori/backend/user/domain/User.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/User.java
@@ -48,6 +48,11 @@ public class User {
         this.deviceToken = deviceToken;
     }
 
+    /** 로그아웃 등으로 기기 토큰을 반납합니다. 이후 이 사용자는 알림 대상에서 제외됩니다. */
+    public void clearDeviceToken() {
+        this.deviceToken = null;
+    }
+
     public static User create(String email, String encodedPassword,
                               String major, String secondMajor,
                               int grade, String enrollmentStatus) {

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -17,6 +17,7 @@ expo-env.d.ts
 *.p12
 *.key
 *.mobileprovision
+google-services.json
 
 # Metro
 .metro-health-check*

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "frontend",
-    "slug": "frontend",
+    "name": "cathori",
+    "slug": "cathori",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "frontend",
+    "scheme": "cathori",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -9,7 +9,8 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.catholic-university.cathori"
     },
     "android": {
       "adaptiveIcon": {
@@ -19,7 +20,9 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "package": "com.catholic_university.cathori",
+      "googleServicesFile": "./google-services.json"
     },
     "web": {
       "output": "static",
@@ -37,6 +40,12 @@
           "dark": {
             "backgroundColor": "#000000"
           }
+        }
+      ],
+      [
+        "expo-notifications",
+        {
+          "color": "#00288C"
         }
       ]
     ],

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -41,6 +41,7 @@ import {
 } from 'react-native';
 
 import { Colors } from '@/src/constants/colors';
+import { unregisterDeviceToken } from '@/src/services/pushToken';
 import { MainHeader } from '@/src/shared/components';
 import { useAuthStore } from '@/src/store/useAuthStore';
 
@@ -158,7 +159,14 @@ const checkNotificationPermission = async () => {
         {
           text: '로그아웃',
           style: 'destructive',
-          onPress: () => {
+          onPress: async () => {
+            // 토큰 반납(DELETE)은 JWT가 아직 유효할 때 먼저 호출해야 한다.
+            // clearAuth()가 먼저면 토큰이 사라져 401이 된다. 실패해도 로그아웃은 진행.
+            try {
+              await unregisterDeviceToken();
+            } catch (e) {
+              console.warn('[push] 토큰 반납 실패:', e);
+            }
             clearAuth();
             router.replace('/login');
           },

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import 'react-native-reanimated';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+import { usePushNotifications } from '@/src/features/notifications';
 import { useAuthStore } from '@/src/store/useAuthStore';
 
 // SplashScreen을 수동 제어 — rehydrate 완료 전까지 유지
@@ -94,6 +95,8 @@ export default function RootLayout() {
 function RootLayoutNav() {
   // 인증 상태 기반 라우팅 가드 활성화
   useProtectedRoute();
+  // 푸시 토큰 동기화(로그인 시 등록) + 알림 탭 → 공지 상세 네비게이션
+  usePushNotifications();
 
   // SafeAreaProvider — react-native-safe-area-context의 inset 컨텍스트를 트리에 주입.
   // 트리 상단에 Provider가 없으면 useSafeAreaInsets() - SafeAreaView가 inset을 0으로
@@ -106,6 +109,11 @@ function RootLayoutNav() {
           {/* 공지 상세 화면 */}
           <Stack.Screen
             name="notice/[id]"
+            options={{ headerShown: false, animation: 'slide_from_right' }}
+          />
+          {/* 알림 리스트 화면 */}
+          <Stack.Screen
+            name="notification/index"
             options={{ headerShown: false, animation: 'slide_from_right' }}
           />
           {/* 인증 화면 — 로그인 */}

--- a/frontend/app/notification/index.tsx
+++ b/frontend/app/notification/index.tsx
@@ -1,0 +1,119 @@
+/**
+ * 알림 리스트 화면 — app/notification/index.tsx
+ *
+ * 진입: MainHeader의 알림(종) 아이콘 탭
+ *
+ * 구조:
+ * ┌─ SubHeader ──────────────────────────────┐
+ * │ ←              알림                       │
+ * ├──────────────────────────────────────────┤
+ * │ [#매칭태그]                      [D-day] │
+ * │ 공지 제목                                 │
+ * │ 2026-06-02                                │
+ * │ … (최근순, 커서 무한 스크롤)              │
+ * └──────────────────────────────────────────┘
+ *
+ * - 데이터: GET /api/notifications (useNotifications, 커서 페이지네이션)
+ * - 카드 탭 → 공지 상세(/notice/{noticeId})
+ */
+
+import React from 'react';
+import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Colors } from '@/src/constants/colors';
+import { NotificationItem, useNotifications } from '@/src/features/notifications';
+import { EmptyState, SubHeader } from '@/src/shared/components';
+
+export default function NotificationScreen() {
+  const insets = useSafeAreaInsets();
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    isRefetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useNotifications();
+
+  // 커서 페이지네이션 응답(pages)을 단일 목록으로 평탄화
+  const notifications = data?.pages.flatMap((page) => page.alerts) ?? [];
+
+  const contentPadding = {
+    paddingTop: insets.top + 64 + 16,
+    paddingBottom: insets.bottom + 16,
+  };
+
+  const handleEndReached = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  return (
+    <View style={styles.screen}>
+      <SubHeader title="알림" />
+
+      {isLoading ? (
+        <View style={[styles.center, contentPadding]}>
+          <ActivityIndicator color={Colors.primary} />
+        </View>
+      ) : isError ? (
+        <View style={[styles.center, contentPadding]}>
+          <EmptyState
+            message="알림을 불러오지 못했습니다."
+            iconName="alert-circle"
+          />
+        </View>
+      ) : (
+        <FlatList
+          data={notifications}
+          keyExtractor={(item) => String(item.alertHistoryId)}
+          renderItem={({ item }) => <NotificationItem notification={item} />}
+          contentContainerStyle={[styles.listContent, contentPadding]}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          showsVerticalScrollIndicator={false}
+          onRefresh={refetch}
+          refreshing={isRefetching}
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={
+            isFetchingNextPage ? (
+              <ActivityIndicator
+                style={styles.footerLoader}
+                color={Colors.primary}
+              />
+            ) : null
+          }
+          ListEmptyComponent={
+            <EmptyState message="받은 알림이 없습니다." iconName="bell" />
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  listContent: {
+    flexGrow: 1,
+    paddingHorizontal: 20,
+  },
+  separator: {
+    height: 12,
+  },
+  footerLoader: {
+    paddingVertical: 16,
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,10 +18,12 @@
         "expo": "~54.0.33",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
+        "expo-dev-client": "~6.0.21",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-linking": "~8.0.11",
+        "expo-notifications": "~0.32.17",
         "expo-router": "~6.0.23",
         "expo-sharing": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
@@ -2309,6 +2311,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -4751,6 +4759,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4777,7 +4798,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -5009,6 +5029,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5226,7 +5252,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5258,7 +5283,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5832,7 +5856,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -5859,7 +5882,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -6804,6 +6826,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "12.0.13",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
@@ -6842,6 +6873,79 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-client": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.21.tgz",
+      "integrity": "sha512-SWI6HD0pa4eJujkYFkvvpezUE1zmJXGLu+34azpu7+QJgO+FLutDYDj8BSTdeH/NYDEClDFjCGqVMcWETvmsCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "6.0.21",
+        "expo-dev-menu": "7.0.19",
+        "expo-dev-menu-interface": "2.0.0",
+        "expo-manifests": "~1.0.11",
+        "expo-updates-interface": "~2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-6.0.21.tgz",
+      "integrity": "sha512-QZ9gcKMZbp6EsIhzS0QoGB8Cf4xeVJhjbNgWUwcoBIk8gshoFz8CkCQOnX+HNv2sSY3rdCaNpx3Xo0Rflyq7rA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "expo-dev-menu": "7.0.19",
+        "expo-manifests": "~1.0.11"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-7.0.19.tgz",
+      "integrity": "sha512-ju5MZiBCPhUKKvHy0ElZdnlhq01mkEEiR8jfrgQVvW26aWjzjLiOhppNAyXtvGbhk7WxJim3wYMiqFFrjGdfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
+      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {
@@ -6894,6 +6998,12 @@
         }
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
@@ -6916,6 +7026,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.11.tgz",
+      "integrity": "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -6943,6 +7066,26 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.17",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.17.tgz",
+      "integrity": "sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -7276,6 +7419,15 @@
         }
       }
     },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-web-browser": {
       "version": "15.0.11",
       "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.11.tgz",
@@ -7491,6 +7643,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -7688,7 +7856,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -7798,7 +7965,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8102,7 +8268,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -8445,6 +8610,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8549,7 +8730,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8672,7 +8852,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -8707,6 +8886,22 @@
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8766,7 +8961,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8862,7 +9056,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -11085,11 +11278,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11099,7 +11307,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -11671,7 +11878,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12712,7 +12918,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12862,7 +13067,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -14184,6 +14388,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -14587,7 +14804,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "expo lint"
   },
@@ -21,10 +21,12 @@
     "expo": "~54.0.33",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
+    "expo-dev-client": "~6.0.21",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-linking": "~8.0.11",
+    "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",
     "expo-sharing": "~14.0.8",
     "expo-splash-screen": "~31.0.13",

--- a/frontend/src/features/auth/hooks/useRegister.ts
+++ b/frontend/src/features/auth/hooks/useRegister.ts
@@ -46,9 +46,9 @@ const ERROR_MESSAGES: Record<RegisterErrorCode, string> = {
 };
 
 function extractErrorCode(
-  error: AxiosError<ApiErrorResponse>,
+  error?: AxiosError<ApiErrorResponse>,
 ): RegisterErrorCode {
-  const code = error.response?.data?.code;
+  const code = error?.response?.data?.code;
   if (code && code in ERROR_MESSAGES) {
     return code as RegisterErrorCode;
   }
@@ -71,7 +71,14 @@ export function useRegister() {
   >({
     mutationFn: async (req: RegisterRequest) => {
       // 1단계: 회원가입
-      await register(req);
+      try {
+        await register(req);
+      } catch (registerError) {
+        throw {
+          phase: 'register',
+          axiosError: registerError as AxiosError<ApiErrorResponse>,
+        } as RegisterError;
+      }
 
       // 2단계: 자동 로그인 (트랩 #7 — 가입 응답에 JWT 없음)
       try {
@@ -86,7 +93,7 @@ export function useRegister() {
         throw {
           phase: 'autoLogin',
           axiosError: autoLoginError as AxiosError<ApiErrorResponse>,
-        };
+        } as RegisterError;
       }
     },
   });

--- a/frontend/src/features/notifications/components/NotificationItem.tsx
+++ b/frontend/src/features/notifications/components/NotificationItem.tsx
@@ -1,0 +1,161 @@
+/**
+ * NotificationItem — 알림 리스트 카드
+ *
+ * 구조:
+ * ┌─────────────────────────────┐
+ * │ [#매칭태그]          [D-day] │
+ * │ 공지 제목 텍스트 (최대 2줄)  │
+ * │ 2026-06-02                   │
+ * └─────────────────────────────┘
+ *
+ * - 카드 탭 → 공지 상세(/notice/{noticeId})로 이동
+ * - deadlineAt이 있을 때만 date.ts로 D-day를 연산해 뱃지 표시
+ */
+
+import { useRouter, type Href } from 'expo-router';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { Colors } from '@/src/constants/colors';
+import {
+  calculateDday,
+  formatDate,
+  formatDday,
+  isDdayUrgent,
+} from '@/src/shared/utils/date';
+import type { NotificationListItem } from '@/src/types/notifications';
+
+interface NotificationItemProps {
+  notification: NotificationListItem;
+}
+
+function NotificationItemComponent({ notification }: NotificationItemProps) {
+  const router = useRouter();
+
+  // 카드 탭 → 공지 상세로 이동 (NoticeCard와 동일 패턴)
+  const handlePress = () => {
+    router.push(`/notice/${notification.noticeId}` as Href);
+  };
+
+  const dday =
+    notification.deadlineAt != null
+      ? calculateDday(notification.deadlineAt)
+      : null;
+  const urgent = dday != null && isDdayUrgent(dday);
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={handlePress}
+      activeOpacity={0.7}
+    >
+      {/* 상단: 매칭 태그 칩 + D-day 뱃지 */}
+      <View style={styles.topRow}>
+        {notification.matchedTag ? (
+          <View style={styles.tagChip}>
+            <Text style={styles.tagChipText} numberOfLines={1}>
+              #{notification.matchedTag}
+            </Text>
+          </View>
+        ) : (
+          // 태그가 없는 경우에도 space-between 정렬 유지를 위한 빈 자리
+          <View />
+        )}
+        {dday != null && (
+          <View
+            style={[
+              styles.ddayBadge,
+              urgent ? styles.ddayUrgent : styles.ddayNormal,
+            ]}
+          >
+            <Text
+              style={[
+                styles.ddayText,
+                urgent ? styles.ddayTextUrgent : styles.ddayTextNormal,
+              ]}
+            >
+              {formatDday(dday)}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* 제목 */}
+      <Text style={styles.title} numberOfLines={2}>
+        {notification.title}
+      </Text>
+
+      {/* 발송 시각 */}
+      <Text style={styles.date}>{formatDate(notification.createdAt)}</Text>
+    </TouchableOpacity>
+  );
+}
+
+export const NotificationItem = NotificationItemComponent;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.cardBg,
+    borderRadius: 12,
+    padding: 20,
+    gap: 8,
+  },
+  topRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  // 매칭 태그 칩
+  tagChip: {
+    backgroundColor: Colors.chipBg,
+    borderRadius: 9999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    maxWidth: '70%',
+  },
+  tagChipText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.categoryBadgeText,
+  },
+  // D-day 뱃지
+  ddayBadge: {
+    borderRadius: 9999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  ddayUrgent: {
+    backgroundColor: Colors.ddayUrgentBg,
+  },
+  ddayNormal: {
+    backgroundColor: Colors.ddayNormalBg,
+  },
+  ddayText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  ddayTextUrgent: {
+    color: Colors.ddayUrgentText,
+  },
+  ddayTextNormal: {
+    color: Colors.ddayNormalText,
+  },
+  // 제목
+  title: {
+    fontFamily: 'Pretendard',
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+    lineHeight: 22,
+  },
+  // 발송 시각
+  date: {
+    fontFamily: 'Pretendard',
+    fontSize: 11,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    opacity: 0.7,
+  },
+});

--- a/frontend/src/features/notifications/components/index.ts
+++ b/frontend/src/features/notifications/components/index.ts
@@ -1,0 +1,1 @@
+export { NotificationItem } from './NotificationItem';

--- a/frontend/src/features/notifications/hooks/index.ts
+++ b/frontend/src/features/notifications/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useNotifications } from './useNotifications';
+export { usePushNotifications } from './usePushNotifications';

--- a/frontend/src/features/notifications/hooks/useNotifications.ts
+++ b/frontend/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,25 @@
+/**
+ * useNotifications — 알림 리스트 조회 TanStack Query 훅 (커서 페이지네이션)
+ *
+ * 백엔드 GET /api/notifications가 { alerts, nextCursor, hasNext } 형태로
+ * 커서 페이지네이션을 반환하므로 useInfiniteQuery로 구성한다.
+ * 화면에서는 data.pages.flatMap(p => p.alerts)로 평탄화해 사용한다.
+ */
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { fetchNotifications } from '@/src/services/notifications';
+import type { NotificationPage } from '@/src/types/notifications';
+
+export function useNotifications() {
+  return useInfiniteQuery<NotificationPage>({
+    queryKey: ['notifications'],
+    queryFn: ({ pageParam }) =>
+      fetchNotifications({ cursor: pageParam as number | null }),
+    // 첫 페이지는 커서 없음
+    initialPageParam: null,
+    // hasNext가 false거나 nextCursor가 null이면 undefined를 반환해 페이징 종료
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor ?? undefined : undefined,
+  });
+}

--- a/frontend/src/features/notifications/hooks/usePushNotifications.ts
+++ b/frontend/src/features/notifications/hooks/usePushNotifications.ts
@@ -1,0 +1,81 @@
+/**
+ * usePushNotifications — 푸시 알림 토큰 동기화 + 탭 네비게이션 훅
+ *
+ * RootLayoutNav에서 1회 호출한다.
+ *
+ * 1) 토큰 등록: accessToken이 생기면(로그인/자동로그인) 권한 요청 → 토큰 발급 →
+ *    서버 등록(PUT). 로그아웃(accessToken=null) 시 ref를 리셋해 재로그인 시 재등록.
+ *    (로그아웃 시점의 토큰 반납 DELETE는 settings.tsx handleLogout에서 처리)
+ * 2) 탭 네비게이션: 알림을 탭하면 data.noticeId로 공지 상세 화면 이동.
+ *    앱이 종료된 상태에서 알림으로 진입한 경우(cold start)도 처리.
+ */
+
+import * as Notifications from 'expo-notifications';
+import { useRouter, type Href } from 'expo-router';
+import { useEffect, useRef } from 'react';
+
+import { getDevicePushToken, requestNotificationPermission } from '@/src/services/notification';
+import { registerDeviceToken } from '@/src/services/pushToken';
+import { useAuthStore } from '@/src/store/useAuthStore';
+
+/** 알림 payload의 noticeId를 안전하게 꺼내 공지 상세로 이동 */
+function navigateToNotice(router: ReturnType<typeof useRouter>, data: unknown) {
+  if (data != null && typeof data === 'object' && 'noticeId' in data) {
+    const noticeId = (data as { noticeId?: string | number }).noticeId;
+    if (noticeId != null) {
+      router.push(`/notice/${noticeId}` as Href);
+    }
+  }
+}
+
+export function usePushNotifications() {
+  const router = useRouter();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const registeredRef = useRef(false); // 등록여부 확인 플래그
+
+  // 1) 로그인 직후 디바이스 토큰 등록
+  useEffect(() => {
+    if (!accessToken) {
+      registeredRef.current = false; // 로그아웃 → 재로그인 시 재등록 가능하도록 리셋
+      return;
+    }
+    if (registeredRef.current) return;
+    registeredRef.current = true;
+
+    (async () => {
+      try {
+        const granted = await requestNotificationPermission();
+        if (!granted) return;
+        const token = await getDevicePushToken();
+        if (!token) return;
+        // 테스트 중에는 콘솔에 찍힌 토큰을 복사해 DB users.device_token에 수기 입력할 수 있다.
+        // console.log('[push] device token =', token);
+        await registerDeviceToken(token);
+      } catch (e) {
+        // console.warn('[push] 토큰 등록 실패:', e);
+        registeredRef.current = false; // 실패 시 다음 변화에서 재시도
+      }
+    })();
+  }, [accessToken]);
+
+  // 2) 알림 탭 → 공지 상세 이동 (포그라운드/백그라운드)
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      navigateToNotice(router, response.notification.request.content.data);
+    });
+    return () => sub.remove();
+  }, [router]);
+
+  // 2-b) cold start: 종료 상태에서 알림 탭으로 진입한 경우
+  useEffect(() => {
+    let cancelled = false;
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (!cancelled && response) {
+        navigateToNotice(router, response.notification.request.content.data);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+}

--- a/frontend/src/features/notifications/hooks/usePushNotifications.ts
+++ b/frontend/src/features/notifications/hooks/usePushNotifications.ts
@@ -51,9 +51,9 @@ export function usePushNotifications() {
         // 테스트 중에는 콘솔에 찍힌 토큰을 복사해 DB users.device_token에 수기 입력할 수 있다.
         // console.log('[push] device token =', token);
         await registerDeviceToken(token);
-      } catch (e) {
-        // console.warn('[push] 토큰 등록 실패:', e);
-        registeredRef.current = false; // 실패 시 다음 변화에서 재시도
+      } catch {
+        // 토큰 등록 실패해도 앱 흐름은 진행. 다음 accessToken 변화에서 재시도.
+        registeredRef.current = false;
       }
     })();
   }, [accessToken]);

--- a/frontend/src/features/notifications/index.ts
+++ b/frontend/src/features/notifications/index.ts
@@ -1,0 +1,2 @@
+export * from './components';
+export * from './hooks';

--- a/frontend/src/mocks/notifications.ts
+++ b/frontend/src/mocks/notifications.ts
@@ -1,0 +1,122 @@
+/**
+ * 알림 리스트 Mock 데이터 — 백엔드 GET /api/notifications 준비 전 UI 개발용
+ *
+ * 실제 API 연동 시 services/notifications.ts의 USE_MOCK 플래그만 false로 바꾸면 됨.
+ * fetchNotificationsMock은 실제 fetcher와 동일한 시그니처
+ * ({ cursor, size }) → Promise<NotificationPage> 를 지키므로 호출부 수정이 없다.
+ *
+ * 데이터는 alertHistoryId 내림차순(최신순)으로 정렬돼 있다고 가정한다.
+ * 커서 = "마지막으로 받은 alertHistoryId" → 그보다 작은 항목부터 다음 페이지.
+ */
+
+import type { NotificationListItem, NotificationPage } from '@/src/types/notifications';
+
+/** 다양한 UI 케이스를 담은 mock 알림 목록 (alertHistoryId 내림차순) */
+export const MOCK_NOTIFICATIONS: NotificationListItem[] = [
+  {
+    alertHistoryId: 112,
+    noticeId: 1042,
+    title: '2026학년도 1학기 국가장학금 신청 안내',
+    matchedTag: '국가장학',
+    deadlineAt: '2026-06-10', // 임박(D-7 이내일 수 있음)
+    isRead: false,
+    createdAt: '2026-06-03T10:52:00',
+  },
+  {
+    alertHistoryId: 109,
+    noticeId: 1039,
+    title: '2026 하계 해외 연수 프로그램 참가자 모집 — 미국·영국·독일 등 12개국 협약 대학',
+    matchedTag: '해외연수',
+    deadlineAt: '2026-06-20',
+    isRead: false,
+    createdAt: '2026-06-03T09:14:00',
+  },
+  {
+    alertHistoryId: 104,
+    noticeId: 1031,
+    title: '교내 근로장학생 2차 모집 공고',
+    matchedTag: '근로장학',
+    deadlineAt: '2026-06-05', // 곧 마감
+    isRead: true, // 읽음 처리 도입 전엔 항상 false지만, UI 변형 확인용
+    createdAt: '2026-06-02T17:40:00',
+  },
+  {
+    alertHistoryId: 98,
+    noticeId: 1024,
+    title: 'AI융합전공 신설 설명회 개최 안내',
+    matchedTag: 'AI융합',
+    deadlineAt: null, // 마감일 없음 → D-day 뱃지 미표시
+    isRead: false,
+    createdAt: '2026-06-02T11:05:00',
+  },
+  {
+    alertHistoryId: 91,
+    noticeId: 1018,
+    title: '제2전공(복수전공) 신청 기간 종료 D-1',
+    matchedTag: '복수전공',
+    deadlineAt: '2026-05-30', // 이미 지남 → "마감"
+    isRead: false,
+    createdAt: '2026-06-01T08:30:00',
+  },
+  {
+    alertHistoryId: 85,
+    noticeId: 1009,
+    title: '컴퓨터정보공학부 캡스톤 디자인 경진대회 안내',
+    matchedTag: '캡스톤',
+    deadlineAt: '2026-06-25',
+    isRead: false,
+    createdAt: '2026-05-31T14:20:00',
+  },
+  {
+    alertHistoryId: 77,
+    noticeId: 994,
+    title: '교환학생 파견 프로그램 2차 선발 결과 발표',
+    matchedTag: '교환학생',
+    deadlineAt: null,
+    isRead: true,
+    createdAt: '2026-05-30T16:00:00',
+  },
+  {
+    alertHistoryId: 70,
+    noticeId: 988,
+    title: '취업 역량 강화 특강 — 자기소개서 클리닉',
+    matchedTag: '취업특강',
+    deadlineAt: '2026-06-12',
+    isRead: false,
+    createdAt: '2026-05-29T10:10:00',
+  },
+];
+
+/** mock 네트워크 지연(ms) — 로딩 인디케이터 확인용 */
+const MOCK_DELAY_MS = 350;
+
+interface FetchParams {
+  cursor?: number | null;
+  size?: number;
+}
+
+/**
+ * 실제 fetcher와 동일 시그니처의 mock.
+ * cursor(=마지막으로 받은 alertHistoryId) 다음부터 size개를 잘라 반환한다.
+ */
+export async function fetchNotificationsMock(
+  { cursor, size = 20 }: FetchParams = {},
+): Promise<NotificationPage> {
+  await new Promise((resolve) => setTimeout(resolve, MOCK_DELAY_MS));
+
+  // cursor가 없으면 처음부터, 있으면 그 alertHistoryId 미만(=더 오래된)부터
+  const startIndex =
+    cursor == null
+      ? 0
+      : MOCK_NOTIFICATIONS.findIndex((n) => n.alertHistoryId < cursor);
+
+  // findIndex가 -1이면 더 이상 없음 → 빈 페이지
+  const safeStart = startIndex === -1 ? MOCK_NOTIFICATIONS.length : startIndex;
+  const slice = MOCK_NOTIFICATIONS.slice(safeStart, safeStart + size);
+
+  const hasNext = safeStart + size < MOCK_NOTIFICATIONS.length;
+  const nextCursor =
+    hasNext && slice.length > 0 ? slice[slice.length - 1].alertHistoryId : null;
+
+  return { alerts: slice, nextCursor, hasNext };
+}

--- a/frontend/src/services/notification.ts
+++ b/frontend/src/services/notification.ts
@@ -1,0 +1,51 @@
+/**
+ * expo-notifications 래퍼 — 권한 요청 / 디바이스 토큰 발급 / 포그라운드 표시 정책
+ *
+ * ADR `알림 발송 방식 도입`에 따라 RN 클라이언트는 expo-notifications를 사용한다.
+ * 현재는 FCM 직접 방식(네이티브 FCM 토큰)이며, 추후 Expo Push로 전환 시
+ * getDevicePushToken()의 본문 한 줄만 교체하면 된다(아래 주석 참고).
+ *
+ * 주의: getDevicePushTokenAsync()는 google-services.json이 포함된 개발 빌드(EAS dev build)에서만
+ * 동작하며 Expo Go에서는 동작하지 않는다.
+ */
+
+import * as Notifications from 'expo-notifications';
+
+// 앱이 포그라운드일 때도 OS 알림 배너를 표시한다.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+/** OS 알림 권한을 확인하고, 미허용 시 요청한다. 최종 허용 여부를 반환. */
+export async function requestNotificationPermission(): Promise<boolean> {
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+
+/**
+ * 디바이스 푸시 토큰을 발급한다. 실패 시 null.
+ *
+ * 현재: FCM 직접 방식 — 네이티브 FCM 토큰.
+ * [Expo Push 전환 시] 아래 본문을 다음으로 교체:
+ *   import Constants from 'expo-constants';
+ *   const projectId = Constants?.expoConfig?.extra?.eas?.projectId;
+ *   const { data } = await Notifications.getExpoPushTokenAsync({ projectId });
+ *   return data;
+ */
+export async function getDevicePushToken(): Promise<string | null> {
+  try {
+    const { data } = await Notifications.getDevicePushTokenAsync();
+    return data;
+  } catch (e) {
+    console.warn('[push] 디바이스 토큰 발급 실패:', e);
+    return null;
+  }
+}

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -1,0 +1,49 @@
+/**
+ * 알림 리스트 API fetcher
+ *
+ * 백엔드 API 명세(정본: personal_docs/api/API_알림이력조회.md):
+ *  - GET /api/notifications?cursor={마지막 alert_history.id}&size={개수}
+ *    → { alerts, nextCursor, hasNext } (커서 페이지네이션, 최신순)
+ *
+ * ⚠️ 백엔드 GET /api/notifications가 아직 미구현이라 현재는 mock으로 동작한다.
+ *    실제 연동 시 아래 USE_MOCK 플래그만 false로 바꾸면 된다. (호출부 수정 불필요)
+ */
+
+import { fetchNotificationsMock } from '@/src/mocks/notifications';
+import type { NotificationPage } from '@/src/types/notifications';
+
+import apiClient from './api';
+
+/** 한 페이지 기본 조회 개수 */
+export const NOTIFICATIONS_PAGE_SIZE = 20;
+
+/** true면 mock 데이터, false면 실제 백엔드 호출 */
+const USE_MOCK = true;
+
+interface FetchNotificationsParams {
+  /** 직전 페이지의 nextCursor. 첫 페이지는 생략(null) */
+  cursor?: number | null;
+  /** 페이지 크기 (기본 20) */
+  size?: number;
+}
+
+/** 실제 백엔드 호출 — GET /api/notifications */
+async function fetchNotificationsReal(
+  { cursor, size = NOTIFICATIONS_PAGE_SIZE }: FetchNotificationsParams,
+): Promise<NotificationPage> {
+  const { data } = await apiClient.get<NotificationPage>('/api/notifications', {
+    // cursor가 null/undefined면 파라미터 자체를 보내지 않음 → 첫 페이지
+    params: { cursor: cursor ?? undefined, size },
+  });
+  return data;
+}
+
+/**
+ * 인증 사용자의 알림 목록 한 페이지 조회
+ * GET /api/notifications
+ */
+export async function fetchNotifications(
+  params: FetchNotificationsParams = {},
+): Promise<NotificationPage> {
+  return USE_MOCK ? fetchNotificationsMock(params) : fetchNotificationsReal(params);
+}

--- a/frontend/src/services/pushToken.ts
+++ b/frontend/src/services/pushToken.ts
@@ -1,0 +1,23 @@
+/**
+ * 디바이스 푸시 토큰 등록/반납 API fetcher
+ *
+ * 백엔드 API 명세:
+ *  - PUT    /api/users/device-token { deviceToken } → 204
+ *  - DELETE /api/users/device-token                  → 204 (토큰 반납)
+ *
+ * 호출 시점:
+ *  - 등록: 로그인 성공 직후 (usePushNotifications)
+ *  - 반납: 로그아웃 시 clearAuth() 직전 (settings.tsx)
+ */
+
+import apiClient from './api';
+
+/** 디바이스 토큰 등록/갱신 */
+export async function registerDeviceToken(deviceToken: string): Promise<void> {
+  await apiClient.put('/api/users/device-token', { deviceToken });
+}
+
+/** 디바이스 토큰 반납 (로그아웃) */
+export async function unregisterDeviceToken(): Promise<void> {
+  await apiClient.delete('/api/users/device-token');
+}

--- a/frontend/src/shared/components/MainHeader.tsx
+++ b/frontend/src/shared/components/MainHeader.tsx
@@ -15,14 +15,16 @@
  */
 
 import { Feather } from '@expo/vector-icons';
+import { useRouter, type Href } from 'expo-router';
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
 
 function MainHeaderComponent() {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
@@ -33,12 +35,17 @@ function MainHeaderComponent() {
           <Text style={styles.logoText}>Cathori</Text>
         </View>
 
-        {/* 알림 아이콘 + dot */}
-        <View style={styles.bellSection}>
+        {/* 알림 아이콘 + dot — 탭 시 알림 리스트로 이동 */}
+        <TouchableOpacity
+          style={styles.bellSection}
+          onPress={() => router.push('/notification' as Href)}
+          hitSlop={8}
+          activeOpacity={0.7}
+        >
           <Feather name="bell" size={20} color="#FFFFFF" />
           {/* 알림 dot — #FCC006, 10x10, border #00288C 2px */}
           <View style={styles.notificationDot} />
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
   );

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -1,0 +1,36 @@
+/**
+ * 알림 리스트 API 계약 타입
+ *
+ * 백엔드 `GET /api/notifications`(커서 페이지네이션) 응답을 미러링한다.
+ * 정본 명세: personal_docs/api/API_알림이력조회.md
+ */
+
+export interface NotificationListItem {
+  /** alert_history PK — 리스트 key, 읽음 처리(Phase 6 PATCH) 식별자, 커서 산출 기준 */
+  alertHistoryId: number;
+  /** 연결된 공지 ID — 카드 탭 시 공지 상세로 이동 */
+  noticeId: number;
+  /** 공지 제목 */
+  title: string;
+  /** 발송 시점에 매칭됐던 관심 태그 (alert_history.matched_tag) — 없으면 null */
+  matchedTag: string | null;
+  /** 공지 마감일 (없으면 null) — 표시는 date.ts로 연산 */
+  deadlineAt: string | null;
+  /** 읽음 여부 — Phase 5에서는 읽음 처리 미구현으로 항상 false */
+  isRead: boolean;
+  /** 알림 수신 시각 (ISO 8601) */
+  createdAt: string;
+}
+
+/**
+ * 커서 페이지네이션 응답 한 페이지
+ * - cursor에 직전 페이지의 nextCursor를 넣어 다음 페이지를 요청한다.
+ */
+export interface NotificationPage {
+  /** 이 페이지의 알림 카드 목록 */
+  alerts: NotificationListItem[];
+  /** 다음 페이지 커서(마지막 alert_history.id). 다음 페이지 없으면 null */
+  nextCursor: number | null;
+  /** 다음 페이지 존재 여부 */
+  hasNext: boolean;
+}


### PR DESCRIPTION
# 1. 📖 작업 배경

2nd 스프린트 **Phase 5** — 이미 머지된 백엔드 알림 발송 기능을 프런트와 연결하고, 사용자가 받은 알림을 앱에서 다시 볼 수 있는 **알림 리스트 화면**을 완성한다.

- #73 

> 옛 계획의 `notification_log` 테이블은 폐기되고 `alert_history` 단일 테이블로 통합됨에 따라 계획·문서를 전면 재정리

<br>

## 🔧 작업 내용

- **푸시 인프라 / 토큰 라이프사이클** (일부 기머지 + 정리)
  - `expo-notifications` 도입, `app.json` 플러그인 + `googleServicesFile` 등록.
  - 로그인 직후 권한 요청 → `getDevicePushTokenAsync()` → `PUT /api/users/device-token` 등록. 로그아웃 시 `clearAuth()` 전에 `DELETE`.
  - 포그라운드 핸들러 + 알림 탭 응답 → `router.push('/notice/{noticeId}')`.
- **알림 리스트 화면** (`app/notification/index.tsx`)
  - `MainHeader` 종 아이콘 → `/notification` 진입.
  - `SubHeader` + `FlatList` + 빈/로딩/에러 상태 + 당겨서 새로고침.
  - **커서 페이지네이션 무한 스크롤** (`useInfiniteQuery`, `onEndReached`).
  - 카드: `#matchedTag` 칩 + D-day 뱃지(`date.ts`) + 발송시각, 탭 시 공지 상세 이동.
- **명세 정합 + mock**
  - `NotificationListItem`(`alertHistoryId` 포함) + `NotificationPage`(`alerts/nextCursor/hasNext`) 타입.
  - `services/notifications.ts`에 `USE_MOCK` 플래그로 real↔mock 스왑. `mocks/notifications.ts`에 실제와 동일 시그니처의 mock fetcher(커서·지연 흉내).

<br>

## 🔍 동작 방식

```
[로그인] accessToken 발급
   → 권한 요청 → getDevicePushTokenAsync() → PUT /api/users/device-token
[종 아이콘 탭] → /notification
   → useNotifications(useInfiniteQuery)
   → GET /api/notifications?cursor&size → { alerts, nextCursor, hasNext }
   → pages.flatMap → FlatList, onEndReached → fetchNextPage
[알림 카드 탭] → router.push('/notice/{noticeId}')
[로그아웃] DELETE /api/users/device-token → clearAuth → /login
```

<br>

## 💡 설계 근거

- **`alert_history` 단일 테이블 채택** — 백엔드 테이블 설계안으로 협의. OS 발송 로직(`FcmPort`)은 건드리지 않고, `matched_tag`는 **리스트 표시용으로만** 저장해 백엔드 담당자가 발송 파이프라인을 재개편하지 않도록 함.
- **`alertHistoryId`(PK)를 응답에 노출** — 리스트 key / 커서 산출 / Phase 6 읽음 처리(PATCH) 식별자로 한 값을 일관되게 재사용. (PK 미노출안에서 프론트(본인)의 의견 반영해 노출로 전환)
- **읽음 처리는 범위 밖** — 이번엔 조회/표시 + 카드 탭까지. `isRead`는 항상 false 표시. (PATCH는 `noticeId`/`alertHistoryId`만으로 가능 — `UNIQUE(user_id,notice_id)` + JWT userId)
- **mock을 real과 같은 계약으로** — `{cursor,size}→NotificationPage` 시그니처를 mock도 동일하게 지켜, 백엔드 연동 시 `USE_MOCK=false` 한 줄만 바꾸면 호출부 수정 0.
- **로그아웃 순서(DELETE→clearAuth) 강제** — `clearAuth`가 먼저면 JWT 소실로 DELETE가 401.

<br>

## ✅ 체크리스트

- [x] `tsc --noEmit` 통과 (0 error)
- [x] `expo lint` 통과 (0 error; 신규 알림 파일 경고 없음)
- [x] 실기기에서 디바이스 토큰 발급 확인 (prebuild --clean 후)
- [x] mock 데이터로 리스트 렌더/무한스크롤/카드 탭 동작 확인
- [ ] 백엔드 `GET /api/notifications` + `matched_tag` 구현 후 `USE_MOCK=false` 실연동 검증 (담당자 작업 대기)

<br>

## 🐛 트러블슈팅

실기기 첫 빌드에서 표면화된 별개 환경 이슈 3건 (알림 프런트 코드와 무관):
- 회원가입 USER_NOT_VERIFIED — 인메모리 인증 스토어 휘발(85)
- FCM 토큰 발급 실패 — stale android prebuild 패키지명 불일치(86)
- 공지 상세 500 — `notices.alert_dispatched` 컬럼 누락(`update`의 NOT NULL 한계)(89)

> 본 PR의 커밋 범위는 **프런트 알림 리스트 화면 + 토큰 라이프사이클**까지다. 발송 트리거는 되나 실기기 미수신이던 **백엔드 FCM 발송 정상화**는 워킹트리에서 분리해 별도 브랜치/PR로 정리했습니다.

<br>

## ⏭️ 다음 단계 (다음 작업 인계)

- **알림 리스트 실연동**: 백엔드 `GET /api/notifications` + `alert_history.matched_tag` 구현 후 `services/notifications.ts`의 `USE_MOCK=false`로 전환 (호출부 수정 0).

<br>

## 🔗 연관 이슈

- #50 
- #85 
- #86 
- #89 
