### PR TITLE
JWT 토큰 검증 및 클라이언트 저장 방식 개선

### DIFF
--- a/backend/src/main/java/org/cathori/backend/security/JwtFilter.java
+++ b/backend/src/main/java/org/cathori/backend/security/JwtFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -28,8 +29,8 @@ public class JwtFilter extends OncePerRequestFilter {
      *
      * 1. 요청 헤더에서 "Authorization: Bearer {토큰}" 형식으로 토큰 추출
      * 2. 토큰이 없거나 형식이 맞지 않으면 검증 없이 다음 필터로 넘김 (인증 제외 경로 처리)
-     * 3. 토큰 유효성 검증 → userId 추출 → DB에서 사용자 조회
-     * 4. 조회한 사용자 정보를 SecurityContext에 등록
+     * 3. 액세스 토큰 유효성 검증 (형식/서명/알고리즘 -> type=access -> 만료기한) → userId 추출
+     * 4. subject가 유효한 사용자인지 DB 조회로 확인 → SecurityContext에 등록
      *    → 이후 컨트롤러에서 @AuthenticationPrincipal로 꺼내 쓸 수 있음
      * 5. 다음 필터로 넘김
      */
@@ -41,14 +42,19 @@ public class JwtFilter extends OncePerRequestFilter {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
 
-            if (jwtUtil.validateToken(token)) {
+            if (jwtUtil.validateAccessToken(token)) {
                 Long userId = jwtUtil.extractUserId(token);
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
 
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                try {
+                    UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
+
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (UsernameNotFoundException e) {
+                    SecurityContextHolder.clearContext();
+                }
             }
         }
 

--- a/backend/src/main/java/org/cathori/backend/security/JwtUtil.java
+++ b/backend/src/main/java/org/cathori/backend/security/JwtUtil.java
@@ -1,5 +1,7 @@
 package org.cathori.backend.security;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
@@ -12,6 +14,10 @@ import java.util.Date;
 
 @Component
 public class JwtUtil {
+
+    private static final String CLAIM_TYPE = "type";
+    private static final String TOKEN_TYPE_ACCESS = "access";
+    private static final String TOKEN_TYPE_REFRESH = "refresh";
 
     @Value("${jwt.secret-key}")
     private String secretKey;
@@ -40,6 +46,7 @@ public class JwtUtil {
     public String generateAccessToken(Long userId) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
+                .claim(CLAIM_TYPE, TOKEN_TYPE_ACCESS)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpiry))
                 .signWith(getSigningKey())
@@ -54,30 +61,60 @@ public class JwtUtil {
     public String generateRefreshToken(Long userId) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
+                .claim(CLAIM_TYPE, TOKEN_TYPE_REFRESH)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiry))
                 .signWith(getSigningKey())
                 .compact();
     }
 
-
-    public boolean validateToken(String token) {
+    /**
+     * 서명/포맷/허용 알고리즘을 검증하고 claims를 반환한다.
+     * exp가 지났더라도 type 클레임은 먼저 확인할 수 있도록,
+     * 만료 예외는 잡아서 claims를 그대로 반환한다 (만료 여부는 호출부에서 별도 판단).
+     */
+    private Claims parseClaims(String token) {
         try {
-            Jwts.parser()
+            return Jwts.parser()
                     .verifyWith(getSigningKey())
                     .build()
-                    .parseSignedClaims(token);
-            return true;
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    /**
+     * 액세스 토큰 검증: 형식/서명/알고리즘 -> type=access -> 만료기한 순으로 확인한다.
+     * (subject의 사용자 유효성은 JwtFilter에서 DB 조회로 별도 확인한다)
+     */
+    public boolean validateAccessToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            if (!TOKEN_TYPE_ACCESS.equals(claims.get(CLAIM_TYPE, String.class))) {
+                return false;
+            }
+            Date expiration = claims.getExpiration();
+            return expiration != null && expiration.after(new Date());
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
     }
 
     /**
-     * 토큰의 유효성을 검증한다. (로그인 이후 매 요청 시 JwtFilter에서 호출)
-     * 서명이 올바른지, 만료되지 않았는지 확인한다.
-     * 검증 실패 시 JwtException이 발생하며 false를 반환한다.
+     * 리프레시 토큰 여부 검증: 형식/서명/알고리즘 -> type=refresh 순으로 확인한다.
+     * DB 일치 여부, 만료기한(DB 기준), subject 사용자 유효성은 AuthService에서 확인한다.
      */
+    public boolean isRefreshToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return TOKEN_TYPE_REFRESH.equals(claims.get(CLAIM_TYPE, String.class));
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     public Long extractUserId(String token) {
         String subject = Jwts.parser()
                 .verifyWith(getSigningKey())

--- a/backend/src/main/java/org/cathori/backend/security/TokenHasher.java
+++ b/backend/src/main/java/org/cathori/backend/security/TokenHasher.java
@@ -1,0 +1,22 @@
+package org.cathori.backend.security;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+@Component
+public class TokenHasher {
+
+    public String hash(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
@@ -2,6 +2,7 @@ package org.cathori.backend.user.application;
 
 import org.cathori.backend.common.exception.BusinessException;
 import org.cathori.backend.security.JwtUtil;
+import org.cathori.backend.security.TokenHasher;
 import org.cathori.backend.tag.application.TagService;
 import org.cathori.backend.tag.api.dto.TagDto;
 import org.cathori.backend.user.UserErrorCode;
@@ -27,6 +28,7 @@ public class AuthService {
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final TokenHasher tokenHasher;
     private final TagService tagService;
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -34,12 +36,13 @@ public class AuthService {
     private long refreshTokenExpiry;
 
     public AuthService(VerifiedEmailStore verifiedEmailStore, UserService userService,
-                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil, TagService tagService,
-                       RefreshTokenRepository refreshTokenRepository) {
+                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil, TokenHasher tokenHasher,
+                       TagService tagService, RefreshTokenRepository refreshTokenRepository) {
         this.verifiedEmailStore = verifiedEmailStore;
         this.userService = userService;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil = jwtUtil;
+        this.tokenHasher = tokenHasher;
         this.tagService = tagService;
         this.refreshTokenRepository = refreshTokenRepository;
     }
@@ -71,7 +74,7 @@ public class AuthService {
         String refreshTokenValue = jwtUtil.generateRefreshToken(user.getId());
 
         refreshTokenRepository.deleteByUserId(user.getId());
-        refreshTokenRepository.save(RefreshToken.create(user.getId(), refreshTokenValue, refreshTokenExpiry));
+        refreshTokenRepository.save(RefreshToken.create(user.getId(), tokenHasher.hash(refreshTokenValue), refreshTokenExpiry));
 
         List<TagDto> tags = tagService.getTagsByUserId(user.getId());
 
@@ -86,7 +89,13 @@ public class AuthService {
 
     @Transactional
     public ReissueResponse reissue(ReissueRequest request) {
-        RefreshToken stored = refreshTokenRepository.findByToken(request.refreshToken())
+        String refreshTokenValue = request.refreshToken();
+
+        if (!jwtUtil.isRefreshToken(refreshTokenValue)) {
+            throw new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        RefreshToken stored = refreshTokenRepository.findByToken(tokenHasher.hash(refreshTokenValue))
                 .orElseThrow(() -> new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID));
 
         if (stored.isExpired()) {
@@ -94,11 +103,14 @@ public class AuthService {
             throw new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID);
         }
 
-        String newAccessToken = jwtUtil.generateAccessToken(stored.getUserId());
-        String newRefreshTokenValue = jwtUtil.generateRefreshToken(stored.getUserId());
+        User user = userService.findById(stored.getUserId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        refreshTokenRepository.deleteByUserId(stored.getUserId());
-        refreshTokenRepository.save(RefreshToken.create(stored.getUserId(), newRefreshTokenValue, refreshTokenExpiry));
+        String newAccessToken = jwtUtil.generateAccessToken(user.getId());
+        String newRefreshTokenValue = jwtUtil.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.save(RefreshToken.create(user.getId(), tokenHasher.hash(newRefreshTokenValue), refreshTokenExpiry));
 
         return new ReissueResponse(newAccessToken, newRefreshTokenValue);
     }

--- a/backend/src/main/java/org/cathori/backend/user/application/UserService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/UserService.java
@@ -44,6 +44,10 @@ public class UserService {
         return userRepository.findByEmail(email);
     }
 
+    public Optional<User> findById(Long userId) {
+        return userRepository.findById(userId);
+    }
+
     @Transactional
     public User save(RegisterRequest request) {
         String encoded = passwordEncoder.encode(request.password());

--- a/backend/src/main/java/org/cathori/backend/user/domain/RefreshToken.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/RefreshToken.java
@@ -20,6 +20,7 @@ public class RefreshToken {
     @Column(nullable = false)
     private Long userId;
 
+    /** raw refresh token의 SHA-256 해시값 (원문은 저장하지 않음) */
     @Column(nullable = false, unique = true, length = 500)
     private String token;
 

--- a/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
@@ -1,12 +1,14 @@
 package org.cathori.backend.user.api;
 
 import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.security.JwtUtil;
 import org.cathori.backend.user.application.AuthService;
 import org.cathori.backend.user.application.NotificationPort;
 import org.cathori.backend.user.application.VerificationStore;
 import org.cathori.backend.user.application.VerifiedEmailStore;
 import org.cathori.backend.user.api.dto.LoginRequest;
 import org.cathori.backend.user.api.dto.RegisterRequest;
+import org.cathori.backend.user.api.dto.ReissueRequest;
 import org.cathori.backend.user.infra.UserJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 
@@ -32,6 +36,7 @@ class AuthIntegrationTest extends IntegrationTestBase {
     @Autowired VerifiedEmailStore verifiedEmailStore;
     @Autowired VerificationStore verificationStore;
     @Autowired UserJpaRepository userJpaRepository;
+    @Autowired JwtUtil jwtUtil;
     @MockitoBean
     NotificationPort notificationPort;
 
@@ -130,5 +135,69 @@ class AuthIntegrationTest extends IntegrationTestBase {
                         .content(objectMapper.writeValueAsString(new LoginRequest("nobody@catholic.ac.kr", PASSWORD))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("A-7: 정상 refreshToken으로 재발급 요청 시 200과 새 accessToken/refreshToken 반환")
+    void reissue_success() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+        String refreshToken = loginAndGetRefreshToken();
+
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReissueRequest(refreshToken))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isString())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("A-8: accessToken을 refreshToken 자리에 보내면 (type 불일치) 401 REFRESH_TOKEN_INVALID 반환")
+    void reissue_rejectsAccessTokenAsRefreshToken() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+        String accessToken = loginAndGetAccessToken();
+
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReissueRequest(accessToken))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_INVALID"));
+    }
+
+    @Test
+    @DisplayName("A-9: DB에 저장되지 않은 refreshToken으로 재발급 시도 시 401 REFRESH_TOKEN_INVALID 반환")
+    void reissue_rejectsUnknownRefreshToken() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+        Long userId = userJpaRepository.findByEmail(EMAIL).orElseThrow().getId();
+        String unstoredRefreshToken = jwtUtil.generateRefreshToken(userId);
+
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReissueRequest(unstoredRefreshToken))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_INVALID"));
+    }
+
+    private String loginAndGetRefreshToken() throws Exception {
+        return extractField(login(), "refreshToken");
+    }
+
+    private String loginAndGetAccessToken() throws Exception {
+        return extractField(login(), "accessToken");
+    }
+
+    private MvcResult login() throws Exception {
+        return mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest(EMAIL, PASSWORD))))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    private String extractField(MvcResult result, String field) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.get(field).asText();
     }
 }

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,21 @@
+# Testcontainers - Spring Boot? ???? DB ?? ??? ????? ?? ???
+
+spring.datasource.url=jdbc:tc:postgresql:16-alpine:///cathori
+spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+
+
+# JPA
+
+spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.jpa.show-sql=false
+
+
+# ????? ???? ?? ????
+
+spring.mail.host=
+gemini.api.key=test
+jwt.secret-key=Y2F0aG9yaVNlY3JldEtleUZvckpXVEF1dGhlbnRpY2F0aW9uMjAyNg==
+jwt.access-token-expiry=3600000
+jwt.refresh-token-expiry=2592000000
+firebase.credential.path=src/main/resources/cathori-firebase.json

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -37,6 +37,7 @@ export default {
         dark: { backgroundColor: "#000000" }
       }],
       ["expo-notifications", { color: "#00288C" }],
+      "expo-secure-store",
       "expo-font"
     ],
     experiments: {

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -174,7 +174,7 @@ const checkNotificationPermission = async () => {
     } catch (e) {
       console.warn('[push] 토큰 반납 실패:', e);
     }
-    clearAuth();
+    await clearAuth();
     router.replace('/login');
   };
 
@@ -196,7 +196,7 @@ const checkNotificationPermission = async () => {
             } catch (e) {
               console.warn('[push] 토큰 반납 실패:', e);
             }
-            clearAuth();
+            await clearAuth();
             router.replace('/login');
           },
         },

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -63,15 +63,30 @@ export default function RootLayout() {
   const [isRehydrated, setIsRehydrated] = useState(false);
 
   useEffect(() => {
+    let initializationStarted = false;
+
+    const initialize = () => {
+      if (initializationStarted) return;
+      initializationStarted = true;
+
+      void useAuthStore
+        .getState()
+        .initializeAuth()
+        .catch((error) => {
+          console.warn('[auth] Failed to restore tokens:', error);
+        })
+        .finally(() => {
+          setIsRehydrated(true);
+        });
+    };
+
     // Zustand persist rehydrate 완료 대기
     // useAuthStore.persist.onFinishHydration은 이미 hydrate 되었으면 즉시 호출 (휴대폰에서 영구 저장소에서 토큰 데이터 불러오게 되었을 때 호출)
-    const unsubscribe = useAuthStore.persist.onFinishHydration(() => {
-      setIsRehydrated(true);
-    });
+    const unsubscribe = useAuthStore.persist.onFinishHydration(initialize);
 
     // 이미 rehydrate가 완료된 경우를 대비
     if (useAuthStore.persist.hasHydrated()) {
-      setIsRehydrated(true);
+      initialize();
     }
 
     return unsubscribe;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "expo-linking": "~8.0.11",
         "expo-notifications": "~0.32.17",
         "expo-router": "~6.0.24",
+        "expo-secure-store": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
@@ -93,6 +94,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1495,6 +1497,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3629,6 +3632,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -3851,8 +3855,9 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3923,6 +3928,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -4285,9 +4291,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4302,9 +4305,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4319,9 +4319,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4336,9 +4333,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4353,9 +4347,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4370,9 +4361,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4387,9 +4375,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4404,9 +4389,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4534,6 +4516,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5269,6 +5252,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5813,7 +5797,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -6389,6 +6373,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6585,6 +6570,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6875,6 +6861,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
       "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.25",
@@ -6962,6 +6949,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -7059,6 +7047,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
       "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -7115,6 +7104,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
       "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.13",
         "invariant": "^2.2.4"
@@ -7437,6 +7427,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {
@@ -9147,6 +9146,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10164,9 +10164,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10186,9 +10183,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10210,9 +10204,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10232,9 +10223,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12034,6 +12022,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12053,6 +12042,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -12089,6 +12079,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -12146,6 +12137,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -12171,6 +12163,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -12198,6 +12191,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -12208,6 +12202,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -12223,6 +12218,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -12255,6 +12251,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -12365,6 +12362,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13951,8 +13949,9 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "expo-linking": "~8.0.11",
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.24",
+    "expo-secure-store": "~15.0.8",
     "expo-sharing": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/frontend/src/features/auth/hooks/useLogin.ts
+++ b/frontend/src/features/auth/hooks/useLogin.ts
@@ -2,7 +2,7 @@
  * 로그인 TanStack Query mutation 훅
  *
  * 성공 시:
- *  1. useAuthStore.setAuth(response) → 토큰+사용자+태그 영속 저장
+ *  1. useAuthStore.setAuth(response) → 토큰은 SecureStore, 사용자 정보는 AsyncStorage에 저장
  *  2. 라우팅 가드가 accessToken 감지 → 자동으로 (tabs)로 이동
  *
  * 에러 분기 (API 명세 기반):
@@ -59,10 +59,10 @@ export function useLogin() {
     LoginRequest
   >({
     mutationFn: login,
-    onSuccess: (response) => {
-      // 토큰 + 사용자 정보 + 태그 영속 저장
+    onSuccess: async (response) => {
+      // 토큰은 SecureStore, 사용자 정보와 태그는 AsyncStorage에 저장
       // _layout.tsx의 useProtectedRoute가 accessToken 변경 감지 → (tabs)로 자동 이동
-      setAuth(response);
+      await setAuth(response);
     },
   });
 

--- a/frontend/src/features/auth/hooks/useRegister.ts
+++ b/frontend/src/features/auth/hooks/useRegister.ts
@@ -87,7 +87,7 @@ export function useRegister() {
           password: req.password,
         });
         // 토큰 + 사용자 정보 + 태그 영속 저장
-        setAuth(loginResponse);
+        await setAuth(loginResponse);
       } catch (autoLoginError) {
         // 가입은 성공했지만 자동 로그인 실패 — 별도 에러 코드로 처리
         throw {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,7 +35,7 @@ apiClient.interceptors.request.use(
 // ─── 응답 인터셉터 ─────────────────────────────────────────────────
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
     // 401 Unauthorized → 토큰 클리어 + 로그인 화면 리다이렉트
     // 1차 MVP: refreshToken 갱신 미구현, 단순 로그아웃 처리
     // (트랩 #9: accessToken 만료 + refreshToken 유효 케이스는 추후에 재검토)
@@ -45,7 +45,7 @@ apiClient.interceptors.response.use(
       // 이미 인증 토큰이 있었는데 401을 받은 경우에만 로그아웃 처리
       // (인증 불필요 API의 401은 무시 — 로그인/회원가입 API의 비밀번호 오답 등)
       if (accessToken) {
-        useAuthStore.getState().clearAuth();
+        await useAuthStore.getState().clearAuth();
         router.replace('/login' as never);
       }
     }

--- a/frontend/src/services/tokenStorage.ts
+++ b/frontend/src/services/tokenStorage.ts
@@ -1,0 +1,59 @@
+import * as SecureStore from 'expo-secure-store';
+
+const ACCESS_TOKEN_KEY = 'cathori.auth.access-token';
+const REFRESH_TOKEN_KEY = 'cathori.auth.refresh-token';
+const SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  requireAuthentication: false,
+};
+
+export interface StoredTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export async function saveTokens(tokens: StoredTokens): Promise<void> {
+  try {
+    await Promise.all([
+      SecureStore.setItemAsync(
+        ACCESS_TOKEN_KEY,
+        tokens.accessToken,
+        SECURE_STORE_OPTIONS,
+      ),
+      SecureStore.setItemAsync(
+        REFRESH_TOKEN_KEY,
+        tokens.refreshToken,
+        SECURE_STORE_OPTIONS,
+      ),
+    ]);
+  } catch (error) {
+    // Do not leave a partially written token pair behind.
+    await Promise.allSettled([
+      SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY, SECURE_STORE_OPTIONS),
+      SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY, SECURE_STORE_OPTIONS),
+    ]);
+    throw error;
+  }
+}
+
+export async function getTokens(): Promise<StoredTokens | null> {
+  const [accessToken, refreshToken] = await Promise.all([
+    SecureStore.getItemAsync(ACCESS_TOKEN_KEY, SECURE_STORE_OPTIONS),
+    SecureStore.getItemAsync(REFRESH_TOKEN_KEY, SECURE_STORE_OPTIONS),
+  ]);
+
+  if (!accessToken || !refreshToken) {
+    if (accessToken || refreshToken) {
+      await clearTokens();
+    }
+    return null;
+  }
+
+  return { accessToken, refreshToken };
+}
+
+export async function clearTokens(): Promise<void> {
+  await Promise.all([
+    SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY, SECURE_STORE_OPTIONS),
+    SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY, SECURE_STORE_OPTIONS),
+  ]);
+}

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,13 +1,14 @@
 /**
- * 인증 상태 Zustand 스토어 (AsyncStorage 영속화)
+ * 인증 상태 Zustand 스토어
  *
  * 정책:
- *  - accessToken + refreshToken을 영속 저장 (앱 재실행 시 자동 로그인 기반)
- *  - user 정보 + tags도 영속 저장 (로그인 응답 한 번으로 채움, 별도 조회 불필요)
+ *  - accessToken + refreshToken은 OS 보안 저장소(SecureStore)에 저장
+ *  - user 정보 + tags는 AsyncStorage에 영속 저장
  *  - clearAuth() 호출 시 토큰·사용자·태그 모두 초기화 (로그아웃)
  *
  * 영속화:
- *  - zustand/middleware persist + createJSONStorage(() => AsyncStorage)
+ *  - persist 미들웨어는 user + tags만 AsyncStorage에 저장
+ *  - 앱 시작 시 SecureStore의 토큰을 메모리 상태로 복원
  *  - 키: 'cathori-auth'
  *  - 앱 재시작 후 자동 rehydrate
  *
@@ -18,6 +19,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import {
+  clearTokens,
+  getTokens,
+  saveTokens,
+} from '@/src/services/tokenStorage';
 import type { AuthUser, LoginResponse, UserTag } from '@/src/types/auth';
 
 interface AuthState {
@@ -34,13 +40,16 @@ interface AuthState {
    * 로그인 성공 시 호출 — 토큰 + 사용자 정보 + 태그를 한 번에 세팅
    * LoginResponse를 그대로 받아 필요한 필드를 추출
    */
-  setAuth: (response: LoginResponse) => void;
+  setAuth: (response: LoginResponse) => Promise<void>;
 
   /**
    * 로그아웃 시 호출 — 토큰·사용자·태그 모두 초기화
-   * AsyncStorage에서도 자동으로 삭제됨 (persist 미들웨어)
+   * SecureStore의 토큰과 AsyncStorage의 사용자 정보를 함께 삭제
    */
-  clearAuth: () => void;
+  clearAuth: () => Promise<void>;
+
+  /** SecureStore에 저장된 토큰을 앱 메모리로 복원합니다. */
+  initializeAuth: () => Promise<void>;
 
   /**
    * 태그 목록 갱신 — 태그 추가/삭제 후 클라이언트 낙관적 갱신용
@@ -56,12 +65,18 @@ const INITIAL_STATE = {
   tags: [] as UserTag[],
 };
 
+type PersistedAuthState = Pick<AuthState, 'user' | 'tags'>;
+
 export const useAuthStore = create<AuthState>()(
-  persist(
+  persist<AuthState, [], [], PersistedAuthState>(
     (set) => ({
       ...INITIAL_STATE, // 스토어 처음 켜졌을 시 세팅용 초기값
 
-      setAuth: (response) =>
+      setAuth: async (response) => {
+        await saveTokens({
+          accessToken: response.accessToken,
+          refreshToken: response.refreshToken,
+        });
         set({
           accessToken: response.accessToken,
           refreshToken: response.refreshToken,
@@ -74,15 +89,31 @@ export const useAuthStore = create<AuthState>()(
             enrollmentStatus: response.enrollmentStatus,
           },
           tags: response.tags,
-        }),
+        });
+      },
 
-      clearAuth: () => set({ ...INITIAL_STATE }),
+      clearAuth: async () => {
+        await clearTokens();
+        set({ ...INITIAL_STATE });
+      },
+
+      initializeAuth: async () => {
+        const tokens = await getTokens();
+        set({
+          accessToken: tokens?.accessToken ?? null,
+          refreshToken: tokens?.refreshToken ?? null,
+        });
+      },
 
       updateTags: (tags) => set({ tags }),
     }),
     {
       name: 'cathori-auth', // 저장소 안의 아이템의 이름
-      storage: createJSONStorage(() => AsyncStorage), // AsyncStorage에 저장
+      storage: createJSONStorage(() => AsyncStorage), // 사용자 정보와 태그만 저장
+      partialize: (state) => ({
+        user: state.user,
+        tags: state.tags,
+      }),
     },
   ),
 );


### PR DESCRIPTION
## 🔧 작업 내용

- access token과 refresh token에 `type` 클레임 추가
- API 인증 시 access token만 허용하도록 검증 로직 분리
- 토큰 재발급 시 refresh token 타입 및 사용자 유효성 검증
- DB에 refresh token 원문 대신 SHA-256 해시값 저장
- FE 인증 토큰 저장소를 AsyncStorage에서 SecureStore로 변경
- user와 tags는 기존처럼 AsyncStorage에 저장
- 앱 시작 시 SecureStore의 토큰을 Zustand 상태로 복원
- 토큰 저장·삭제 비동기화에 맞춰 인증 관련 호출부 수정

---

## 🔍 동작 방식

**서버 토큰 검증**

로그인 → access/refresh token에 각각 `type` 클레임 포함 → refresh token은 SHA-256 해시 후 DB 저장 → API 요청 시 `type=access` 검증 → 토큰 재발급 시 `type=refresh`, DB 해시값, 만료 여부 및 사용자 존재 여부 검증

**클라이언트 토큰 저장**

로그인 성공 → access/refresh token을 SecureStore에 저장 → 저장 성공 후 Zustand 메모리 상태 갱신 → 앱 재실행 시 AsyncStorage의 user/tags 복원 → SecureStore의 토큰 복원 → 인증 상태에 따라 화면 이동

**로그아웃 및 인증 만료**

로그아웃·회원 탈퇴 또는 인증된 요청의 401 응답 → SecureStore의 토큰 삭제 → Zustand 인증 상태 초기화 → 로그인 화면 이동

---

## 💡 설계 근거

**access/refresh token에 `type` 클레임을 추가한 이유**

두 토큰이 같은 서명 키를 사용하더라도 용도를 명확히 구분하여 refresh token이 일반 API 인증에 사용되거나 access token이 재발급에 사용되는 것을 방지한다. 본인이 초기에 깜박하고 안넣었음.

**refresh token을 해시로 저장한 이유**

DB가 노출되더라도 저장된 값만으로 refresh token 원문을 사용할 수 없도록 한다. 재발급 요청으로 받은 토큰을 동일하게 해시한 뒤 DB 값과 비교한다.

**SecureStore를 사용한 이유**

AsyncStorage는 일반 영구 저장소이므로 인증 토큰 보관에 적합하지 않다. 토큰은 OS 보안 저장소에 보관하고, 민감하지 않은 user/tags만 AsyncStorage에 유지한다.

**토큰 쌍을 함께 저장·삭제하는 이유**

access token과 refresh token 중 하나만 저장되는 불완전한 상태를 방지한다. 저장 중 하나라도 실패하면 두 토큰을 모두 삭제한다.

**SecureStore 복원 후 앱 화면을 렌더링하는 이유**

토큰 복원이 끝나기 전에 라우팅 가드가 실행되어 로그인 화면으로 잘못 이동하는 현상을 방지한다.

---

## ✅ 체크리스트

- [x] 인증 통합 테스트 전체 통과
- [x] access token으로 일반 인증 API 요청 가능
- [x] refresh token을 일반 인증에 사용할 경우 거부
- [x] access token을 토큰 재발급에 사용할 경우 거부
- [x] 정상 refresh token으로 토큰 재발급 가능
- [x] refresh token이 DB에 해시값으로 저장되는지 확인
- [ ] 로그인 후 앱 재실행 시 인증 상태 유지 확인


---

## 🔗 연관 이슈

closes #123