### PR TITLE
fix: workflow_dispatch 추가로 수동 배포 트리거 가능하게 함

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy to AWS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## 🔧 작업 내용

`deploy.yml`에 `workflow_dispatch` 트리거를 추가하여, push 없이도 Actions 탭에서 수동으로 배포를 실행할 수 있도록 함. 배포 실패 원인 재확인 및 재시도 과정에서 필요성이 확인되어 추가.

## 🔍 동작 방식

기존에는 `push` 트리거만 있어서, `backend/`, `nginx/`, `docker-compose.prod.yml` 경로 변경이 있어야만 워크플로우가 실행됐음. `workflow_dispatch` 추가로 Actions 탭에서 "Run workflow" 버튼을 통해 언제든 수동 트리거 가능.

## 💡 설계 근거

#144(CI/CD SSH 인증 실패) 해결 과정에서, 원인이 실제로는 NCP 배포 시절 남아있던 Bastion 관련 Secrets(`BASTION_*`, `WAS_HOST_PRIVATE`)를 `deploy.yml`이 여전히 참조하고 있었기 때문으로 확인됨. 해당 Secrets는 삭제 처리했고, 수정 사항을 파일 변경 없이 즉시 재검증할 수 있도록 수동 트리거를 추가함.

## ✅ 체크리스트

- [x] Bastion 관련 Secrets(`BASTION_HOST`, `BASTION_USER`, `BASTION_SSH_KEY`, `WAS_HOST_PRIVATE`) 삭제 확인
- [x] `deploy.yml`에서 Bastion 참조(`proxy_host`, `proxy_username`, `proxy_key`) 제거 확인
- [ ] `workflow_dispatch`로 수동 실행 시 정상 배포되는지 확인

## 🔗 연관 이슈

related to #144