### PR TITLE
fix : app.config.js의 안드로이드 패키지명을 플레이콘솔에 등록된 패키지명과 일치

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -23,7 +23,7 @@ export default {
       },
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
-      package: "site.cathori.cathori",
+      package: "site.cathori.cathoriapp",
       googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
       versionCode: 1
     },


### PR DESCRIPTION
## 🐛 버그 현상

Google Play Console 비공개 테스트 트랙에 AAB 업로드 시 패키지명 불일치 오류 발생. 이후 `app.config.js` 수정 후 재빌드했을 때도 `:app:processReleaseGoogleServices` 태스크에서 `No matching client found for package name 'site.cathori.cathoriapp'` 오류로 빌드 실패.

- 기대 동작: `eas build --platform android --profile production` 실행 시 Play Console에 등록된 패키지명(`site.cathori.cathoriapp`)으로 정상 빌드되어야 함
- 실제 동작: 1차로는 Play Console 업로드 단계에서 패키지명 불일치 오류, 2차로는 Gradle 빌드 자체가 `google-services.json`에서 해당 패키지명을 찾지 못해 실패
- 재현 조건: `app.config.js`의 `android.package` 수정 후 재빌드 시

## 🔍 원인

1. `app.config.js`의 `android.package`가 `site.cathori.cathori`로 설정되어 있었고, Play Console에는 `site.cathori.cathoriapp`로 앱이 등록되어 있어 두 값이 불일치했음
2. `google-services.json`이 `.gitignore` 대상이며, `app.config.js`에서 `process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json"`로 참조하고 있었으나 `GOOGLE_SERVICES_JSON` EAS Secret이 등록되어 있지 않았음. 이로 인해 EAS 클라우드 빌드 서버(`/home/expo/workingdir/build/...`)는 로컬 `google-services.json` 파일에 접근하지 못해 `site.cathori.cathoriapp` 패키지명에 대응하는 Firebase 클라이언트 정보를 찾지 못함

## 🔧 해결 방법

1. `app.config.js`의 `android.package`를 `site.cathori.cathoriapp`로 수정
2. Firebase Console에서 `site.cathori.cathoriapp` 패키지명으로 Android 앱 신규 등록, 새 `google-services.json` 발급받음 (기존 `site.cathori.cathori` 항목과 함께 `client` 배열에 공존)
3. `eas secret:create --scope project --name GOOGLE_SERVICES_JSON --type file --value ./google-services.json` 로 EAS Secret 등록하여 클라우드 빌드 서버에 파일 전달

## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| 기존 `site.cathori.cathori` Firebase 앱 등록 삭제 | 실기기에 구 패키지명 빌드가 남아있을 가능성 대비 | 신규 패키지명 빌드 안정화 확인 후 |
| iOS `GOOGLE_SERVICES_IOS_PLIST` Secret 등록 여부 | 동일 패턴(Secret 미등록)의 잠재 문제 가능성 있으나 이번 이슈 범위 아님 | iOS 재빌드 필요 시점에 별도 확인 |

## ✅ 체크리스트
- [ ] 로컬에서 재현 후 수정 확인했는가
- [ ] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [ ] 동일 원인으로 인한 다른 버그 가능성을 확인했는가

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| FCM 푸시 알림 | 패키지명 변경으로 신규 빌드의 FCM 등록 경로가 기존과 달라짐 | 재빌드 후 실기기에서 알림 수신 재확인 필요 |

## 🔗 연관 이슈
closes #155