### PR TITLE
[CHORE] Phase 4 — 서버 1차 MVP 테스트 후 세팅 마무리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to NCP
 on:
   push:
     branches:
-      - develop
+      - main
     paths:
       - 'backend/**'
       - 'nginx/**'

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
@@ -18,8 +18,7 @@ public class CrawlingScheduler {
 
     private final NoticeService noticeService;
 
-    // @Scheduled(cron = "0 0 0,12 * * *") // 12시간에 한번
-    @Scheduled(cron = "${crawler.dispatch.cron}") // 1시간에 한번
+    @Scheduled(cron = "${crawler.dispatch.cron}")
     public void scheduleCrawling() {
         log.info("크롤링 시작");
         int total = 0;

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
@@ -1,14 +1,15 @@
 package org.cathori.backend.notice.infra.crawler;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.cathori.backend.notice.application.CrawledNotice;
 import org.cathori.backend.notice.application.NoticeService;
 import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -17,7 +18,8 @@ public class CrawlingScheduler {
 
     private final NoticeService noticeService;
 
-    @Scheduled(cron = "0 0 0,12 * * *") // 12시간에 한번
+    // @Scheduled(cron = "0 0 0,12 * * *") // 12시간에 한번
+    @Scheduled(cron = "${crawler.dispatch.cron}") // 1시간에 한번
     public void scheduleCrawling() {
         log.info("크롤링 시작");
         int total = 0;

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -30,6 +30,7 @@ jwt.access-token-expiry=${JWT_ACCESS_TOKEN_EXPIRY}
 jwt.refresh-token-expiry=${JWT_REFRESH_TOKEN_EXPIRY}
 
 # ALRAM
+crawler.dispatch.cron=0 0 */1 * * *
 alert.dispatch.cron=0 */2 * * * *
 
 # Firebase

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -30,7 +30,8 @@ jwt.access-token-expiry=${JWT_ACCESS_TOKEN_EXPIRY}
 jwt.refresh-token-expiry=${JWT_REFRESH_TOKEN_EXPIRY}
 
 # ALRAM
-alert.dispatch.cron=0 */2 * * * *
+crawler.dispatch.cron=0 0 0,12 * * *
+alert.dispatch.cron=0 0 10 * * *
 
 # swagger
 springdoc.api-docs.enabled=false


### PR DESCRIPTION
# 1. 📖 작업 배경

NCP 배포 파이프라인을 코드화하고 첫 통합 검증까지 끝냈다. 그동안 자동배포 트리거는 안정화를 위해 임시로 **`develop`** 에 걸어 두었는데, 검증이 마무리됐으므로 본 PR로 **운영 모드로 확정**한다. 동시에 코드에 하드코딩돼 있던 스케줄러 cron을 환경변수로 외부화해 로컬/운영이 서로 다른 주기를 쓰도록 분리한다.

- #110

> 이 PR로 백엔드 축이 완료된다.

<br>

## 🔧 작업 내용

### A. 자동배포 운영 전환 (`.github/workflows/deploy.yml`)
- `on.push.branches` **`develop` → `main`**. 이제 `main`에 `backend/**`·`nginx/**`·`docker-compose.prod.yml` 변경이 push되면 운영 자동배포.

### B. 스케줄러 cron 외부화
- **`CrawlingScheduler`** — `@Scheduled(cron = "0 0 0,12 * * *")` 하드코딩 → `@Scheduled(cron = "${crawler.dispatch.cron}")` 플레이스홀더화.
- **`application-local.properties`** — `crawler.dispatch.cron=0 0 */1 * * *` (로컬 1시간 주기).
- **`application-prod.properties`** — `crawler.dispatch.cron=0 0 0,12 * * *` (운영 12시간), `alert.dispatch.cron=0 0 10 * * *` 이전 PR에서 테스트 주기로 단축했던 값을 **운영값으로 복원**.

### C. 정리
- `CrawlingScheduler` import 정렬 + 불필요 주석 제거.

<br>

## 🔍 동작 방식

```
[운영] main push (backend/** 등 변경) → Actions: Bastion ProxyJump → web-was
  → cd /home/${WAS_USER}/cathori && git pull
  → docker compose -f docker-compose.prod.yml up -d --build
  → prod 프로파일 활성 → crawler.dispatch.cron=0 0 0,12 (12시간), alert.dispatch.cron=0 0 10 (오전 10시)
[로컬] local 프로파일 → crawler 1시간 주기로 개발 중 동작 확인
```

<br>

## 💡 설계 근거

- **트리거 `main` 승격** — `develop`는 검증용이었고, 운영 배포 의도를 `main` 머지에 일치시키는 게 GitOps 흐름상 자연스럽다. 검증이 끝난 시점에 올려야 "코드에 박힌 테스트 트리거"가 운영에 남는 사고를 막는다.
- **cron 외부화 + 프로파일 분리** — 로컬은 잦은 주기(1시간)로 빠르게 동작을 확인하고, 운영은 12시간/오전10시. 같은 코드가 프로파일만 바꿔 다른 주기로 도는 게 "테스트용 단축 → 운영 복원" 수작업을 없앤다.

<br>

## ✅ 체크리스트

- [x] `deploy.yml` 트리거 `develop` → `main`
- [x] `CrawlingScheduler` cron `${crawler.dispatch.cron}` 외부화
- [x] `application-local.properties` 로컬 cron(1시간) 추가
- [x] `application-prod.properties` 운영 cron(크롤러 12시간 / 발송 오전10시) 복원
- [x] import 정렬·주석 정리

<br>

## 🐛 관련 트러블슈팅

비고

<br>

## 🔗 연관 이슈

- #96 
