### PR TITLE
feat: 액세스 토큰 자동 재발급 및 로그아웃 처리

### DIFF
--- a/backend/src/main/java/org/cathori/backend/security/JwtUtil.java
+++ b/backend/src/main/java/org/cathori/backend/security/JwtUtil.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtUtil {
@@ -45,6 +46,7 @@ public class JwtUtil {
      */
     public String generateAccessToken(Long userId) {
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .subject(String.valueOf(userId))
                 .claim(CLAIM_TYPE, TOKEN_TYPE_ACCESS)
                 .issuedAt(new Date())
@@ -60,6 +62,7 @@ public class JwtUtil {
      */
     public String generateRefreshToken(Long userId) {
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .subject(String.valueOf(userId))
                 .claim(CLAIM_TYPE, TOKEN_TYPE_REFRESH)
                 .issuedAt(new Date())

--- a/backend/src/main/java/org/cathori/backend/user/api/AuthController.java
+++ b/backend/src/main/java/org/cathori/backend/user/api/AuthController.java
@@ -1,11 +1,13 @@
 package org.cathori.backend.user.api;
 
 import jakarta.validation.Valid;
+import org.cathori.backend.security.CustomUserDetails;
 import org.cathori.backend.user.api.dto.*;
 import org.cathori.backend.user.application.AuthService;
 import org.cathori.backend.user.application.EmailVerificationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -49,5 +51,11 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissue(@RequestBody @Valid ReissueRequest request) {
         return ResponseEntity.ok(authService.reissue(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.logout(userDetails.getUserId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
+++ b/backend/src/main/java/org/cathori/backend/user/application/AuthService.java
@@ -114,4 +114,9 @@ public class AuthService {
 
         return new ReissueResponse(newAccessToken, newRefreshTokenValue);
     }
+
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
 }

--- a/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/user/api/AuthIntegrationTest.java
@@ -180,6 +180,32 @@ class AuthIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_INVALID"));
     }
 
+    @Test
+    @DisplayName("A-10: 로그아웃 시 204를 반환하고 기존 refreshToken을 폐기")
+    void logout_success() throws Exception {
+        createVerifiedUser(EMAIL, PASSWORD);
+        MvcResult loginResult = login();
+        String accessToken = extractField(loginResult, "accessToken");
+        String refreshToken = extractField(loginResult, "refreshToken");
+
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReissueRequest(refreshToken))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_INVALID"));
+    }
+
+    @Test
+    @DisplayName("A-11: 인증 없이 로그아웃 요청 시 401 반환")
+    void logout_unauthorized() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
     private String loginAndGetRefreshToken() throws Exception {
         return extractField(login(), "refreshToken");
     }

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -12,10 +12,13 @@ spring.jpa.show-sql=false
 
 
 # ????? ???? ?? ????
-
 spring.mail.host=
 gemini.api.key=test
 jwt.secret-key=Y2F0aG9yaVNlY3JldEtleUZvckpXVEF1dGhlbnRpY2F0aW9uMjAyNg==
 jwt.access-token-expiry=3600000
 jwt.refresh-token-expiry=2592000000
 firebase.credential.path=src/main/resources/cathori-firebase.json
+
+# Disable scheduled jobs during integration tests
+crawler.dispatch.cron=-
+alert.dispatch.cron=-

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -42,7 +42,7 @@ import {
 } from 'react-native';
 
 import { Colors } from '@/src/constants/colors';
-import { withdraw } from '@/src/services/auth';
+import { logout, withdraw } from '@/src/services/auth';
 import { unregisterDeviceToken } from '@/src/services/pushToken';
 import { MainHeader } from '@/src/shared/components';
 import { useAuthStore } from '@/src/store/useAuthStore';
@@ -178,7 +178,7 @@ const checkNotificationPermission = async () => {
     router.replace('/login');
   };
 
-  /** 로그아웃 — 확인 다이얼로그 → clearAuth → 로그인 화면 이동 */
+  /** 로그아웃 — 서버 refresh token 폐기 → 로컬 인증 삭제 → 로그인 화면 이동 */
   const handleLogout = () => {
     Alert.alert(
       '로그아웃',
@@ -196,8 +196,20 @@ const checkNotificationPermission = async () => {
             } catch (e) {
               console.warn('[push] 토큰 반납 실패:', e);
             }
-            await clearAuth();
-            router.replace('/login');
+
+            try {
+              await logout();
+            } catch (e) {
+              // 네트워크 문제로 서버 로그아웃이 실패해도 로컬 로그아웃은 진행한다.
+              console.warn('[auth] 서버 로그아웃 실패:', e);
+            } finally {
+              try {
+                await clearAuth();
+              } catch (e) {
+                console.warn('[auth] 로컬 토큰 삭제 실패:', e);
+              }
+              router.replace('/login');
+            }
           },
         },
       ],

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -18,6 +18,13 @@ interface RetryableRequestConfig {
   _retry?: boolean;
 }
 
+const PUBLIC_AUTH_ENDPOINTS = new Set([
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/email/send',
+  '/api/auth/email/verify',
+]);
+
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
   timeout: API_TIMEOUT,
@@ -55,10 +62,10 @@ apiClient.interceptors.response.use(
       | undefined;
     const { accessToken, refreshToken } = useAuthStore.getState();
 
-    // 로그인 실패 등 인증 API의 401은 access token 만료로 처리하지 않는다.
+    // 로그인 실패 등 공개 인증 API의 401은 access token 만료로 처리하지 않는다.
     if (
       !originalRequest ||
-      originalRequest.url?.startsWith('/api/auth/') ||
+      PUBLIC_AUTH_ENDPOINTS.has(originalRequest.url ?? '') ||
       !accessToken
     ) {
       return Promise.reject(error);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,6 +9,14 @@ import { router } from 'expo-router';
 
 import { API_BASE_URL, API_TIMEOUT } from '@/src/constants/api';
 import { useAuthStore } from '@/src/store/useAuthStore';
+import type {
+  ReissueRequest,
+  ReissueResponse,
+} from '@/src/types/auth';
+
+interface RetryableRequestConfig {
+  _retry?: boolean;
+}
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -17,6 +25,8 @@ const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+let reissuePromise: Promise<string> | null = null;
 
 // ─── 요청 인터셉터 ─────────────────────────────────────────────────
 apiClient.interceptors.request.use(
@@ -36,20 +46,67 @@ apiClient.interceptors.request.use(
 apiClient.interceptors.response.use(
   (response) => response,
   async (error) => {
-    // 401 Unauthorized → 토큰 클리어 + 로그인 화면 리다이렉트
-    // 1차 MVP: refreshToken 갱신 미구현, 단순 로그아웃 처리
-    // (트랩 #9: accessToken 만료 + refreshToken 유효 케이스는 추후에 재검토)
-    if (axios.isAxiosError(error) && error.response?.status === 401) {
-      const { accessToken } = useAuthStore.getState();
-
-      // 이미 인증 토큰이 있었는데 401을 받은 경우에만 로그아웃 처리
-      // (인증 불필요 API의 401은 무시 — 로그인/회원가입 API의 비밀번호 오답 등)
-      if (accessToken) {
-        await useAuthStore.getState().clearAuth();
-        router.replace('/login' as never);
-      }
+    if (!axios.isAxiosError(error) || error.response?.status !== 401) {
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
+
+    const originalRequest = error.config as
+      | (NonNullable<typeof error.config> & RetryableRequestConfig)
+      | undefined;
+    const { accessToken, refreshToken } = useAuthStore.getState();
+
+    // 로그인 실패 등 인증 API의 401은 access token 만료로 처리하지 않는다.
+    if (
+      !originalRequest ||
+      originalRequest.url?.startsWith('/api/auth/') ||
+      !accessToken
+    ) {
+      return Promise.reject(error);
+    }
+
+    // 재발급 후에도 401이거나 refresh token이 없으면 인증을 종료한다.
+    if (originalRequest._retry || !refreshToken) {
+      await useAuthStore.getState().clearAuth();
+      router.replace('/login' as never);
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+
+    try {
+      // 여러 API가 동시에 401을 받아도 토큰 재발급 요청은 한 번만 보낸다.
+      // 먼저 시작된 재발급이 있다면 아래에서 같은 Promise의 완료를 함께 기다린다.
+      if (!reissuePromise) {
+        const request: ReissueRequest = { refreshToken };
+
+        // 재발급 요청에는 현재 응답 인터셉터가 적용되지 않는 기본 axios를 사용한다.
+        // apiClient를 사용하면 재발급 실패의 401까지 다시 재발급 처리할 수 있기 때문이다.
+        reissuePromise = axios
+          .post<ReissueResponse>(`${API_BASE_URL}/api/auth/reissue`, request, {
+            timeout: API_TIMEOUT,
+            headers: { 'Content-Type': 'application/json' },
+          })
+          .then(async ({ data }) => {
+            // 서버가 반환한 새 access/refresh token을 SecureStore와 Zustand에 반영한다.
+            await useAuthStore.getState().setTokens(data);
+            return data.accessToken;
+          })
+          .finally(() => {
+            // 성공과 실패에 관계없이 다음 401에서는 새 재발급 요청을 시작할 수 있게 한다.
+            reissuePromise = null;
+          });
+      }
+
+      // 재발급 완료 후 원래 실패했던 요청에 새 access token을 넣어 한 번 재시도한다.
+      const newAccessToken = await reissuePromise;
+      originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+      return apiClient(originalRequest);
+    } catch (reissueError) {
+      // refresh token도 유효하지 않거나 재발급에 실패하면 인증 상태를 종료한다.
+      await useAuthStore.getState().clearAuth();
+      router.replace('/login' as never);
+      return Promise.reject(reissueError);
+    }
   },
 );
 

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,14 +1,15 @@
 /**
- * 인증 서비스 레이어 — /api/auth/* fetcher 4종
+ * 인증 서비스 레이어 — /api/auth/* fetcher
  *
  * 엔드포인트:
  *   POST /api/auth/login         — 이메일/비밀번호 로그인, JWT + 사용자 정보 반환
  *   POST /api/auth/register      — 회원가입 (JWT 미포함!)
  *   POST /api/auth/email/send    — 이메일 인증번호 발송
  *   POST /api/auth/email/verify  — 이메일 인증번호 검증
+ *   POST /api/auth/logout        — 서버에 저장된 refresh token 폐기
  *
  * 주의:
- *   - 인증 API 4종은 모두 공개 엔드포인트 (JWT 불필요)
+ *   - logout을 제외한 인증 API는 공개 엔드포인트 (JWT 불필요)
  *   - 회원가입 응답에 JWT가 없으므로 가입 후 자동 로그인은
  *     프론트에서 동일 자격증명으로 login을 별도 호출해야 함 (트랩 #7)
  */
@@ -71,6 +72,13 @@ export async function verifyEmail(
     req,
   );
   return data;
+}
+
+/**
+ * 로그아웃 — 서버에 저장된 refresh token 폐기
+ */
+export async function logout(): Promise<void> {
+  await apiClient.post('/api/auth/logout');
 }
 
 /**

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -109,8 +109,12 @@ export const useAuthStore = create<AuthState>()(
       },
 
       clearAuth: async () => {
-        await clearTokens();
-        set({ ...INITIAL_STATE });
+        try {
+          await clearTokens();
+        } finally {
+          // SecureStore 삭제가 실패해도 현재 앱의 인증 상태는 반드시 초기화한다.
+          set({ ...INITIAL_STATE });
+        }
       },
 
       initializeAuth: async () => {

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -24,7 +24,12 @@ import {
   getTokens,
   saveTokens,
 } from '@/src/services/tokenStorage';
-import type { AuthUser, LoginResponse, UserTag } from '@/src/types/auth';
+import type {
+  AuthUser,
+  LoginResponse,
+  ReissueResponse,
+  UserTag,
+} from '@/src/types/auth';
 
 interface AuthState {
   /** JWT 액세스 토큰 (1시간 유효) */
@@ -41,6 +46,9 @@ interface AuthState {
    * LoginResponse를 그대로 받아 필요한 필드를 추출
    */
   setAuth: (response: LoginResponse) => Promise<void>;
+
+  /** 토큰 재발급 성공 시 새 토큰 쌍만 교체합니다. */
+  setTokens: (tokens: ReissueResponse) => Promise<void>;
 
   /**
    * 로그아웃 시 호출 — 토큰·사용자·태그 모두 초기화
@@ -89,6 +97,14 @@ export const useAuthStore = create<AuthState>()(
             enrollmentStatus: response.enrollmentStatus,
           },
           tags: response.tags,
+        });
+      },
+
+      setTokens: async (tokens) => {
+        await saveTokens(tokens);
+        set({
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
         });
       },
 

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -40,6 +40,17 @@ export interface LoginResponse {
   tags: UserTag[];
 }
 
+/** 토큰 재발급 요청 */
+export interface ReissueRequest {
+  refreshToken: string;
+}
+
+/** 토큰 재발급 응답 */
+export interface ReissueResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
 // ─── 회원가입 ────────────────────────────────────────────────────────
 
 /** 회원가입 요청 */


### PR DESCRIPTION
## 🔧 작업 내용

- API 요청이 `401 Unauthorized`를 반환하면 refresh token으로 토큰을 자동 재발급하도록 구현
- 재발급 성공 시 새 토큰 저장 후 실패했던 요청을 한 번 재호출
- 여러 요청에서 동시에 401이 발생해도 재발급 요청은 한 번만 전송하도록 처리
- 백엔드 로그아웃 API 추가 및 사용자의 refresh token 폐기
- FE 로그아웃 시 서버 로그아웃 요청 후 SecureStore와 Zustand 인증 상태 초기화
- 로그인·재발급·로그아웃 시 생성되는 JWT가 서로 다른 값을 갖도록 `jti` 추가

---

## 🔍 동작 방식

**토큰 자동 재발급**

API 요청 → access token 만료로 401 응답 → refresh token으로 `/api/auth/reissue` 요청 → 새 access/refresh token 저장 → 기존 요청에 새 access token을 담아 한 번 재호출

재발급이 실패하거나 refresh token이 없으면 로컬 인증 상태를 초기화하고 로그인 화면으로 이동합니다.

**동시 재발급 방지**

여러 API가 동시에 401을 반환하면 최초 요청만 토큰 재발급을 수행합니다. 나머지 요청은 동일한 재발급 Promise를 기다린 후 발급된 access token을 공유하여 재호출합니다.

**로그아웃**

로그아웃 선택 → 디바이스 푸시 토큰 반납 → 백엔드 `/api/auth/logout` 호출 → DB에 저장된 refresh token 삭제 → SecureStore 및 Zustand 인증 상태 초기화 → 로그인 화면 이동

서버 로그아웃 요청이 실패하더라도 `finally`에서 로컬 인증 정보는 반드시 삭제합니다.

---

## 💡 설계 근거

**재발급 요청에 기본 axios를 사용한 이유**

기존 `apiClient`로 재발급 요청을 보내면 재발급 API의 401 응답도 같은 인터셉터에 들어와 재발급을 반복할 수 있습니다. 이를 방지하기 위해 재발급 API는 인터셉터가 없는 기본 axios로 호출했습니다.

**원 요청 재시도를 1회로 제한한 이유**

새 access token으로 재호출한 요청도 401을 반환하면 토큰 만료가 아닌 권한 또는 서버 인증 문제일 가능성이 높습니다. 무한 재시도 방지를 위해 요청별 재시도를 한 번으로 제한했습니다.

**로그아웃 실패와 관계없이 로컬 토큰을 삭제하는 이유**

네트워크 오류나 서버 장애가 발생하더라도 사용자가 선택한 로그아웃은 현재 기기에서 완료되어야 합니다. 따라서 서버 요청 결과와 관계없이 SecureStore와 메모리의 인증 상태를 초기화합니다.

**JWT에 `jti`를 추가한 이유**

같은 사용자의 토큰이 짧은 시간 안에 연속 생성되더라도 토큰마다 고유한 값을 갖게 하여 재발급 전후 토큰이 동일해지는 것을 방지합니다.

---

## ✅ 체크리스트

- [x] access token 만료 시 토큰 재발급 확인
- [x] 재발급 성공 후 기존 요청 재호출 확인
- [x] 동시 401 응답에서 재발급 요청을 한 번만 수행하도록 처리
- [x] 재발급 실패 시 인증 상태 초기화 및 로그인 화면 이동 확인
- [x] 로그아웃 시 백엔드 refresh token 삭제 확인
- [x] 서버 로그아웃 실패 시에도 로컬 인증 상태 초기화
- [x] 인증 관련 백엔드 통합 테스트 통과
- [x] 프런트엔드 TypeScript 검사 및 lint 통과

---

## 🔗 연관 이슈

closes #125