### PR TITLE
[PR] fix: CI/CD 배포 실패 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,23 +17,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy via SSH (Bastion → WAS)
+      - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host:           ${{ secrets.WAS_HOST }}
-          username:       ${{ secrets.WAS_USER }}
-          key:            ${{ secrets.WAS_SSH_KEY }}
-          proxy_host:     ${{ secrets.BASTION_HOST }}
-          proxy_username: ${{ secrets.BASTION_USER }}
-          proxy_key:      ${{ secrets.BASTION_SSH_KEY }}
+          host:     ${{ secrets.WAS_HOST }}
+          username: ${{ secrets.WAS_USER }}
+          key:      ${{ secrets.WAS_SSH_KEY }}
           script: |
             cd /home/${{ secrets.WAS_USER }}/cathori
-            
+
             # 최신 코드 받기
             git pull origin main
 
             # 컨테이너 재빌드 + 재시작
             docker compose -f docker-compose.prod.yml up -d --build
-            
+
             # 사용하지 않는 이미지 정리
             docker image prune -f


### PR DESCRIPTION
## 🐛 버그 현상

`main` 브랜치에 push하면 GitHub Actions `Deploy to AWS` 워크플로우가 자동 실행되어야 하는데, `Deploy via SSH (Bastion → WAS)` 스텝에서 아래 오류와 함께 실패함.

```
ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
Error: Process completed with exit code 1.
```

재현 조건: `backend/`, `nginx/`, `docker-compose.prod.yml` 중 하나라도 변경되어 `main`에 push되면 매번 동일하게 발생.

## 🔍 원인

두 가지 원인이 겹쳐서 발생했음.

1. Repository Secrets(`WAS_HOST`, `WAS_USER`, `WAS_SSH_KEY`, `BASTION_HOST`, `BASTION_USER`, `BASTION_SSH_KEY`)가 전부 미등록 상태였음. GitHub 저장소 Settings → Secrets and variables → Actions 확인 결과 "This repository has no secrets" 상태.
2. `deploy.yml`이 Bastion 서버를 경유해 WAS 서버로 접속하는 2단계 구조(`proxy_host`, `proxy_username`, `proxy_key`)로 작성되어 있으나, 실제 인프라는 Lightsail 인스턴스 1개(`cathori-prod`, `13.124.205.27`)뿐이며 Bastion 서버는 존재하지 않음. 다른 프로젝트 템플릿을 참고하는 과정에서 불필요한 구조가 그대로 남아있었던 것으로 추정.

## 🔧 해결 방법

- GitHub Repository Secrets에 `WAS_HOST`, `WAS_USER`, `WAS_SSH_KEY` 3개 등록
- `deploy.yml`에서 Bastion 관련 설정(`proxy_host`, `proxy_username`, `proxy_key`) 제거하고 WAS 서버 단일 접속 구조로 단순화

## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| Bastion(Private subnet) 구조 도입 여부 | 현재 규모(캡스톤, 단일 서버)에서는 불필요 | 향후 서비스 확장 시 보안 강화 필요해지면 재검토 |

## ✅ 체크리스트

- [x] 로컬에서 재현 후 수정 확인했는가 (로컬 SSH 접속 테스트로 키/계정 유효성 확인)
- [ ] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가 (Secrets 미등록은 이 워크플로우 하나에만 해당)

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| CI/CD 배포 파이프라인 | `main` push 시 자동배포 전체가 동작하지 않았음 | 없음 (본 수정으로 해결) |

## 🔗 연관 이슈

closes #144