### PR TITLE
refactor: 알림도메인 애플리케이션 계층 메소드 구조 개선

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notification/application/push/PushNotificationService.java
+++ b/backend/src/main/java/org/cathori/backend/notification/application/push/PushNotificationService.java
@@ -44,13 +44,21 @@ public class PushNotificationService {
     }
 
     private void dispatchForNotice(Notice notice) {
+        boolean hasRecipients = registerRecipients(notice);
+        if (!hasRecipients) return;
+        sendToRecipients(notice);
+    }
+
+    // 발송 대상을 계산해 AlertHistory PENDING row로 원자적으로 저장한다.
+    // 이후 sendToRecipients는 이 결과를 신뢰의 원천으로 삼아 DB에서 다시 읽어 발송한다.
+    private boolean registerRecipients(Notice notice) {
         List<UserToken> targets = buildTargets(notice);
         log.info("noticeId={} 발송 대상 {}명", notice.getId(), targets.size());
 
         if (targets.isEmpty()) {
             notice.markAlertDispatched();
             noticeRepository.save(notice);
-            return;
+            return false;
         }
         // (user_id, notice_id)는 유니크 제약이므로, 이미 이력이 있는 사용자에게는 새 PENDING row를 INSERT X
         // 발송 자체는 전체 대상에게 하고, 기존 row는 persistDispatchResult의 UPDATE로 갱신된다.
@@ -69,14 +77,21 @@ public class PushNotificationService {
         if (!pendingLogs.isEmpty()) {
             alertHistoryRepository.saveAll(pendingLogs);
         }
+        return true;
+    }
 
-        // 4. @Transactional 범위 밖에서 FCM HTTP 호출
+    // registerRecipients가 저장한 PENDING 대상을 DB에서 다시 읽어와 발송한다.
+    private void sendToRecipients(Notice notice) {
+        List<UserToken> recipients = loadPendingRecipients(notice.getId());
+        if (recipients.isEmpty()) return;
+
+        // @Transactional 범위 밖에서 FCM HTTP 호출
         List<UserPushResult> results;
         try {
-            results = pushNotificationPort.sendMulticast(targets, "Cathori 새 공지", notice.getTitle(), notice.getId());
+            results = pushNotificationPort.sendMulticast(recipients, "Cathori 새 공지", notice.getTitle(), notice.getId());
         } catch (Exception e) {
             log.error("FCM 발송 실패. noticeId={}", notice.getId(), e);
-            List<Long> allUserIds = targets.stream().map(UserToken::userId).toList();
+            List<Long> allUserIds = recipients.stream().map(UserToken::userId).toList();
 
             // 여기서 발송 실패는 UPDATE 라서 괜찮음
             notificationResultWriter.persistDispatchFailure(notice, allUserIds);
@@ -87,8 +102,19 @@ public class PushNotificationService {
         List<Long> successIds = results.stream().filter(UserPushResult::success).map(UserPushResult::userId).toList();
         List<Long> failedIds = results.stream().filter(r -> !r.success()).map(UserPushResult::userId).toList();
         notificationResultWriter.persistDispatchResult(notice, successIds, failedIds);
-        
+
         log.info("FCM 발송 완료. noticeId={}, success={}, fail={}", notice.getId(), successIds.size(), failedIds.size());
+    }
+
+    private List<UserToken> loadPendingRecipients(Long noticeId) {
+        List<Long> recipients = alertHistoryRepository.findPendingUserIdsByNoticeId(noticeId);
+        if (recipients.isEmpty()) return List.of();
+
+        Map<Long, String> deviceTokens = userRepository.findDeviceTokensByIds(recipients);
+        return recipients.stream()
+                .filter(deviceTokens::containsKey)
+                .map(id -> new UserToken(id, deviceTokens.get(id)))
+                .toList();
     }
 
     private List<UserToken> buildTargets(Notice notice) {

--- a/backend/src/main/java/org/cathori/backend/notification/domain/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notification/domain/AlertHistoryRepository.java
@@ -11,6 +11,8 @@ public interface AlertHistoryRepository {
 
     List<Long> findUserIdsByNoticeId(Long noticeId);
 
+    List<Long> findPendingUserIdsByNoticeId(Long noticeId);
+
     AlertHistory save(AlertHistory log);
 
     void markSuccessForUsers(Long noticeId, List<Long> userIds);

--- a/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryJpaRepository.java
@@ -17,6 +17,9 @@ public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, L
     @Query("SELECT ah.userId FROM AlertHistory ah WHERE ah.noticeId = :noticeId")
     List<Long> findUserIdsByNoticeId(@Param("noticeId") Long noticeId);
 
+    @Query("SELECT ah.userId FROM AlertHistory ah WHERE ah.noticeId = :noticeId AND ah.alarmStatus = 'PENDING'")
+    List<Long> findPendingUserIdsByNoticeId(@Param("noticeId") Long noticeId);
+
     @Modifying
     @Query("UPDATE AlertHistory ah SET ah.alarmStatus = 'SUCCESS' WHERE ah.noticeId = :noticeId AND ah.userId IN :userIds")
     void markSuccessForUsers(@Param("noticeId") Long noticeId, @Param("userIds") List<Long> userIds);

--- a/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryRepositoryImpl.java
@@ -32,6 +32,11 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     }
 
     @Override
+    public List<Long> findPendingUserIdsByNoticeId(Long noticeId) {
+        return jpaRepository.findPendingUserIdsByNoticeId(noticeId);
+    }
+
+    @Override
     public AlertHistory save(AlertHistory log) {
         return jpaRepository.save(log);
     }

--- a/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/domain/UserRepository.java
@@ -11,5 +11,6 @@ public interface UserRepository {
     Optional<User> findById(Long id);
     List<User> findUsersWithTagMatchingTitle(String title);
     Map<Long, String> findFirstMatchedTagsByTitle(String title);
+    Map<Long, String> findDeviceTokensByIds(List<Long> userIds);
     void delete(User user);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserDeviceTokenView.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserDeviceTokenView.java
@@ -1,0 +1,6 @@
+package org.cathori.backend.user.infra;
+
+public interface UserDeviceTokenView {
+    Long getId();
+    String getDeviceToken();
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
@@ -17,4 +17,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     @Query(value = "SELECT t.user_id, MIN(t.name) AS matched_tag FROM user_tag t WHERE :title LIKE '%' || t.name || '%' GROUP BY t.user_id", nativeQuery = true)
     List<Object[]> findFirstMatchedTagsByTitle(@Param("title") String title);
+    @Query("SELECT u.id AS id, u.deviceToken AS deviceToken FROM User u WHERE u.id IN :userIds AND u.deviceToken IS NOT NULL")
+    List<UserDeviceTokenView> findDeviceTokensByIds(@Param("userIds") List<Long> userIds);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserJpaRepository.java
@@ -15,8 +15,9 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT DISTINCT u.* FROM users u JOIN user_tag t ON t.user_id = u.id WHERE :title LIKE '%' || t.name || '%'", nativeQuery = true)
     List<User> findUsersWithTagMatchingTitle(@Param("title") String title);
 
-    @Query(value = "SELECT t.user_id, MIN(t.name) AS matched_tag FROM user_tag t WHERE :title LIKE '%' || t.name || '%' GROUP BY t.user_id", nativeQuery = true)
-    List<Object[]> findFirstMatchedTagsByTitle(@Param("title") String title);
+    @Query(value = "SELECT t.user_id AS userId, MIN(t.name) AS matchedTag FROM user_tag t WHERE :title LIKE '%' || t.name || '%' GROUP BY t.user_id", nativeQuery = true)
+    List<UserMatchedTagView> findFirstMatchedTagsByTitle(@Param("title") String title);
+
     @Query("SELECT u.id AS id, u.deviceToken AS deviceToken FROM User u WHERE u.id IN :userIds AND u.deviceToken IS NOT NULL")
     List<UserDeviceTokenView> findDeviceTokensByIds(@Param("userIds") List<Long> userIds);
 }

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserMatchedTagView.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserMatchedTagView.java
@@ -1,0 +1,6 @@
+package org.cathori.backend.user.infra;
+
+public interface UserMatchedTagView {
+    Long getUserId();
+    String getMatchedTag();
+}

--- a/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/user/infra/UserRepositoryImpl.java
@@ -46,10 +46,14 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Map<Long, String> findFirstMatchedTagsByTitle(String title) {
         return jpaRepository.findFirstMatchedTagsByTitle(title).stream()
-                .collect(Collectors.toMap(
-                        row -> ((Number) row[0]).longValue(),
-                        row -> (String) row[1]
-                ));
+                .collect(Collectors.toMap(UserMatchedTagView::getUserId, UserMatchedTagView::getMatchedTag));
+    }
+
+    @Override
+    public Map<Long, String> findDeviceTokensByIds(List<Long> userIds) {
+        if (userIds.isEmpty()) return Map.of();
+        return jpaRepository.findDeviceTokensByIds(userIds).stream()
+                .collect(Collectors.toMap(UserDeviceTokenView::getId, UserDeviceTokenView::getDeviceToken));
     }
 
     @Override


### PR DESCRIPTION
## 🔧 리팩터링 대상
 
1. **`UserRepository.findFirstMatchedTagsByTitle`** — 네이티브 쿼리 결과를 `Object[]`로 받아 인덱스로 캐스팅했음. 컬럼 순서가 바뀌어도 컴파일 타임에 못 잡고 런타임에만 깨지는 구조였음
2. **`PushNotificationService`의 발송 메서드(구 `dispatchForNotice`)** — 수신자 확정, PENDING 이력 저장, 실제 발송까지 한 메서드가 처리해 책임이 분리되어 있지 않았음
## 📐 As-Is → To-Be
 
**As-Is**
```
PushNotificationService.dispatchForNotice(Notice notice)
  - 대상 계산(buildTargets) → PENDING 이력 저장 → FCM 발송까지 한 메서드가 전부 처리
  - FCM 발송 시점에도 처음 계산한 targets를 그대로 재사용
```
```
UserJpaRepository.findFirstMatchedTagsByTitle
  - List<Object[]> 반환 → 호출부에서 row[0], row[1] 인덱스로 캐스팅
```
 
**To-Be**
```
PushNotificationService
  ├── registerRecipients(Notice)   대상 계산 + PENDING row 저장 (트랜잭션 범위 안)
  └── sendToRecipients(Notice)     PENDING row를 DB에서 재조회 + FCM 발송 (트랜잭션 범위 밖)
        └── loadPendingRecipients(noticeId)
```
```
UserJpaRepository.findFirstMatchedTagsByTitle
  - List<UserMatchedTagView> 반환 (프로젝션 DTO, userId/matchedTag 필드 접근)
 
UserJpaRepository.findDeviceTokensByIds  (신규)
  - List<UserDeviceTokenView> 반환 (프로젝션 DTO, id/deviceToken 필드 접근)
```
 
 
## 🎯 결정 사항
 
### 결정 1 — 쿼리 결과 매핑 방식
- 옵션: (a) 기존 `Object[]` + 인덱스 캐스팅 유지, (b) Spring Data 인터페이스 프로젝션(`UserMatchedTagView`) 도입
- 근거: (a)는 컬럼 순서 변경 시 런타임에만 오류가 드러남
- 선택: (b), 쿼리에 컬럼 별칭을 명시해 프로젝션 프로퍼티와 매핑
### 결정 2 — 발송 메서드 책임 분리
- 옵션: (a) 기존처럼 `dispatchForNotice` 하나가 대상 계산·PENDING 이력 저장·FCM 발송을 전부 처리, (b) `registerRecipients`/`sendToRecipients`로 분리하고, 발송 시점엔 처음 계산한 대상이 아니라 DB에 저장된 PENDING row를 재조회해서 사용
- 근거: 트랜잭션 범위 안에서 계산한 대상을 트랜잭션 밖 FCM 호출까지 그대로 들고 가면, 그 사이 상태가 바뀌어도 반영이 안 됨. PENDING row를 먼저 원자적으로 저장해두고 이걸 신뢰의 원천으로 삼아 재조회하면, 발송 시점의 실제 상태를 기준으로 동작하게 됨
- 선택: (b)
## ⚠️ 동작 불변 검증
 
- [x] 기존 테스트가 모두 그대로 통과하는가 (수정 없이)
- [ ] **재검증 필요**: 기존 테스트 결과(106개 중 103통과, 3개 실패는 무관한 기존 문제)는 5개 커밋 전체 기준으로 실행된 것. 지금은 162번 PR이 2개 커밋만 담고 있으므로, 이 범위만으로 다시 테스트 실행해서 확인 필요
## ⏳ 미정 사항
 
- `closes #152` 이슈 연결을 162번 PR과 163번 PR(네이밍 3개 커밋) 중 어디에 남길지 결정 필요
## 🌐 연관 도메인 영향
 
| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| `user` 도메인 | `UserRepository`에 `UserMatchedTagView`, `UserDeviceTokenView` 프로젝션 추가 | 없음 (신규 조회 메서드만 추가, 기존 메서드 영향 없음) |
 
 
## 🔗 연관 이슈
close #154 