### PR TITLE
[FEAT] 회원탈퇴 UI 및 요청응답흐름 구현

### DIFF
--- a/backend/src/main/java/org/cathori/backend/user/api/UserController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/UserController.java
@@ -31,6 +31,9 @@ public class UserController {
     @DeleteMapping("/me")
     public ResponseEntity<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.withdraw(userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+
     @DeleteMapping("/device-token")
     public ResponseEntity<Void> clearDeviceToken(
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/backend/src/main/java/org/cathori/backend/user/application/UserService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/UserService.java
@@ -71,6 +71,8 @@ public class UserService {
         alertHistoryRepository.deleteByUserId(userId);
         refreshTokenRepository.deleteByUserId(userId);
         userRepository.delete(user);
+    }
+
     public void clearDeviceToken(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -30,6 +30,7 @@ import {
   Alert,
   AppState,
   Linking,
+  Modal,
   Platform,
   ScrollView,
   StyleSheet,
@@ -81,6 +82,9 @@ export default function SettingsScreen() {
 
   // ── 알림 권한 상태 ──
   const [notificationPermitted, setNotificationPermitted] = useState(true);
+
+  // ── 회원탈퇴 모달 ──
+  const [withdrawModalVisible, setWithdrawModalVisible] = useState(false);
   const appStateRef = useRef(AppState.currentState);
 
   /** OS 알림 권한 확인 */
@@ -147,6 +151,16 @@ const checkNotificationPermission = async () => {
   /** 알림 권한 배너 → OS 설정 이동 */
   const handleGoToPermissionSettings = () => {
     Linking.openSettings();
+  };
+
+  /** 회원탈퇴 확인 모달 열기 */
+  const handleWithdrawPress = () => {
+    setWithdrawModalVisible(true);
+  };
+
+  /** 회원탈퇴 확정 — TODO: 탈퇴 API 연동 */
+  const handleWithdrawConfirm = () => {
+    setWithdrawModalVisible(false);
   };
 
   /** 로그아웃 — 확인 다이얼로그 → clearAuth → 로그인 화면 이동 */
@@ -338,13 +352,25 @@ const checkNotificationPermission = async () => {
 
             {/* 로그아웃 */}
             <TouchableOpacity
-              style={styles.settingsRow}
+              style={[styles.settingsRow, styles.settingsRowBorder]}
               onPress={handleLogout}
               activeOpacity={0.7}
             >
               <View style={styles.settingsRowLeft}>
                 <Feather name="log-out" size={18} color="#BA1A1A" />
                 <Text style={styles.logoutText}>로그아웃</Text>
+              </View>
+            </TouchableOpacity>
+
+            {/* 회원탈퇴 */}
+            <TouchableOpacity
+              style={styles.settingsRow}
+              onPress={handleWithdrawPress}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingsRowLeft}>
+                <Feather name="user-x" size={18} color="#BA1A1A" />
+                <Text style={styles.withdrawText}>회원탈퇴</Text>
               </View>
             </TouchableOpacity>
           </View>
@@ -357,6 +383,42 @@ const checkNotificationPermission = async () => {
           </Text>
         </View>
       </ScrollView>
+
+      {/* ── 회원탈퇴 확인 모달 ── */}
+      <Modal
+        visible={withdrawModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setWithdrawModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalCard}>
+            <View style={styles.modalIconWrapper}>
+              <Feather name="alert-triangle" size={28} color="#BA1A1A" />
+            </View>
+            <Text style={styles.modalTitle}>회원탈퇴</Text>
+            <Text style={styles.modalDescription}>
+              탈퇴 시 모든 데이터가 삭제되며{'\n'}복구할 수 없습니다.{'\n'}정말 탈퇴하시겠습니까?
+            </Text>
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                style={[styles.modalButton, styles.modalButtonConfirm]}
+                onPress={handleWithdrawConfirm}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.modalButtonConfirmText}>탈퇴하기</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalButton, styles.modalButtonCancel]}
+                onPress={() => setWithdrawModalVisible(false)}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.modalButtonCancelText}>취소</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -571,6 +633,94 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: '#BA1A1A',
     letterSpacing: -0.375,
+  },
+  withdrawText: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '500',
+    color: '#BA1A1A',
+    letterSpacing: -0.375,
+  },
+
+  // ─── 회원탈퇴 모달 ───
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  modalCard: {
+    width: '100%',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 24,
+    padding: 28,
+    alignItems: 'center',
+    gap: 12,
+    ...Platform.select({
+      android: { elevation: 8 },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.12,
+        shadowRadius: 16,
+      },
+    }),
+  },
+  modalIconWrapper: {
+    width: 56,
+    height: 56,
+    borderRadius: 9999,
+    backgroundColor: 'rgba(186, 26, 26, 0.08)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  modalTitle: {
+    fontFamily: 'Pretendard',
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#BA1A1A',
+    letterSpacing: -0.45,
+  },
+  modalDescription: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 8,
+  },
+  modalButtons: {
+    flexDirection: 'row',
+    gap: 12,
+    width: '100%',
+  },
+  modalButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modalButtonCancel: {
+    backgroundColor: '#F2F2F2',
+  },
+  modalButtonConfirm: {
+    backgroundColor: '#BA1A1A',
+  },
+  modalButtonCancelText: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '600',
+    color: Colors.textPrimary,
+  },
+  modalButtonConfirmText: {
+    fontFamily: 'Pretendard',
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#FFFFFF',
   },
 
   // ─── 푸터 ───

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -42,6 +42,7 @@ import {
 } from 'react-native';
 
 import { Colors } from '@/src/constants/colors';
+import { withdraw } from '@/src/services/auth';
 import { unregisterDeviceToken } from '@/src/services/pushToken';
 import { MainHeader } from '@/src/shared/components';
 import { useAuthStore } from '@/src/store/useAuthStore';
@@ -158,9 +159,23 @@ const checkNotificationPermission = async () => {
     setWithdrawModalVisible(true);
   };
 
-  /** 회원탈퇴 확정 — TODO: 탈퇴 API 연동 */
-  const handleWithdrawConfirm = () => {
+  /** 회원탈퇴 확정 — DELETE /api/users/me → clearAuth → 로그인 화면 이동 */
+  const handleWithdrawConfirm = async () => {
     setWithdrawModalVisible(false);
+    try {
+      await withdraw();
+    } catch (e) {
+      console.warn('[withdraw] 탈퇴 API 실패:', e);
+      Alert.alert('탈퇴 실패', '회원탈퇴 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+    try {
+      await unregisterDeviceToken();
+    } catch (e) {
+      console.warn('[push] 토큰 반납 실패:', e);
+    }
+    clearAuth();
+    router.replace('/login');
   };
 
   /** 로그아웃 — 확인 다이얼로그 → clearAuth → 로그인 화면 이동 */

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -72,3 +72,10 @@ export async function verifyEmail(
   );
   return data;
 }
+
+/**
+ * 회원탈퇴 — 계정 및 관련 데이터(태그/북마크/알림/토큰) 전체 삭제
+ */
+export async function withdraw(): Promise<void> {
+  await apiClient.delete('/api/users/me');
+}


### PR DESCRIPTION
## 🔧 작업 내용

설정 화면에 회원탈퇴 기능을 추가했습니다.

- 회원탈퇴 버튼 및 확인 모달 UI 구현
- `withdraw()` API 호출 후 `clearAuth()` → 로그인 화면 이동
- `auth.ts`에 `withdraw()` 서비스 함수 추가

## 🔍 동작 방식

```
설정 화면 → 회원탈퇴 버튼 탭
   ↓
확인 모달 표시
   ↓
탈퇴하기 버튼 탭
   ↓
DELETE /api/users/me 요청
   ↓ 실패 시 Alert 표시 후 중단
unregisterDeviceToken() 시도 (실패해도 탈퇴 흐름 계속)
   ↓
clearAuth() → AsyncStorage 초기화
   ↓
로그인 화면으로 이동
```

## 💡 설계 근거

**withdraw() 실패 시 clearAuth() 차단**
탈퇴는 되돌릴 수 없는 작업이므로 서버 응답 성공을 확인한 후에만 클라이언트 상태를 초기화합니다.

**unregisterDeviceToken 실패 허용**
디바이스 토큰 반납은 부가 작업이므로 실패해도 탈퇴 흐름을 막지 않습니다.

## ✅ 체크리스트

- [x] 탈퇴 성공 시 로그인 화면 이동 확인
- [x] 모달 취소 버튼 동작 확인
- [x] clearAuth() 후 AsyncStorage 초기화 확인

## 🔗 연관 이슈

closes #106 