### PR TITLE
fix: iOS 번들 ID 및 GoogleService-Info.plist 설정 추가

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -10,7 +10,11 @@ export default {
     newArchEnabled: true,
     ios: {
       supportsTablet: true,
-      bundleIdentifier: "site.cathori.cathori"
+      bundleIdentifier: "site.cathori.cathoriapp",
+      googleServicesFile: process.env.GOOGLE_SERVICES_IOS_PLIST ?? "./GoogleService-Info.plist",
+      infoPlist: {
+        ITSAppUsesNonExemptEncryption: false
+      }
     },
     android: {
       adaptiveIcon: {


### PR DESCRIPTION
- bundleIdentifier를 site.cathori.cathoriapp으로 변경
- googleServicesFile 경로 및 ITSAppUsesNonExemptEncryption 설정 추가