### PR TITLE
fix: 배포 경로 대소문자 불일치 수정 및 실패 감지 강화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,8 @@ jobs:
           username: ${{ secrets.WAS_USER }}
           key:      ${{ secrets.WAS_SSH_KEY }}
           script: |
-            cd /home/${{ secrets.WAS_USER }}/cathori
+            set -e
+            cd /home/${{ secrets.WAS_USER }}/Cathori
 
             # 최신 코드 받기
             git pull origin main


### PR DESCRIPTION
## 🔧 작업 내용

`deploy.yml`의 배포 경로 오타(대소문자 불일치)를 수정하고, 유사한 실패가 조용히 넘어가지 않도록 `set -e`를 추가함.

## 🔍 동작 방식

기존 `cd /home/${{ secrets.WAS_USER }}/cathori`는 실제 서버 디렉토리(`/home/ubuntu/Cathori`, 대문자)와 이름이 달라 `cd` 자체가 실패했음. 그런데 스크립트에 `set -e`가 없어서 `cd` 실패 후에도 뒤의 `git pull`, `docker compose up -d --build`가 계속 실행됐고, 워크플로우는 exit code 0으로 끝나 "Success"로 표시됐음. 실제로는 `git pull`이 엉뚱한 위치(SSH 기본 접속 디렉토리)에서 실행되어 아무 변경사항도 반영되지 않았음.

경로를 `Cathori`로 맞추고, `set -e`를 추가해 앞으로 동일 유형의 실패가 나면 워크플로우 자체가 실패로 표시되도록 함.

## 💡 설계 근거

`docker-compose.prod.yml`, `git log` 등 서버 상태를 직접 SSH 접속해 확인한 결과, `Deploy to AWS #9` 실행이 "Success"였음에도 서버의 `git log` HEAD가 8/18(PR #122) 시점에 멈춰 있는 게 확인됨. 서버 디렉토리명을 바꾸는 대신 `deploy.yml`을 실제 상태에 맞추는 방향을 택함 — 서버 디렉토리는 재현 불가능한 일회성 상태이고, `deploy.yml`은 Git으로 관리되는 재현 가능한 설정이라, 인프라가 재생성되어도 반복되지 않게 코드 쪽을 고치는 게 근본적인 해결.

## ✅ 체크리스트

- [x] 서버 SSH 접속하여 실제 디렉토리 경로(`/home/ubuntu/Cathori`) 확인
- [x] `set -e` 추가로 향후 유사 실패 시 워크플로우가 실패로 표시되는지 확인 필요
- [ ] `main` merge 후 실제 배포 결과가 서버에 반영되는지 (`git log` HEAD 갱신) 확인

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| CI/CD 배포 파이프라인 | 지금까지의 자동/수동 배포가 실제로는 반영되지 않았을 가능성 | 이번 수정 반영 후 서버 최신 상태로 갱신 필요 |

## 🔗 연관 이슈

related to #144