### PR TITLE
fix: .env가 로컬, 운영서버에서 공통으로 참조되던 문제 수정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .env
+.env.local
 
 ### STS ###
 .apt_generated

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -53,7 +53,7 @@ tasks.withType<Test> {
 }
 
 tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
-    val envFile = file(".env")
+    val envFile = file(".env.local")
     if (envFile.exists()) {
         envFile.readLines().forEach { line ->
             val trimmed = line.trim()


### PR DESCRIPTION
## 🐛 버그 현상

`bootRun` 태스크가 로컬 환경과 운영 서버에서 동일한 `.env` 파일을 참조하고 있었음. 로컬 개발용 환경변수와 운영 환경변수가 분리되지 않아, 로컬에서 `.env`를 수정하면 운영 설정에도 영향을 줄 수 있는 상태였음(혹은 반대로 운영 배포 시 로컬 값이 섞여 들어갈 위험이 있었음).

## 🔍 원인

`backend/build.gradle.kts`의 `bootRun` 태스크가 `.env` 파일 하나만 하드코딩해서 읽도록 되어 있어, 로컬/운영 환경변수 파일이 분리되어 있지 않았음.

## 🔧 해결 방법

- 로컬 전용 환경변수 파일로 `.env.local`을 신설하고, `bootRun`이 `.env` 대신 `.env.local`을 읽도록 수정
- `.env.local`이 커밋되지 않도록 `backend/.gitignore`에 등록

## ⏳ 미정 사항

해당 없으면: 없음

## ✅ 체크리스트
- [x] 로컬에서 재현 후 수정 확인했는가
- [ ] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [ ] 동일 원인으로 인한 다른 버그 가능성을 확인했는가

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| 로컬 개발 환경 | `bootRun` 실행 시 `.env` 대신 `.env.local` 파일을 새로 만들어야 함 | 팀원들에게 `.env.local` 파일 생성 안내 필요 |
| 운영 서버 배포 스크립트/설정 | 운영 서버에서 사용하던 `.env` 파일 참조 방식 변경 여부 확인 필요 | 운영 서버의 환경변수 주입 방식이 `bootRun`에 의존하지 않는지 확인 필요 |

## 🔗 연관 이슈
closes #139
