### PR TITLE
[FEAT] 수신된 알림내역 조회 및 읽음요청 처리 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/alert/AlertErrorCode.java
+++ b/backend/src/main/java/org/cathori/backend/alert/AlertErrorCode.java
@@ -1,0 +1,33 @@
+package org.cathori.backend.alert;
+
+import org.cathori.backend.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AlertErrorCode implements ErrorCode {
+    ALERT_NOT_FOUND(HttpStatus.NOT_FOUND, "ALERT_NOT_FOUND", "존재하지 않는 알림이거나 본인의 알림이 아닙니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    AlertErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/api/NotificationController.java
+++ b/backend/src/main/java/org/cathori/backend/alert/api/NotificationController.java
@@ -1,0 +1,37 @@
+package org.cathori.backend.alert.api;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.alert.api.dto.NotificationListResponse;
+import org.cathori.backend.alert.application.NotificationService;
+import org.cathori.backend.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<NotificationListResponse> list(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        NotificationListResponse response = notificationService.listNotifications(
+                userDetails.getUserId(), cursor, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{alertHistoryId}/read")
+    public ResponseEntity<Void> markRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long alertHistoryId
+    ) {
+        notificationService.markRead(userDetails.getUserId(), alertHistoryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/api/dto/NotificationItem.java
+++ b/backend/src/main/java/org/cathori/backend/alert/api/dto/NotificationItem.java
@@ -1,0 +1,14 @@
+package org.cathori.backend.alert.api.dto;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record NotificationItem(
+        Long alertHistoryId,
+        Long noticeId,
+        String title,
+        String matchedTag,
+        LocalDate deadlineAt,
+        boolean isRead,
+        OffsetDateTime createdAt
+) {}

--- a/backend/src/main/java/org/cathori/backend/alert/api/dto/NotificationListResponse.java
+++ b/backend/src/main/java/org/cathori/backend/alert/api/dto/NotificationListResponse.java
@@ -1,0 +1,9 @@
+package org.cathori.backend.alert.api.dto;
+
+import java.util.List;
+
+public record NotificationListResponse(
+        List<NotificationItem> alerts,
+        Long nextCursor,
+        boolean hasNext
+) {}

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertHistoryRepository.java
@@ -3,6 +3,7 @@ package org.cathori.backend.alert.application;
 import org.cathori.backend.alert.domain.AlertHistory;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AlertHistoryRepository {
 
@@ -17,4 +18,6 @@ public interface AlertHistoryRepository {
     void markFailedForUsers(Long noticeId, List<Long> userIds);
 
     void incrementRetryForUsers(Long noticeId, List<Long> userIds);
+
+    Optional<AlertHistory> findByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/AlertService.java
@@ -48,8 +48,9 @@ public class AlertService {
         }
 
         // PENDING row 일괄 INSERT
+        Map<Long, String> matchedTags = userRepository.findFirstMatchedTagsByTitle(notice.getTitle());
         List<AlertHistory> pendingLogs = targets.stream()
-                .map(t -> AlertHistory.create(t.userId(), notice.getId()))
+                .map(t -> AlertHistory.create(t.userId(), notice.getId(), matchedTags.get(t.userId())))
                 .toList();
         alertHistoryRepository.saveAll(pendingLogs);
 

--- a/backend/src/main/java/org/cathori/backend/alert/application/NotificationQueryPort.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/NotificationQueryPort.java
@@ -1,0 +1,7 @@
+package org.cathori.backend.alert.application;
+
+import java.util.List;
+
+public interface NotificationQueryPort {
+    List<NotificationRow> findByUserIdWithCursor(Long userId, Long cursor, int limit);
+}

--- a/backend/src/main/java/org/cathori/backend/alert/application/NotificationRow.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/NotificationRow.java
@@ -1,0 +1,14 @@
+package org.cathori.backend.alert.application;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record NotificationRow(
+        Long alertHistoryId,
+        Long noticeId,
+        String title,
+        LocalDate deadlineAt,
+        String matchedTag,
+        boolean isRead,
+        LocalDateTime createdAt
+) {}

--- a/backend/src/main/java/org/cathori/backend/alert/application/NotificationService.java
+++ b/backend/src/main/java/org/cathori/backend/alert/application/NotificationService.java
@@ -1,0 +1,52 @@
+package org.cathori.backend.alert.application;
+
+import lombok.RequiredArgsConstructor;
+import org.cathori.backend.alert.AlertErrorCode;
+import org.cathori.backend.alert.api.dto.NotificationItem;
+import org.cathori.backend.alert.api.dto.NotificationListResponse;
+import org.cathori.backend.alert.domain.AlertHistory;
+import org.cathori.backend.common.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationQueryPort notificationQueryPort;
+    private final AlertHistoryRepository alertHistoryRepository;
+
+    public NotificationListResponse listNotifications(Long userId, Long cursor, int size) {
+        List<NotificationRow> rows = notificationQueryPort.findByUserIdWithCursor(userId, cursor, size + 1);
+
+        boolean hasNext = rows.size() > size;
+        List<NotificationRow> page = hasNext ? rows.subList(0, size) : rows;
+
+        List<NotificationItem> items = page.stream()
+                .map(row -> new NotificationItem(
+                        row.alertHistoryId(),
+                        row.noticeId(),
+                        row.title(),
+                        row.matchedTag(),
+                        row.deadlineAt(),
+                        row.isRead(),
+                        row.createdAt().atOffset(ZoneOffset.ofHours(9))
+                ))
+                .toList();
+
+        Long nextCursor = hasNext ? page.get(page.size() - 1).alertHistoryId() : null;
+
+        return new NotificationListResponse(items, nextCursor, hasNext);
+    }
+
+    @Transactional
+    public void markRead(Long userId, Long alertHistoryId) {
+        AlertHistory alertHistory = alertHistoryRepository.findByIdAndUserId(alertHistoryId, userId)
+                .orElseThrow(() -> new BusinessException(AlertErrorCode.ALERT_NOT_FOUND));
+        alertHistory.markRead();
+        alertHistoryRepository.save(alertHistory);
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
+++ b/backend/src/main/java/org/cathori/backend/alert/domain/AlertHistory.java
@@ -36,7 +36,10 @@ public class AlertHistory {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    public static AlertHistory create(Long userId, Long noticeId) {
+    @Column(name = "matched_tag", length = 20)
+    private String matchedTag;
+
+    public static AlertHistory create(Long userId, Long noticeId, String matchedTag) {
         AlertHistory h = new AlertHistory();
         h.userId = userId;
         h.noticeId = noticeId;
@@ -44,7 +47,12 @@ public class AlertHistory {
         h.isRead = false;
         h.retryCount = 0;
         h.createdAt = LocalDateTime.now();
+        h.matchedTag = matchedTag;
         return h;
+    }
+
+    public void markRead() {
+        this.isRead = true;
     }
 
     public void markSuccess() {

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, Long> {
 
@@ -24,4 +25,6 @@ public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, L
     @Modifying
     @Query("UPDATE AlertHistory ah SET ah.retryCount = ah.retryCount + 1 WHERE ah.noticeId = :noticeId AND ah.userId IN :userIds")
     void incrementRetryForUsers(@Param("noticeId") Long noticeId, @Param("userIds") List<Long> userIds);
+
+    Optional<AlertHistory> findByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.cathori.backend.alert.domain.AlertHistory;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
@@ -46,5 +47,10 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     public void incrementRetryForUsers(Long noticeId, List<Long> userIds) {
         if (userIds.isEmpty()) return;
         jpaRepository.incrementRetryForUsers(noticeId, userIds);
+    }
+
+    @Override
+    public Optional<AlertHistory> findByIdAndUserId(Long id, Long userId) {
+        return jpaRepository.findByIdAndUserId(id, userId);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/alert/infra/NotificationQueryAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/alert/infra/NotificationQueryAdapter.java
@@ -1,0 +1,55 @@
+package org.cathori.backend.alert.infra;
+
+import org.cathori.backend.alert.application.NotificationQueryPort;
+import org.cathori.backend.alert.application.NotificationRow;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class NotificationQueryAdapter implements NotificationQueryPort {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public NotificationQueryAdapter(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public List<NotificationRow> findByUserIdWithCursor(Long userId, Long cursor, int limit) {
+        StringBuilder sql = new StringBuilder(
+                "SELECT ah.id, ah.notice_id, n.title, n.deadline_at, ah.matched_tag, ah.is_read, ah.created_at " +
+                "FROM alert_history ah " +
+                "JOIN notices n ON ah.notice_id = n.id " +
+                "WHERE ah.user_id = ? AND ah.alarm_status = 'SUCCESS'"
+        );
+        List<Object> params = new ArrayList<>();
+        params.add(userId);
+
+        if (cursor != null) {
+            sql.append(" AND ah.id < ?");
+            params.add(cursor);
+        }
+
+        sql.append(" ORDER BY ah.id DESC LIMIT ?");
+        params.add(limit);
+
+        return jdbcTemplate.query(sql.toString(), (rs, rowNum) -> {
+            Date deadlineDate = rs.getDate("deadline_at");
+            Timestamp createdAt = rs.getTimestamp("created_at");
+            return new NotificationRow(
+                    rs.getLong("id"),
+                    rs.getLong("notice_id"),
+                    rs.getString("title"),
+                    deadlineDate != null ? deadlineDate.toLocalDate() : null,
+                    rs.getString("matched_tag"),
+                    rs.getBoolean("is_read"),
+                    createdAt != null ? createdAt.toLocalDateTime() : null
+            );
+        }, params.toArray());
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
@@ -1,6 +1,7 @@
 package org.cathori.backend.user.domain;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -9,4 +10,5 @@ public interface UserRepository {
     Optional<User> findByEmail(String email);
     Optional<User> findById(Long id);
     List<User> findUsersWithTagMatchingTitle(String title);
+    Map<Long, String> findFirstMatchedTagsByTitle(String title);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
@@ -14,4 +14,7 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     @Query(value = "SELECT DISTINCT u.* FROM users u JOIN user_tag t ON t.user_id = u.id WHERE :title LIKE '%' || t.name || '%'", nativeQuery = true)
     List<User> findUsersWithTagMatchingTitle(@Param("title") String title);
+
+    @Query(value = "SELECT t.user_id, MIN(t.name) AS matched_tag FROM user_tag t WHERE :title LIKE '%' || t.name || '%' GROUP BY t.user_id", nativeQuery = true)
+    List<Object[]> findFirstMatchedTagsByTitle(@Param("title") String title);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
@@ -5,7 +5,9 @@ import org.cathori.backend.user.domain.UserRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 public class UserRepositoryImpl implements UserRepository {
@@ -39,5 +41,14 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public List<User> findUsersWithTagMatchingTitle(String title) {
         return jpaRepository.findUsersWithTagMatchingTitle(title);
+    }
+
+    @Override
+    public Map<Long, String> findFirstMatchedTagsByTitle(String title) {
+        return jpaRepository.findFirstMatchedTagsByTitle(title).stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).longValue(),
+                        row -> (String) row[1]
+                ));
     }
 }

--- a/backend/src/test/java/org/cathori/backend/alert/api/NotificationIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/api/NotificationIntegrationTest.java
@@ -1,0 +1,188 @@
+package org.cathori.backend.alert.api;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.alert.infra.AlertHistoryJpaRepository;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.user.application.AuthService;
+import org.cathori.backend.user.application.NotificationPort;
+import org.cathori.backend.user.application.VerifiedEmailStore;
+import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.infra.UserJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("알림 이력 API 통합 테스트")
+class NotificationIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired AuthService authService;
+    @Autowired VerifiedEmailStore verifiedEmailStore;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired AlertHistoryJpaRepository alertHistoryJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired JwtUtil jwtUtil;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final String EMAIL_A = "notif_a@catholic.ac.kr";
+    private static final String EMAIL_B = "notif_b@catholic.ac.kr";
+    private static final String PASSWORD = "password123!";
+
+    private Long userAId;
+    private Long userBId;
+    private String tokenA;
+
+    @BeforeEach
+    void setUp() {
+        verifiedEmailStore.markVerified(EMAIL_A);
+        authService.register(new RegisterRequest(EMAIL_A, PASSWORD, "컴퓨터정보공학부", null, 2, "재학"));
+        userAId = userJpaRepository.findByEmail(EMAIL_A).orElseThrow().getId();
+        tokenA = jwtUtil.generateAccessToken(userAId);
+
+        verifiedEmailStore.markVerified(EMAIL_B);
+        authService.register(new RegisterRequest(EMAIL_B, PASSWORD, "컴퓨터정보공학부", null, 2, "재학"));
+        userBId = userJpaRepository.findByEmail(EMAIL_B).orElseThrow().getId();
+    }
+
+    @AfterEach
+    void cleanup() {
+        alertHistoryJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+        userJpaRepository.findByEmail(EMAIL_A).ifPresent(userJpaRepository::delete);
+        userJpaRepository.findByEmail(EMAIL_B).ifPresent(userJpaRepository::delete);
+        verifiedEmailStore.remove(EMAIL_A);
+        verifiedEmailStore.remove(EMAIL_B);
+    }
+
+    @Test
+    @DisplayName("NI-1: GET /api/notifications → 200 + 응답 구조 확인")
+    void listNotifications_returns200WithStructure() throws Exception {
+        Notice notice = saveNotice();
+        insertAlertHistory(userAId, notice.getId(), "SUCCESS", "장학");
+
+        mockMvc.perform(get("/api/notifications")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts").isArray())
+                .andExpect(jsonPath("$.alerts[0].alertHistoryId").isNumber())
+                .andExpect(jsonPath("$.alerts[0].noticeId").isNumber())
+                .andExpect(jsonPath("$.alerts[0].title").isString())
+                .andExpect(jsonPath("$.alerts[0].matchedTag").value("장학"))
+                .andExpect(jsonPath("$.alerts[0].isRead").value(false))
+                .andExpect(jsonPath("$.alerts[0].createdAt").value(containsString("+09:00")))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.nextCursor").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("NI-2: GET /api/notifications?size=1 → 데이터 2개일 때 hasNext=true")
+    void listNotifications_withSmallSize_returnsHasNextTrue() throws Exception {
+        Notice n1 = saveNotice();
+        Notice n2 = saveNotice();
+        insertAlertHistory(userAId, n1.getId(), "SUCCESS", null);
+        insertAlertHistory(userAId, n2.getId(), "SUCCESS", null);
+
+        mockMvc.perform(get("/api/notifications?size=1")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts.length()").value(1))
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.nextCursor").isNumber());
+    }
+
+    @Test
+    @DisplayName("NI-3: GET /api/notifications JWT 없음 → 401")
+    void listNotifications_withoutJwt_returns401() throws Exception {
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("NI-4: PATCH /{id}/read → 204 No Content")
+    void markRead_validAlert_returns204() throws Exception {
+        Notice notice = saveNotice();
+        Long historyId = insertAlertHistory(userAId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(patch("/api/notifications/" + historyId + "/read")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("NI-5: PATCH /{id}/read 재요청 → 204 (멱등성)")
+    void markRead_alreadyRead_returns204Again() throws Exception {
+        Notice notice = saveNotice();
+        Long historyId = insertAlertHistory(userAId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(patch("/api/notifications/" + historyId + "/read")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(patch("/api/notifications/" + historyId + "/read")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("NI-6: PATCH /{없는id}/read → 404 + ALERT_NOT_FOUND")
+    void markRead_notExistingId_returns404() throws Exception {
+        mockMvc.perform(patch("/api/notifications/99999/read")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("ALERT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("NI-7: PATCH /{타인id}/read → 404")
+    void markRead_othersAlert_returns404() throws Exception {
+        Notice notice = saveNotice();
+        Long historyId = insertAlertHistory(userBId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(patch("/api/notifications/" + historyId + "/read")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("NI-8: PATCH JWT 없음 → 401")
+    void markRead_withoutJwt_returns401() throws Exception {
+        mockMvc.perform(patch("/api/notifications/1/read"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private Notice saveNotice() {
+        return noticeRepository.save(Notice.from(CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType("MAIN").sourceId(null).category("일반")
+                .title("테스트 공지").department("공지사항")
+                .postedAt(LocalDate.now().toString())
+                .url("https://example.com/" + UUID.randomUUID())
+                .bodyText("").imageUrls(List.of()).build()));
+    }
+
+    private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag) {
+        return jdbcTemplate.queryForObject(
+                "INSERT INTO alert_history (user_id, notice_id, alarm_status, is_read, retry_count, created_at, matched_tag) " +
+                "VALUES (?, ?, ?, false, 0, now(), ?) RETURNING id",
+                Long.class, userId, noticeId, status, matchedTag);
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/alert/application/AlertServiceTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/application/AlertServiceTest.java
@@ -195,6 +195,22 @@ class AlertServiceTest extends IntegrationTestBase {
         verify(fcmPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
     }
 
+    @Test
+    @DisplayName("DA-3: FCM 발송 시 matched_tag 저장 — 가나다 순 첫 번째 태그")
+    void dispatchAlerts_savesMatchedTagAsMinTagName() {
+        Notice notice = saveNotice("국가장학금 신청 안내");
+        User user = saveUserWithToken("user1@test.com", "token-abc");
+        saveTag(user.getId(), "장학");
+        saveTag(user.getId(), "국가장학");
+        given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+                .willReturn(List.of(new UserFcmResult(user.getId(), true)));
+
+        alertService.dispatchAlerts();
+
+        AlertHistory history = alertHistoryJpaRepository.findAll().getFirst();
+        assertThat(history.getMatchedTag()).isEqualTo("국가장학");
+    }
+
     // --- retryFailedAlerts() ---
 
     @Test
@@ -202,7 +218,7 @@ class AlertServiceTest extends IntegrationTestBase {
     void retryFailedAlerts_fcmSuccess_updatesStatusToSuccess() {
         Notice notice = saveNotice("장학금 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
-        AlertHistory failed = AlertHistory.create(user.getId(), notice.getId());
+        AlertHistory failed = AlertHistory.create(user.getId(), notice.getId(), null);
         failed.markFailed();
         AlertHistory saved = alertHistoryJpaRepository.save(failed);
         given(fcmPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))

--- a/backend/src/test/java/org/cathori/backend/alert/application/NotificationServiceTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/application/NotificationServiceTest.java
@@ -1,0 +1,190 @@
+package org.cathori.backend.alert.application;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.alert.AlertErrorCode;
+import org.cathori.backend.alert.api.dto.NotificationListResponse;
+import org.cathori.backend.alert.infra.AlertHistoryJpaRepository;
+import org.cathori.backend.common.exception.BusinessException;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.alert.application.FcmPort;
+import org.cathori.backend.user.application.NotificationPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("NotificationService 통합 테스트")
+class NotificationServiceTest extends IntegrationTestBase {
+
+    @Autowired NotificationService notificationService;
+    @Autowired AlertHistoryJpaRepository alertHistoryJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @MockitoBean FcmPort fcmPort;
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final Long USER_ID = 100L;
+    private static final Long OTHER_USER_ID = 200L;
+
+    @AfterEach
+    void cleanup() {
+        alertHistoryJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+    }
+
+    // --- listNotifications ---
+
+    @Test
+    @DisplayName("NS-1: cursor null → 첫 페이지 최신순 반환")
+    void listNotifications_noCursor_returnsFirstPage() {
+        Notice notice = saveNotice("장학금 안내");
+        insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", "장학");
+
+        NotificationListResponse response = notificationService.listNotifications(USER_ID, null, 20);
+
+        assertThat(response.alerts()).hasSize(1);
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("NS-2: cursor 있음 → cursor 미만 결과만 포함")
+    void listNotifications_withCursor_returnsOnlyBelowCursor() {
+        Notice n1 = saveNotice("공지1");
+        Notice n2 = saveNotice("공지2");
+        Long id1 = insertAlertHistory(USER_ID, n1.getId(), "SUCCESS", null);
+        Long id2 = insertAlertHistory(USER_ID, n2.getId(), "SUCCESS", null);
+
+        NotificationListResponse response = notificationService.listNotifications(USER_ID, id2, 20);
+
+        assertThat(response.alerts()).hasSize(1);
+        assertThat(response.alerts().getFirst().alertHistoryId()).isEqualTo(id1);
+    }
+
+    @Test
+    @DisplayName("NS-3: size+1번째 존재 → hasNext=true, nextCursor 설정")
+    void listNotifications_hasMoreData_returnsHasNextTrue() {
+        Notice n1 = saveNotice("공지1");
+        Notice n2 = saveNotice("공지2");
+        Long id1 = insertAlertHistory(USER_ID, n1.getId(), "SUCCESS", null);
+        Long id2 = insertAlertHistory(USER_ID, n2.getId(), "SUCCESS", null);
+
+        NotificationListResponse response = notificationService.listNotifications(USER_ID, null, 1);
+
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.alerts()).hasSize(1);
+        assertThat(response.alerts().getFirst().alertHistoryId()).isEqualTo(id2);
+        assertThat(response.nextCursor()).isEqualTo(id2);
+    }
+
+    @Test
+    @DisplayName("NS-4: 전체 데이터 < size → hasNext=false, nextCursor=null")
+    void listNotifications_lessThanSize_returnsHasNextFalse() {
+        Notice notice = saveNotice("공지");
+        insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", null);
+
+        NotificationListResponse response = notificationService.listNotifications(USER_ID, null, 20);
+
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("NS-5: 결과 없음 → 빈 alerts, hasNext=false")
+    void listNotifications_noData_returnsEmpty() {
+        NotificationListResponse response = notificationService.listNotifications(USER_ID, null, 20);
+
+        assertThat(response.alerts()).isEmpty();
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("NS-6: createdAt이 OffsetDateTime +09:00 형식")
+    void listNotifications_createdAtHasKstOffset() {
+        Notice notice = saveNotice("공지");
+        insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", null);
+
+        NotificationListResponse response = notificationService.listNotifications(USER_ID, null, 20);
+
+        assertThat(response.alerts().getFirst().createdAt().getOffset())
+                .isEqualTo(ZoneOffset.ofHours(9));
+    }
+
+    // --- markRead ---
+
+    @Test
+    @DisplayName("NS-7: 내 알림 → isRead=true 저장")
+    void markRead_myAlert_setsIsReadTrue() {
+        Notice notice = saveNotice("공지");
+        Long historyId = insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", null);
+
+        notificationService.markRead(USER_ID, historyId);
+
+        boolean isRead = alertHistoryJpaRepository.findById(historyId).orElseThrow().isRead();
+        assertThat(isRead).isTrue();
+    }
+
+    @Test
+    @DisplayName("NS-8: 이미 읽은 알림 → 예외 없이 정상 처리 (멱등성)")
+    void markRead_alreadyRead_doesNotThrow() {
+        Notice notice = saveNotice("공지");
+        Long historyId = insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", null);
+
+        notificationService.markRead(USER_ID, historyId);
+        notificationService.markRead(USER_ID, historyId);
+
+        boolean isRead = alertHistoryJpaRepository.findById(historyId).orElseThrow().isRead();
+        assertThat(isRead).isTrue();
+    }
+
+    @Test
+    @DisplayName("NS-9: 존재하지 않는 alertHistoryId → ALERT_NOT_FOUND 예외")
+    void markRead_notExistingId_throwsAlertNotFound() {
+        assertThatThrownBy(() -> notificationService.markRead(USER_ID, 99999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AlertErrorCode.ALERT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("NS-10: 타인 알림 → ALERT_NOT_FOUND 예외")
+    void markRead_othersAlert_throwsAlertNotFound() {
+        Notice notice = saveNotice("공지");
+        Long historyId = insertAlertHistory(OTHER_USER_ID, notice.getId(), "SUCCESS", null);
+
+        assertThatThrownBy(() -> notificationService.markRead(USER_ID, historyId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AlertErrorCode.ALERT_NOT_FOUND));
+    }
+
+    private Notice saveNotice(String title) {
+        return noticeRepository.save(Notice.from(CrawledNotice.builder()
+                .articleNo("NS-" + title.hashCode())
+                .sourceType("MAIN").sourceId(null).category("일반")
+                .title(title).department("공지사항")
+                .postedAt(LocalDate.now().toString())
+                .url("https://example.com/" + title.hashCode())
+                .bodyText("").imageUrls(List.of()).build()));
+    }
+
+    private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag) {
+        return jdbcTemplate.queryForObject(
+                "INSERT INTO alert_history (user_id, notice_id, alarm_status, is_read, retry_count, created_at, matched_tag) " +
+                "VALUES (?, ?, ?, false, 0, now(), ?) RETURNING id",
+                Long.class, userId, noticeId, status, matchedTag);
+    }
+}

--- a/backend/src/test/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/infra/AlertHistoryRepositoryTest.java
@@ -29,14 +29,14 @@ class AlertHistoryRepositoryTest extends IntegrationTestBase {
     @Test
     @DisplayName("R-1: findFailedForRetry() — retryCount=0,1,2인 FAILED 이력 반환")
     void findFailedForRetry_returnsFailedWithRetryCountUnder3() {
-        AlertHistory h0 = AlertHistory.create(1L, 1L);
+        AlertHistory h0 = AlertHistory.create(1L, 1L, null);
         h0.markFailed();
 
-        AlertHistory h1 = AlertHistory.create(2L, 2L);
+        AlertHistory h1 = AlertHistory.create(2L, 2L, null);
         h1.markFailed();
         h1.incrementRetry();
 
-        AlertHistory h2 = AlertHistory.create(3L, 3L);
+        AlertHistory h2 = AlertHistory.create(3L, 3L, null);
         h2.markFailed();
         h2.incrementRetry();
         h2.incrementRetry();
@@ -53,7 +53,7 @@ class AlertHistoryRepositoryTest extends IntegrationTestBase {
     @Test
     @DisplayName("R-2: findFailedForRetry() — retryCount=3인 FAILED 이력 제외 (경계값)")
     void findFailedForRetry_excludesRetryCount3() {
-        AlertHistory h = AlertHistory.create(1L, 1L);
+        AlertHistory h = AlertHistory.create(1L, 1L, null);
         h.markFailed();
         h.incrementRetry();
         h.incrementRetry();

--- a/backend/src/test/java/org/cathori/backend/alert/infra/NotificationQueryAdapterTest.java
+++ b/backend/src/test/java/org/cathori/backend/alert/infra/NotificationQueryAdapterTest.java
@@ -1,0 +1,145 @@
+package org.cathori.backend.alert.infra;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.alert.application.NotificationQueryPort;
+import org.cathori.backend.alert.application.NotificationRow;
+import org.cathori.backend.notice.application.CrawledNotice;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.user.application.NotificationPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NotificationQueryAdapter 쿼리 테스트")
+class NotificationQueryAdapterTest extends IntegrationTestBase {
+
+    @Autowired NotificationQueryPort notificationQueryPort;
+    @Autowired AlertHistoryJpaRepository alertHistoryJpaRepository;
+    @Autowired NoticeRepository noticeRepository;
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @MockitoBean NotificationPort notificationPort;
+
+    private static final Long USER_ID = 1L;
+
+    @AfterEach
+    void cleanup() {
+        alertHistoryJpaRepository.deleteAll();
+        noticeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("AQ-1: alarm_status=SUCCESS만 반환 — PENDING, FAILED 제외")
+    void findByUserIdWithCursor_returnsOnlySuccess() {
+        Notice notice = saveNotice("장학금 안내");
+        insertAlertHistory(USER_ID, notice.getId(), "PENDING", null);
+        insertAlertHistory(USER_ID, notice.getId() + 1000, "FAILED", null);
+
+        Notice notice2 = saveNotice("다른 공지");
+        insertAlertHistory(USER_ID, notice2.getId(), "SUCCESS", "장학");
+
+        List<NotificationRow> result = notificationQueryPort.findByUserIdWithCursor(USER_ID, null, 10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().matchedTag()).isEqualTo("장학");
+    }
+
+    @Test
+    @DisplayName("AQ-2: cursor null → 전체 최신순 조회 (id DESC)")
+    void findByUserIdWithCursor_noCursor_returnsAllInDescOrder() {
+        Notice n1 = saveNotice("공지1");
+        Notice n2 = saveNotice("공지2");
+        insertAlertHistory(USER_ID, n1.getId(), "SUCCESS", null);
+        insertAlertHistory(USER_ID, n2.getId(), "SUCCESS", null);
+
+        List<NotificationRow> result = notificationQueryPort.findByUserIdWithCursor(USER_ID, null, 10);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).alertHistoryId()).isGreaterThan(result.get(1).alertHistoryId());
+    }
+
+    @Test
+    @DisplayName("AQ-3: cursor 있음 → id < cursor 조건 적용")
+    void findByUserIdWithCursor_withCursor_returnsOnlyBelowCursor() {
+        Notice n1 = saveNotice("공지1");
+        Notice n2 = saveNotice("공지2");
+        Long id1 = insertAlertHistory(USER_ID, n1.getId(), "SUCCESS", null);
+        Long id2 = insertAlertHistory(USER_ID, n2.getId(), "SUCCESS", null);
+
+        Long cursor = id2;
+        List<NotificationRow> result = notificationQueryPort.findByUserIdWithCursor(USER_ID, cursor, 10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().alertHistoryId()).isEqualTo(id1);
+    }
+
+    @Test
+    @DisplayName("AQ-4: limit 정확히 전달 — limit=2, 데이터 3개 → 2개만 반환")
+    void findByUserIdWithCursor_respectsLimit() {
+        Notice n1 = saveNotice("공지1");
+        Notice n2 = saveNotice("공지2");
+        Notice n3 = saveNotice("공지3");
+        insertAlertHistory(USER_ID, n1.getId(), "SUCCESS", null);
+        insertAlertHistory(USER_ID, n2.getId(), "SUCCESS", null);
+        insertAlertHistory(USER_ID, n3.getId(), "SUCCESS", null);
+
+        List<NotificationRow> result = notificationQueryPort.findByUserIdWithCursor(USER_ID, null, 2);
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("AQ-5: matched_tag, deadlineAt 정확히 반환")
+    void findByUserIdWithCursor_returnsCorrectFields() {
+        LocalDate deadline = LocalDate.of(2026, 6, 30);
+        Notice notice = saveNoticeWithDeadline("장학금 안내", deadline);
+        insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", "국가장학");
+
+        List<NotificationRow> result = notificationQueryPort.findByUserIdWithCursor(USER_ID, null, 10);
+
+        assertThat(result).hasSize(1);
+        NotificationRow row = result.getFirst();
+        assertThat(row.matchedTag()).isEqualTo("국가장학");
+        assertThat(row.deadlineAt()).isEqualTo(deadline);
+        assertThat(row.title()).isEqualTo("장학금 안내");
+    }
+
+    private Notice saveNotice(String title) {
+        return noticeRepository.save(Notice.from(CrawledNotice.builder()
+                .articleNo("AQ-" + title.hashCode())
+                .sourceType("MAIN").sourceId(null).category("일반")
+                .title(title).department("공지사항")
+                .postedAt(LocalDate.now().toString())
+                .url("https://example.com/" + title.hashCode())
+                .bodyText("").imageUrls(List.of()).build()));
+    }
+
+    private Notice saveNoticeWithDeadline(String title, LocalDate deadline) {
+        Notice notice = Notice.from(CrawledNotice.builder()
+                .articleNo("AQ-DL-" + title.hashCode())
+                .sourceType("MAIN").sourceId(null).category("일반")
+                .title(title).department("공지사항")
+                .postedAt(LocalDate.now().toString())
+                .url("https://example.com/dl/" + title.hashCode())
+                .bodyText("").imageUrls(List.of()).build());
+        Notice saved = noticeRepository.save(notice);
+        jdbcTemplate.update("UPDATE notices SET deadline_at = ? WHERE id = ?", deadline, saved.getId());
+        return saved;
+    }
+
+    private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag) {
+        return jdbcTemplate.queryForObject(
+                "INSERT INTO alert_history (user_id, notice_id, alarm_status, is_read, retry_count, created_at, matched_tag) " +
+                "VALUES (?, ?, ?, false, 0, now(), ?) RETURNING id",
+                Long.class, userId, noticeId, status, matchedTag);
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용

알림 이력 조회 및 읽음 처리 기능을 구현했다.

- `GET /api/notifications` — 사용자의 알림 이력 목록 조회 (커서 기반 페이지네이션)
- `PATCH /api/notifications/{alertHistoryId}/read` — 알림 읽음 처리
- FCM 발송 시 `matched_tag` 저장 — 공지 제목과 매칭된 태그 중 가나다 순 첫 번째를 `alert_history`에 함께 기록

## 🔍 동작 방식

**알림 목록 조회**

```
GET /api/notifications?cursor={id}&size=20
        ↓
NotificationQueryAdapter: alarm_status=SUCCESS인 이력만 JOIN 조회
        ↓
size+1건 조회 후 hasNext 판단
        ↓
createdAt → OffsetDateTime +09:00 변환 후 응답
```

**읽음 처리**

```
PATCH /api/notifications/{alertHistoryId}/read
        ↓
alertHistoryId + userId 조합으로 소유권 확인
        ↓ (없거나 타인 알림이면 404)
isRead = true 저장
```

**matched_tag 저장 흐름 (AlertService 변경)**

```
dispatchAlerts() 진입
        ↓
findFirstMatchedTagsByTitle(title): 공지 제목에 매칭되는 태그를 user_id별로 MIN(name) 집계
        ↓
AlertHistory.create(userId, noticeId, matchedTag)로 PENDING 행 INSERT
```

## 💡 설계 근거

**matched_tag를 발송 시점에 스냅샷으로 저장**
알림 목록에서 "어떤 태그 때문에 이 알림이 왔는지"를 표시하려면 태그 정보가 필요하다. 알림 조회 시점에 동적으로 계산하는 방식은 사용자가 태그를 삭제한 경우 매칭 태그가 사라지는 문제가 있다. 발송 시점에 스냅샷으로 저장하면 이후 태그가 삭제되어도 이력이 보존된다.

**커서 페이지네이션 기준을 `alert_history.id`로 선택**
`created_at` 기준 커서는 동일 시각 데이터가 있을 경우 중복/누락이 발생할 수 있다. `id`는 BIGINT 자동증가로 유일성이 보장되므로 커서로 사용했다.

## ✅ 체크리스트

- [x] `GET /api/notifications` 정상 응답 Swagger로 확인
- [x] `PATCH /{id}/read` 정상 응답 및 타인 알림 404 확인
- [x] 통합 테스트 전체 통과
- [x] `AlertHistory.create()` 시그니처 변경으로 인한 기존 호출부 전부 반영 확인

## 🔗 연관 이슈

closes #88