### PR TITLE
feat: 북마크한 공지 목록 조회 기능 추가

### DIFF
--- a/backend/src/main/java/org/cathori/backend/bookmark/api/BookmarkController.java
+++ b/backend/src/main/java/org/cathori/backend/bookmark/api/BookmarkController.java
@@ -3,12 +3,16 @@ package org.cathori.backend.bookmark.api;
 import lombok.RequiredArgsConstructor;
 import org.cathori.backend.bookmark.api.dto.BookmarkToggleResponse;
 import org.cathori.backend.bookmark.application.BookmarkService;
+import org.cathori.backend.notice.api.dto.NoticeFeedResponse;
+import org.cathori.backend.notice.application.NoticeFeedService;
 import org.cathori.backend.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,8 +21,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
+    private final NoticeFeedService noticeFeedService;
 
-    @PostMapping("/{noticeId}/bookmark")
+    @GetMapping("/bookmarks")
+    public ResponseEntity<NoticeFeedResponse> getBookmarks(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        NoticeFeedResponse response = noticeFeedService.getBookmarked(
+                userDetails.getUserId(), page, size
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{noticeId:\\d+}/bookmark")
     public ResponseEntity<BookmarkToggleResponse> toggle(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long noticeId) {

--- a/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/NoticeController.java
@@ -53,7 +53,7 @@ public class NoticeController {
         return ResponseEntity.ok(noticeFeedService.search(userDetails.getUserId(), q, page, size));
     }
 
-    @GetMapping("/{noticeId}")
+    @GetMapping("/{noticeId:\\d+}")
     public ResponseEntity<NoticeDetailResponse> getDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long noticeId) {

--- a/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
+++ b/backend/src/main/java/org/cathori/backend/notice/api/dto/NoticeSearchItem.java
@@ -12,5 +12,6 @@ public record NoticeSearchItem(
         @Schema(example = "2026학년도 1학기 국가장학금 신청 안내") String title,
         @Schema(example = "학생지원팀") String department,
         @Schema(example = "2026-03-28") LocalDate publishedAt,
-        @Schema(example = "2026-04-30") String deadlineAt
+        @Schema(example = "2026-04-30") String deadlineAt,
+        boolean isBookmarked
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/BookmarkedNoticeQuery.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/BookmarkedNoticeQuery.java
@@ -1,0 +1,10 @@
+package org.cathori.backend.notice.application;
+
+/**
+ * 로그인 사용자의 북마크 공지 목록 조회 조건.
+ */
+public record BookmarkedNoticeQuery(
+        Long userId,
+        int page,
+        int size
+) {}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedPort.java
@@ -4,5 +4,6 @@ import java.util.List;
 
 public interface NoticeFeedPort {
     List<NoticeRow> findFeed(NoticeFeedQuery query);
+    List<NoticeRow> findBookmarked(BookmarkedNoticeQuery query);
     List<NoticeSearchRow> findSearch(NoticeSearchQuery query);
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeFeedService.java
@@ -77,6 +77,28 @@ public class NoticeFeedService {
     }
 
     @Transactional(readOnly = true)
+    public NoticeFeedResponse getBookmarked(Long userId, int page, int size) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        List<String> userTags = tagRepository.findAllByUserId(user.getId()).stream()
+                .map(Tag::getName)
+                .toList();
+        List<NoticeRow> rows = noticeFeedPort.findBookmarked(
+                new BookmarkedNoticeQuery(user.getId(), page, size)
+        );
+
+        boolean hasNext = rows.size() > size;
+        List<NoticeRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+
+        List<NoticeFeedItem> content = pageRows.stream()
+                .map(r -> toItem(r, userTags))
+                .toList();
+
+        return new NoticeFeedResponse(content, page, size, hasNext);
+    }
+
+    @Transactional(readOnly = true)
     public NoticeSearchResponse search(Long userId, String keyword, int page, int size) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
@@ -101,7 +123,8 @@ public class NoticeFeedService {
     private NoticeSearchItem toSearchItem(NoticeSearchRow row) {
         String deadlineAt = row.deadlineAt() != null ? row.deadlineAt().toString() : null;
         return new NoticeSearchItem(
-                String.valueOf(row.id()), row.category(), row.title(), row.department(), row.postedAt(), deadlineAt
+                String.valueOf(row.id()), row.category(), row.title(), row.department(), row.postedAt(), deadlineAt,
+                row.isBookmarked()
         );
     }
 

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeSearchRow.java
@@ -11,5 +11,6 @@ public record NoticeSearchRow(
         String title,
         String department,
         LocalDate postedAt,
-        LocalDate deadlineAt
+        LocalDate deadlineAt,
+        boolean isBookmarked
 ) {}

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -1,6 +1,7 @@
 package org.cathori.backend.notice.infra;
 
 import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.application.BookmarkedNoticeQuery;
 import org.cathori.backend.notice.application.NoticeFeedPort;
 import org.cathori.backend.notice.application.NoticeFeedQuery;
 import org.cathori.backend.notice.application.NoticeRow;
@@ -55,6 +56,23 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
 
         return jdbcTemplate.query(qp.sql(), ROW_MAPPER, qp.params().toArray());
 
+    }
+
+    @Override
+    public List<NoticeRow> findBookmarked(BookmarkedNoticeQuery q) {
+        List<Object> params = new ArrayList<>();
+        params.add(q.userId());
+        params.add(q.size() + 1);
+        params.add((long) q.page() * q.size());
+
+        String sql =
+                "SELECT n.*, true AS is_bookmarked " +
+                "FROM bookmark b " +
+                "JOIN notices n ON n.id = b.notice_id " +
+                "WHERE b.user_id = ? " +
+                "ORDER BY n.posted_at DESC, n.title ASC LIMIT ? OFFSET ?";
+
+        return jdbcTemplate.query(sql, ROW_MAPPER, params.toArray());
     }
 
     // Case1: category도 없고 tags도 없음 — MAIN + 제1전공 + 제2전공(전공심화 제외)
@@ -194,11 +212,14 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         List<Object> params = new ArrayList<>();
 
         StringBuilder sql = new StringBuilder(
-                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at " +
+                "SELECT n.id, n.category, n.title, n.department, n.posted_at, n.deadline_at, " +
+                "       CASE WHEN b.id IS NOT NULL THEN true ELSE false END AS is_bookmarked " +
                 "FROM notices n " +
+                "LEFT JOIN bookmark b ON b.notice_id = n.id AND b.user_id = ? " +
                 "WHERE n.title LIKE '%' || ? || '%' " +
                 "AND (n.source_type = 'MAIN'"
         );
+        params.add(q.userId());
         params.add(q.keyword());
 
         sql.append(" OR (n.source_type = 'DEPARTMENT' AND n.source_id = ?)");
@@ -219,7 +240,8 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
                 rs.getString("title"),
                 rs.getString("department"),
                 rs.getObject("posted_at", LocalDate.class),
-                rs.getObject("deadline_at", LocalDate.class)
+                rs.getObject("deadline_at", LocalDate.class),
+                rs.getBoolean("is_bookmarked")
         );
 
         return jdbcTemplate.query(sql.toString(), mapper, params.toArray());

--- a/backend/src/test/java/org/cathori/backend/bookmark/api/BookmarkIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/bookmark/api/BookmarkIntegrationTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -73,14 +74,18 @@ class BookmarkIntegrationTest extends IntegrationTestBase {
     }
 
     private Notice saveNotice() {
+        return saveNotice("테스트 공지", LocalDate.now());
+    }
+
+    private Notice saveNotice(String title, LocalDate postedAt) {
         CrawledNotice crawled = CrawledNotice.builder()
                 .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
                 .sourceType("MAIN")
                 .sourceId(null)
                 .category("장학")
-                .title("테스트 공지")
+                .title(title)
                 .department("학생처")
-                .postedAt(LocalDate.now().toString())
+                .postedAt(postedAt.toString())
                 .url("https://test.catholic.ac.kr")
                 .bodyText("")
                 .imageUrls(List.of())
@@ -139,5 +144,47 @@ class BookmarkIntegrationTest extends IntegrationTestBase {
                         .header("Authorization", "Bearer " + tokenB))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("B-6: 북마크 목록 조회 시 로그인 사용자가 북마크한 공지만 반환")
+    void listBookmarks_onlyCurrentUserBookmarks() throws Exception {
+        Notice userANotice = saveNotice("유저A 북마크 공지", LocalDate.now());
+        Notice userBNotice = saveNotice("유저B 북마크 공지", LocalDate.now().minusDays(1));
+        bookmarkJpaRepository.save(Bookmark.create(userAId, userANotice.getId()));
+        bookmarkJpaRepository.save(Bookmark.create(userBId, userBNotice.getId()));
+
+        mockMvc.perform(get("/api/notices/bookmarks")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].noticeId").value(String.valueOf(userANotice.getId())))
+                .andExpect(jsonPath("$.content[0].isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("B-7: 북마크 목록이 없으면 빈 content 반환")
+    void listBookmarks_empty() throws Exception {
+        mockMvc.perform(get("/api/notices/bookmarks")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0))
+                .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("B-8: 북마크 목록은 공지 피드 정렬 기준으로 반환")
+    void listBookmarks_sortedByNoticeFeedOrder() throws Exception {
+        Notice oldNotice = saveNotice("오래된 공지", LocalDate.now().minusDays(3));
+        Notice recentNotice = saveNotice("최신 공지", LocalDate.now());
+        bookmarkJpaRepository.save(Bookmark.create(userAId, oldNotice.getId()));
+        bookmarkJpaRepository.save(Bookmark.create(userAId, recentNotice.getId()));
+
+        mockMvc.perform(get("/api/notices/bookmarks")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].noticeId").value(String.valueOf(recentNotice.getId())))
+                .andExpect(jsonPath("$.content[1].noticeId").value(String.valueOf(oldNotice.getId())));
     }
 }

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -128,15 +128,24 @@ export default function HomeScreen() {
   const highlightNotice = null;
 
   // 즐겨찾기 토글 mutation
-  const { mutate: toggleBookmarkMutate } = useToggleBookmark();
+  const {
+    mutate: toggleBookmarkMutate,
+    isPending: isBookmarkPending,
+    variables: pendingBookmarkId,
+  } = useToggleBookmark();
 
   const handleToggleBookmark = (noticeId: string) => {
+    if (isBookmarkPending) return;
     toggleBookmarkMutate(noticeId);
   };
 
   // FlatList renderItem — 인라인 화살표 함수 방지 (Global Rules)
   const renderNoticeCard = ({ item }: { item: Notice }) => (
-    <NoticeCard notice={item} onToggleBookmark={handleToggleBookmark} />
+    <NoticeCard
+      notice={item}
+      onToggleBookmark={handleToggleBookmark}
+      isBookmarkDisabled={isBookmarkPending && pendingBookmarkId === item.id}
+    />
   );
 
   // FlatList keyExtractor

--- a/frontend/app/(tabs)/search.tsx
+++ b/frontend/app/(tabs)/search.tsx
@@ -38,6 +38,7 @@ import {
   SearchResultItem,
   useSearchNotices,
 } from '@/src/features/search';
+import { useToggleBookmark } from '@/src/features/notices';
 import { EmptyState, MainHeader } from '@/src/shared/components';
 import { useDebounce } from '@/src/shared/hooks';
 import { useSearchHistoryStore } from '@/src/store/useSearchHistoryStore';
@@ -66,6 +67,11 @@ export default function SearchScreen() {
     hasNextPage,           // ← 다음 페이지 있는지?
     isFetchingNextPage,    // ← 다음 페이지 로딩 중인지?
   } = useSearchNotices(debouncedQuery);
+  const {
+    mutate: toggleBookmarkMutate,
+    isPending: isBookmarkPending,
+    variables: pendingBookmarkId,
+  } = useToggleBookmark();
 
   // 모든 페이지의 content를 평탄화 — 검색 슬림 페이로드(SearchNoticeListItem)
   const results: SearchNoticeListItem[] = data?.pages.flatMap((p) => p.content) ?? [];
@@ -89,10 +95,20 @@ export default function SearchScreen() {
     }
   };
 
+  const handleToggleBookmark = (noticeId: string) => {
+    if (isBookmarkPending) return;
+    toggleBookmarkMutate(noticeId);
+  };
+
   // FlatList 콜백 — 인라인 화살표 함수 방지 (Global Rules)
   // debouncedQuery를 prop으로 넘겨 매칭 부분 하이라이트에 사용
   const renderItem = ({ item }: { item: SearchNoticeListItem }) => (
-    <SearchResultItem notice={item} query={debouncedQuery} />
+    <SearchResultItem
+      notice={item}
+      query={debouncedQuery}
+      onToggleBookmark={handleToggleBookmark}
+      isBookmarkDisabled={isBookmarkPending && pendingBookmarkId === item.id}
+    />
   );
   const keyExtractor = (item: SearchNoticeListItem) => item.id;
   const getItemLayout = (_: unknown, index: number) => ({

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -131,6 +131,11 @@ function RootLayoutNav() {
             name="notification/index"
             options={{ headerShown: false, animation: 'slide_from_right' }}
           />
+          {/* 북마크 목록 화면 */}
+          <Stack.Screen
+            name="bookmark/index"
+            options={{ headerShown: false, animation: 'slide_from_right' }}
+          />
           {/* 인증 화면 — 로그인 */}
           <Stack.Screen
             name="login"

--- a/frontend/app/bookmark/index.tsx
+++ b/frontend/app/bookmark/index.tsx
@@ -1,0 +1,189 @@
+/**
+ * 북마크 목록 화면 — app/bookmark/index.tsx
+ *
+ * 로그인 사용자가 저장한 공지만 기존 NoticeCard UI로 표시한다.
+ */
+
+import { Feather } from '@expo/vector-icons';
+import React from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Colors } from '@/src/constants/colors';
+import {
+  NoticeCard,
+  useBookmarkedNotices,
+  useToggleBookmark,
+} from '@/src/features/notices';
+import { EmptyState, SubHeader } from '@/src/shared/components';
+import type { Notice } from '@/src/types/api';
+
+const ESTIMATED_CARD_HEIGHT = 200;
+
+export default function BookmarkScreen() {
+  const insets = useSafeAreaInsets();
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isRefetching,
+  } = useBookmarkedNotices();
+  const {
+    mutate: toggleBookmarkMutate,
+    isPending: isBookmarkPending,
+    variables: pendingBookmarkId,
+  } = useToggleBookmark();
+
+  const notices = data?.pages.flatMap((page) => page.content) ?? [];
+
+  const handleToggleBookmark = (noticeId: string) => {
+    if (isBookmarkPending) return;
+    toggleBookmarkMutate(noticeId);
+  };
+
+  const handleLoadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  const renderNoticeCard = ({ item }: { item: Notice }) => (
+    <NoticeCard
+      notice={item}
+      onToggleBookmark={handleToggleBookmark}
+      isBookmarkDisabled={isBookmarkPending && pendingBookmarkId === item.id}
+    />
+  );
+
+  const keyExtractor = (item: Notice) => item.id;
+
+  const getItemLayout = (_: unknown, index: number) => ({
+    length: ESTIMATED_CARD_HEIGHT,
+    offset: ESTIMATED_CARD_HEIGHT * index,
+    index,
+  });
+
+  const ListEmpty = () =>
+    isLoading ? (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={Colors.primary} />
+      </View>
+    ) : (
+      <EmptyState
+        iconName="bookmark"
+        message={'저장한 공지가 없습니다.\n관심 있는 공지의 북마크 아이콘을 눌러 저장해보세요.'}
+      />
+    );
+
+  const ListFooter = () => {
+    if (!isFetchingNextPage) return null;
+    return (
+      <View style={styles.footerLoading}>
+        <ActivityIndicator size="small" color={Colors.primary} />
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.screen}>
+      <SubHeader title="북마크" />
+
+      {isError ? (
+        <View
+          style={[
+            styles.errorContainer,
+            { paddingTop: insets.top + 64, paddingBottom: insets.bottom },
+          ]}
+        >
+          <Feather name="alert-circle" size={48} color={Colors.separator} />
+          <Text style={styles.errorText}>북마크 목록을 불러오지 못했습니다</Text>
+          <Pressable onPress={() => refetch()} hitSlop={8}>
+            <Text style={styles.retryText}>다시 시도</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <FlatList
+          data={notices}
+          renderItem={renderNoticeCard}
+          keyExtractor={keyExtractor}
+          getItemLayout={getItemLayout}
+          ListEmptyComponent={ListEmpty}
+          ListFooterComponent={ListFooter}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.5}
+          contentContainerStyle={[
+            styles.listContent,
+            {
+              paddingTop: insets.top + 64 + 16,
+              paddingBottom: insets.bottom + 100,
+            },
+            notices.length === 0 && styles.emptyListContent,
+          ]}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={refetch}
+              colors={[Colors.primary]}
+            />
+          }
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  listContent: {
+    gap: 16,
+    paddingHorizontal: 16,
+  },
+  emptyListContent: {
+    flexGrow: 1,
+  },
+  loadingContainer: {
+    paddingVertical: 80,
+    alignItems: 'center',
+  },
+  footerLoading: {
+    paddingVertical: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '400',
+    color: Colors.textSecondary,
+    textAlign: 'center',
+  },
+  retryText: {
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    fontWeight: '700',
+    color: Colors.primary,
+  },
+});

--- a/frontend/app/notice/[id].tsx
+++ b/frontend/app/notice/[id].tsx
@@ -21,7 +21,7 @@
  * 기기별 insets 수동 계산 불필요.
  */
 
-import { Feather } from '@expo/vector-icons';
+import { Feather, FontAwesome } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React from 'react';
@@ -76,10 +76,10 @@ export default function NoticeDetailScreen() {
   };
 
   // 즐겨찾기 토글 mutation
-  const { mutate: toggleBookmarkMutate } = useToggleBookmark(); // mutate함수명을 변경함 (toggleBookmark)
+  const { mutate: toggleBookmarkMutate, isPending: isBookmarkPending } = useToggleBookmark(); // mutate함수명을 변경함 (toggleBookmark)
 
   const handleBookmark = () => {
-    if (notice) {
+    if (notice && !isBookmarkPending) {
       toggleBookmarkMutate(notice.id);
     }
   };
@@ -121,14 +121,16 @@ export default function NoticeDetailScreen() {
           <Feather name="arrow-left" size={24} color={Colors.textPrimary} />
         </TouchableOpacity>
         <View style={styles.headerActions}>
-          <TouchableOpacity onPress={handleBookmark} hitSlop={8}>
-            <Feather
-              name="bookmark"
-              size={22}
-              color={
-                notice.isBookmarked ? Colors.primary : Colors.bookmarkInactive
-              }
-            />
+          <TouchableOpacity
+            onPress={handleBookmark}
+            hitSlop={8}
+            disabled={isBookmarkPending}
+          >
+            {notice.isBookmarked ? (
+              <FontAwesome name="bookmark" size={21} color={Colors.primary} />
+            ) : (
+              <Feather name="bookmark" size={22} color={Colors.bookmarkInactive} />
+            )}
           </TouchableOpacity>
           <TouchableOpacity onPress={handleShare} hitSlop={8}>
             <Feather name="share-2" size={22} color={Colors.textSecondary} />

--- a/frontend/app/notice/[id].tsx
+++ b/frontend/app/notice/[id].tsx
@@ -127,7 +127,7 @@ export default function NoticeDetailScreen() {
             disabled={isBookmarkPending}
           >
             {notice.isBookmarked ? (
-              <FontAwesome name="bookmark" size={21} color={Colors.primary} />
+              <FontAwesome name="bookmark" size={21} color={Colors.bookmarkActive} />
             ) : (
               <Feather name="bookmark" size={22} color={Colors.bookmarkInactive} />
             )}

--- a/frontend/src/constants/colors.ts
+++ b/frontend/src/constants/colors.ts
@@ -65,6 +65,8 @@ export const Colors = {
   separator: '#C5C5D4',
   /** 즐겨찾기 미선택 아이콘 */
   bookmarkInactive: '#CBD5E1',
+  /** 즐겨찾기 선택 아이콘 */
+  bookmarkActive: '#F59E0B',
 
   // ─── 네비게이션 바 ─────────────────────────────────────
   /** 하단 NavBar 배경 (80% 흰색) */

--- a/frontend/src/features/notices/components/NoticeCard.tsx
+++ b/frontend/src/features/notices/components/NoticeCard.tsx
@@ -15,7 +15,7 @@
  * padding 20, gap 8, cornerRadius 12, fill #FFFFFF
  */
 
-import { Feather } from '@expo/vector-icons';
+import { Feather, FontAwesome } from '@expo/vector-icons';
 import { useRouter, type Href } from 'expo-router';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -31,9 +31,15 @@ interface NoticeCardProps {
   notice: Notice;
   /** 즐겨찾기 토글 콜백 */
   onToggleBookmark?: (noticeId: string) => void;
+  /** 즐겨찾기 요청 중 중복 클릭 방지 */
+  isBookmarkDisabled?: boolean;
 }
 
-function NoticeCardComponent({ notice, onToggleBookmark }: NoticeCardProps) {
+function NoticeCardComponent({
+  notice,
+  onToggleBookmark,
+  isBookmarkDisabled = false,
+}: NoticeCardProps) {
   const router = useRouter();
 
   // 카드 탭 → 공지 상세로 이동
@@ -43,23 +49,24 @@ function NoticeCardComponent({ notice, onToggleBookmark }: NoticeCardProps) {
 
   // 즐겨찾기 토글
   const handleBookmarkPress = () => {
+    if (isBookmarkDisabled) return;
     onToggleBookmark?.(notice.id);
   };
 
   // AI 요약 1줄만 가져오기
   const getFirstSummaryLine = (aiSummary: string | null): string => {
-  if (!aiSummary) return '';
-  try {
-    const parsed = JSON.parse(aiSummary);
-    if (Array.isArray(parsed)) {
-      return parsed[0] || '';
+    if (!aiSummary) return '';
+    try {
+      const parsed = JSON.parse(aiSummary);
+      if (Array.isArray(parsed)) {
+        return parsed[0] || '';
+      }
+      return aiSummary;
+    } catch {
+      // 백엔드에서 간혹 일반 string으로 줄바꿈해서 줄 때를 위한 대비책
+      return aiSummary.replace(/•\s*/g, '').split('\n')[0] || '';
     }
-    return aiSummary;
-  } catch {
-    // 백엔드에서 간혹 일반 string으로 줄바꿈해서 줄 때를 위한 대비책
-    return aiSummary.replace(/•\s*/g, '').split('\n')[0] || '';
-  }
-};
+  };
 
   return (
     <TouchableOpacity
@@ -107,14 +114,19 @@ function NoticeCardComponent({ notice, onToggleBookmark }: NoticeCardProps) {
           <View style={styles.metaDot} />
           <Text style={styles.metaText}>{notice.department}</Text>
         </View>
-        <TouchableOpacity onPress={handleBookmarkPress} hitSlop={8}>
-          <Feather
-            name="bookmark"
-            size={18}
-            color={
-              notice.isBookmarked ? Colors.primary : Colors.bookmarkInactive
-            }
-          />
+        <TouchableOpacity
+          onPress={(event) => {
+            event.stopPropagation();
+            handleBookmarkPress();
+          }}
+          hitSlop={8}
+          disabled={isBookmarkDisabled}
+        >
+          {notice.isBookmarked ? (
+            <FontAwesome name="bookmark" size={17} color={Colors.primary} />
+          ) : (
+            <Feather name="bookmark" size={18} color={Colors.bookmarkInactive} />
+          )}
         </TouchableOpacity>
       </View>
     </TouchableOpacity>

--- a/frontend/src/features/notices/components/NoticeCard.tsx
+++ b/frontend/src/features/notices/components/NoticeCard.tsx
@@ -123,7 +123,7 @@ function NoticeCardComponent({
           disabled={isBookmarkDisabled}
         >
           {notice.isBookmarked ? (
-            <FontAwesome name="bookmark" size={17} color={Colors.primary} />
+            <FontAwesome name="bookmark" size={17} color={Colors.bookmarkActive} />
           ) : (
             <Feather name="bookmark" size={18} color={Colors.bookmarkInactive} />
           )}

--- a/frontend/src/features/notices/hooks/index.ts
+++ b/frontend/src/features/notices/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useNoticeDetail } from './useNoticeDetail';
+export { useBookmarkedNotices } from './useBookmarkedNotices';
 export { useNotices } from './useNotices';
 export { useToggleBookmark } from './useToggleBookmark';

--- a/frontend/src/features/notices/hooks/useBookmarkedNotices.ts
+++ b/frontend/src/features/notices/hooks/useBookmarkedNotices.ts
@@ -1,0 +1,23 @@
+/**
+ * useBookmarkedNotices — 로그인 사용자의 북마크 공지 목록 조회 hook
+ */
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { NOTICE_PAGE_SIZE } from '@/src/constants/api';
+import { fetchBookmarkedNotices } from '@/src/services/notices';
+import type { Notice, PageResponse } from '@/src/types/api';
+
+export function useBookmarkedNotices() {
+  return useInfiniteQuery<PageResponse<Notice>>({
+    queryKey: ['bookmarkedNotices'],
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      fetchBookmarkedNotices({
+        page: pageParam as number,
+        size: NOTICE_PAGE_SIZE,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.page + 1 : undefined,
+  });
+}

--- a/frontend/src/features/notices/hooks/useToggleBookmark.ts
+++ b/frontend/src/features/notices/hooks/useToggleBookmark.ts
@@ -9,6 +9,8 @@
  *
  * 캐시 무효화 대상:
  *  - ['notices', ...] — 메인 목록의 isBookmarked 상태 갱신
+ *  - ['search', ...] — 검색 목록의 isBookmarked 상태 갱신
+ *  - ['bookmarkedNotices'] — 북마크 목록 갱신
  *  - ['notice', noticeId] — 상세 화면의 isBookmarked 상태 갱신
  */
 
@@ -21,12 +23,46 @@ import type { Notice, PageResponse } from '@/src/types/api';
 /** 낙관적 업데이트 롤백용 컨텍스트 */
 interface ToggleBookmarkContext {
   /** 낙관적 업데이트 전 스냅샷 (목록 캐시) */
-  previousNoticesQueries: Array<{
+  previousNoticesQueries: {
     queryKey: readonly unknown[];
     data: InfiniteData<PageResponse<Notice>> | undefined;
-  }>;
+  }[];
+  /** 낙관적 업데이트 전 스냅샷 (북마크 목록 캐시) */
+  previousBookmarkedQueries: {
+    queryKey: readonly unknown[];
+    data: InfiniteData<PageResponse<Notice>> | undefined;
+  }[];
   /** 낙관적 업데이트 전 스냅샷 (상세 캐시) */
   previousDetail: Notice | undefined;
+}
+
+function updateNoticeBookmarkInPages(
+  data: InfiniteData<PageResponse<Notice>>,
+  noticeId: string,
+  isBookmarked: boolean,
+): InfiniteData<PageResponse<Notice>> {
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      content: page.content.map((notice) =>
+        notice.id === noticeId ? { ...notice, isBookmarked } : notice,
+      ),
+    })),
+  };
+}
+
+function removeNoticeFromPages(
+  data: InfiniteData<PageResponse<Notice>>,
+  noticeId: string,
+): InfiniteData<PageResponse<Notice>> {
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      content: page.content.filter((notice) => notice.id !== noticeId),
+    })),
+  };
 }
 
 export function useToggleBookmark() {
@@ -38,11 +74,15 @@ export function useToggleBookmark() {
     onMutate: async (noticeId): Promise<ToggleBookmarkContext> => {
       // 진행 중인 관련 쿼리 취소 (충돌 방지)
       await queryClient.cancelQueries({ queryKey: ['notices'] });
+      await queryClient.cancelQueries({ queryKey: ['bookmarkedNotices'] });
       await queryClient.cancelQueries({ queryKey: ['notice', noticeId] });
 
       // ── 목록 캐시 스냅샷 + 낙관적 업데이트 ──
       const noticesQueries = queryClient.getQueriesData<InfiniteData<PageResponse<Notice>>>({
         queryKey: ['notices'],
+      });
+      const bookmarkedQueries = queryClient.getQueriesData<InfiniteData<PageResponse<Notice>>>({
+        queryKey: ['bookmarkedNotices'],
       });
 
       // getQueriesData가 반환하는 형태가 [queryKey, data][] 튜플 배열이기 때문에 매핑을 통해 분리
@@ -50,34 +90,46 @@ export function useToggleBookmark() {
         queryKey,
         data,
       }));
+      const previousBookmarkedQueries = bookmarkedQueries.map(([queryKey, data]) => ({
+        queryKey,
+        data,
+      }));
+
+      const previousDetail = queryClient.getQueryData<Notice>(['notice', noticeId]);
+      const cachedNotice = noticesQueries
+        .flatMap(([, data]) => data?.pages.flatMap((page) => page.content) ?? [])
+        .find((notice) => notice.id === noticeId);
+      const isCurrentlyBookmarked =
+        previousDetail?.isBookmarked ?? cachedNotice?.isBookmarked ?? true;
+      const nextIsBookmarked = !isCurrentlyBookmarked;
 
       // 모든 목록 캐시에서 해당 공지의 isBookmarked 반전
       noticesQueries.forEach(([queryKey, data]) => {
         if (!data) return;
-        queryClient.setQueryData<InfiniteData<PageResponse<Notice>>>(queryKey, {
-          ...data,
-          pages: data.pages.map((page) => ({
-            ...page,
-            content: page.content.map((notice) =>
-              notice.id === noticeId
-                ? { ...notice, isBookmarked: !notice.isBookmarked }
-                : notice,
-            ),
-          })),
-        });
+        queryClient.setQueryData<InfiniteData<PageResponse<Notice>>>(
+          queryKey,
+          updateNoticeBookmarkInPages(data, noticeId, nextIsBookmarked),
+        );
       });
 
-      // ── 상세 캐시 스냅샷 + 낙관적 업데이트 ──
-      const previousDetail = queryClient.getQueryData<Notice>(['notice', noticeId]);
+      bookmarkedQueries.forEach(([queryKey, data]) => {
+        if (!data) return;
+        queryClient.setQueryData<InfiniteData<PageResponse<Notice>>>(
+          queryKey,
+          nextIsBookmarked
+            ? updateNoticeBookmarkInPages(data, noticeId, true)
+            : removeNoticeFromPages(data, noticeId),
+        );
+      });
 
       if (previousDetail) {
         queryClient.setQueryData<Notice>(['notice', noticeId], {
           ...previousDetail,
-          isBookmarked: !previousDetail.isBookmarked,
+          isBookmarked: nextIsBookmarked,
         });
       }
 
-      return { previousNoticesQueries, previousDetail };
+      return { previousNoticesQueries, previousBookmarkedQueries, previousDetail };
     },
 
     onError: (_error, noticeId, context) => {
@@ -88,17 +140,58 @@ export function useToggleBookmark() {
         queryClient.setQueryData(queryKey, data);
       });
 
+      // 북마크 목록 캐시 롤백
+      context.previousBookmarkedQueries.forEach(({ queryKey, data }) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+
       // 상세 캐시 롤백
       if (context.previousDetail) {
         queryClient.setQueryData(['notice', noticeId], context.previousDetail);
       }
     },
 
+    onSuccess: (data, noticeId) => {
+      const noticesQueries = queryClient.getQueriesData<InfiniteData<PageResponse<Notice>>>({
+        queryKey: ['notices'],
+      });
+      const bookmarkedQueries = queryClient.getQueriesData<InfiniteData<PageResponse<Notice>>>({
+        queryKey: ['bookmarkedNotices'],
+      });
+
+      noticesQueries.forEach(([queryKey, queryData]) => {
+        if (!queryData) return;
+        queryClient.setQueryData<InfiniteData<PageResponse<Notice>>>(
+          queryKey,
+          updateNoticeBookmarkInPages(queryData, noticeId, data.isBookmarked),
+        );
+      });
+
+      bookmarkedQueries.forEach(([queryKey, queryData]) => {
+        if (!queryData) return;
+        queryClient.setQueryData<InfiniteData<PageResponse<Notice>>>(
+          queryKey,
+          data.isBookmarked
+            ? updateNoticeBookmarkInPages(queryData, noticeId, true)
+            : removeNoticeFromPages(queryData, noticeId),
+        );
+      });
+
+      const previousDetail = queryClient.getQueryData<Notice>(['notice', noticeId]);
+      if (previousDetail) {
+        queryClient.setQueryData<Notice>(['notice', noticeId], {
+          ...previousDetail,
+          isBookmarked: data.isBookmarked,
+        });
+      }
+    },
+
     onSettled: (_data, _error, noticeId) => {
       // 서버 상태와 동기화 — 성공/실패 불문
       queryClient.invalidateQueries({ queryKey: ['notices'] });
+      queryClient.invalidateQueries({ queryKey: ['search'] });
+      queryClient.invalidateQueries({ queryKey: ['bookmarkedNotices'] });
       queryClient.invalidateQueries({ queryKey: ['notice', noticeId] });
     },
   });
 }
-

--- a/frontend/src/features/search/components/SearchResultItem.tsx
+++ b/frontend/src/features/search/components/SearchResultItem.tsx
@@ -82,7 +82,7 @@ function SearchResultItemComponent({
           disabled={isBookmarkDisabled}
         >
           {notice.isBookmarked ? (
-            <FontAwesome name="bookmark" size={17} color={Colors.primary} />
+            <FontAwesome name="bookmark" size={17} color={Colors.bookmarkActive} />
           ) : (
             <Feather name="bookmark" size={18} color={Colors.bookmarkInactive} />
           )}

--- a/frontend/src/features/search/components/SearchResultItem.tsx
+++ b/frontend/src/features/search/components/SearchResultItem.tsx
@@ -9,15 +9,16 @@
  *
  *  - 좌측: CategoryBadge (small)
  *  - 중앙: 제목 1줄 (검색어 매칭 부분 하이라이트) + 부서·날짜 1줄
- *  - 우측: DeadlineBadge (deadlineAt이 있을 때만)
+ *  - 우측: DeadlineBadge (deadlineAt이 있을 때만) + 북마크
  *
  * 카드(NoticeCard) 대신 검색 결과에서만 쓰는 행 컴포넌트. AI 요약 미리보기는
  * 스캔 효율을 위해 제거하고, 빠르게 훑어 원하는 공지로 진입하는 흐름에 최적화.
  */
 
+import { Feather, FontAwesome } from '@expo/vector-icons';
 import { useRouter, type Href } from 'expo-router';
 import React from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { Colors } from '@/src/constants/colors';
 import { CategoryBadge, DeadlineBadge } from '@/src/features/notices';
@@ -25,17 +26,31 @@ import { formatDate } from '@/src/shared/utils/date';
 import type { SearchNoticeListItem } from '@/src/types/api';
 
 interface SearchResultItemProps {
-  // 슬림 페이로드 — aiSummary/url/isBookmarked/tags는 검색 응답에 미포함
+  // 슬림 페이로드 — aiSummary/url/tags는 검색 응답에 미포함
   notice: SearchNoticeListItem;
   /** 검색어 — 제목 내 매칭 부분 하이라이트용. 빈 문자열이면 하이라이트 없이 표시 */
   query: string;
+  /** 즐겨찾기 토글 콜백 */
+  onToggleBookmark?: (noticeId: string) => void;
+  /** 즐겨찾기 요청 중 중복 클릭 방지 */
+  isBookmarkDisabled?: boolean;
 }
 
-function SearchResultItemComponent({ notice, query }: SearchResultItemProps) {
+function SearchResultItemComponent({
+  notice,
+  query,
+  onToggleBookmark,
+  isBookmarkDisabled = false,
+}: SearchResultItemProps) {
   const router = useRouter();
 
   const handlePress = () => {
     router.push(`/notice/${notice.id}` as Href);
+  };
+
+  const handleBookmarkPress = () => {
+    if (isBookmarkDisabled) return;
+    onToggleBookmark?.(notice.id);
   };
 
   return (
@@ -54,9 +69,25 @@ function SearchResultItemComponent({ notice, query }: SearchResultItemProps) {
         </View>
       </View>
 
-      {notice.deadlineAt != null && (
-        <DeadlineBadge deadlineAt={notice.deadlineAt} />
-      )}
+      <View style={styles.rightActions}>
+        {notice.deadlineAt != null && (
+          <DeadlineBadge deadlineAt={notice.deadlineAt} />
+        )}
+        <TouchableOpacity
+          onPress={(event) => {
+            event.stopPropagation();
+            handleBookmarkPress();
+          }}
+          hitSlop={8}
+          disabled={isBookmarkDisabled}
+        >
+          {notice.isBookmarked ? (
+            <FontAwesome name="bookmark" size={17} color={Colors.primary} />
+          ) : (
+            <Feather name="bookmark" size={18} color={Colors.bookmarkInactive} />
+          )}
+        </TouchableOpacity>
+      </View>
     </Pressable>
   );
 }
@@ -139,5 +170,9 @@ const styles = StyleSheet.create({
     height: 3,
     borderRadius: 9999,
     backgroundColor: Colors.separator,
+  },
+  rightActions: {
+    alignItems: 'center',
+    gap: 8,
   },
 });

--- a/frontend/src/mocks/notices.ts
+++ b/frontend/src/mocks/notices.ts
@@ -156,7 +156,7 @@ export function getMockSearchNotices(params: {
   );
 
   const start = (params.page - 1) * params.size;
-  // 실제 API 응답과 동일한 슬림 페이로드로 매핑 — aiSummary/url/isBookmarked/tags 제외
+  // 실제 API 응답과 동일한 슬림 페이로드로 매핑 — aiSummary/url/tags 제외
   const content: SearchNoticeListItem[] = filtered
     .slice(start, start + params.size)
     .map((n) => ({
@@ -166,6 +166,7 @@ export function getMockSearchNotices(params: {
       department: n.department,
       postedAt: n.postedAt,
       deadlineAt: n.deadlineAt ?? null,
+      isBookmarked: n.isBookmarked,
     }));
 
   return {

--- a/frontend/src/services/notices.ts
+++ b/frontend/src/services/notices.ts
@@ -22,6 +22,7 @@
 import apiClient from '@/src/services/api';
 import type {
   BookmarkToggleResponse,
+  BookmarkedNoticeListParams,
   Notice,
   NoticeCategory,
   NoticeListParams,
@@ -60,7 +61,7 @@ interface BackendNoticeListItem {
 
 /**
  * 백엔드 공지 검색 응답의 슬림 아이템
- * 목록/상세보다 적은 6필드만 — aiSummary/url/isBookmarked/tags 미포함
+ * 목록/상세보다 적은 슬림 아이템 — aiSummary/url/tags 미포함
  * (검색 결과는 행 단위 빠른 스캔 UX, 행 탭 시 상세에서 재조회)
  */
 interface BackendSearchListItem {
@@ -70,6 +71,7 @@ interface BackendSearchListItem {
   department: string;
   publishedAt: string;
   deadlineAt?: string | null;
+  isBookmarked: boolean;
 }
 
 /** 백엔드 공지 상세 응답 */
@@ -125,6 +127,7 @@ function mapSearchItem(item: BackendSearchListItem): SearchNoticeListItem {
     department: item.department,
     postedAt: item.publishedAt,
     deadlineAt: item.deadlineAt ?? null,
+    isBookmarked: item.isBookmarked,
   };
 }
 
@@ -170,6 +173,31 @@ export async function fetchNotices(
   return {
     content: data.content.map(mapListItemToNotice),
     page: data.page + 1, // 백엔드 0-based → 프론트 1-based로 복원
+    size: data.size,
+    hasNext: data.hasNext,
+  };
+}
+
+/**
+ * 로그인 사용자의 북마크 공지 목록 조회 fetcher
+ * 프론트 page는 1-based → API 호출 시 0-based로 변환
+ */
+export async function fetchBookmarkedNotices(
+  params: BookmarkedNoticeListParams,
+): Promise<PageResponse<Notice>> {
+  const { data } = await apiClient.get<BackendPageResponse<BackendNoticeListItem>>(
+    '/api/notices/bookmarks',
+    {
+      params: {
+        page: params.page - 1,
+        size: params.size,
+      },
+    },
+  );
+
+  return {
+    content: data.content.map(mapListItemToNotice),
+    page: data.page + 1,
     size: data.size,
     hasNext: data.hasNext,
   };

--- a/frontend/src/shared/components/MainHeader.tsx
+++ b/frontend/src/shared/components/MainHeader.tsx
@@ -6,12 +6,12 @@
  *
  * 구조:
  * ┌─────────────────────────────┐
- * │ 🏫 Cathori              🔔  │
+ * │ 🏫 Cathori           🔖 🔔  │
  * └─────────────────────────────┘
  *
  * fill #00175B (DCU Blue), height 64, padding [0, 24]
  * 로고: Pretendard 20 / 900 / white, letterSpacing -1
- * 알림 아이콘: 16x20 흰색 + 노란 dot (#FCC006)
+ * 북마크/알림 아이콘: 20x20 흰색, 알림 dot (#FCC006)
  */
 
 import { Feather } from '@expo/vector-icons';
@@ -22,7 +22,12 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
 
-function MainHeaderComponent() {
+interface MainHeaderProps {
+  /** 필요 시 특정 화면에서만 북마크 목록 진입 버튼을 숨긴다. */
+  showBookmark?: boolean;
+}
+
+function MainHeaderComponent({ showBookmark = true }: MainHeaderProps) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
@@ -35,17 +40,31 @@ function MainHeaderComponent() {
           <Text style={styles.logoText}>Cathori</Text>
         </View>
 
-        {/* 알림 아이콘 + dot — 탭 시 알림 리스트로 이동 */}
-        <TouchableOpacity
-          style={styles.bellSection}
-          onPress={() => router.push('/notification' as Href)}
-          hitSlop={8}
-          activeOpacity={0.7}
-        >
-          <Feather name="bell" size={20} color="#FFFFFF" />
-          {/* 알림 dot — #FCC006, 10x10, border #00288C 2px */}
-          <View style={styles.notificationDot} />
-        </TouchableOpacity>
+        <View style={styles.actionSection}>
+          {/* 북마크 아이콘 — 탭 시 북마크 목록으로 이동 */}
+          {showBookmark && (
+            <TouchableOpacity
+              style={styles.iconButton}
+              onPress={() => router.push('/bookmark' as Href)}
+              hitSlop={8}
+              activeOpacity={0.7}
+            >
+              <Feather name="bookmark" size={20} color="#FFFFFF" />
+            </TouchableOpacity>
+          )}
+
+          {/* 알림 아이콘 + dot — 탭 시 알림 리스트로 이동 */}
+          <TouchableOpacity
+            style={[styles.iconButton, styles.bellSection]}
+            onPress={() => router.push('/notification' as Href)}
+            hitSlop={8}
+            activeOpacity={0.7}
+          >
+            <Feather name="bell" size={20} color="#FFFFFF" />
+            {/* 알림 dot — #FCC006, 10x10, border #00288C 2px */}
+            <View style={styles.notificationDot} />
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   );
@@ -77,6 +96,17 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     letterSpacing: -1,
     lineHeight: 28,
+  },
+  actionSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  iconButton: {
+    width: 24,
+    height: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   // 알림 아이콘
   bellSection: {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -67,7 +67,7 @@ export interface Notice {
  */
 export type SearchNoticeListItem = Pick<
   Notice,
-  'id' | 'category' | 'title' | 'department' | 'postedAt' | 'deadlineAt'
+  'id' | 'category' | 'title' | 'department' | 'postedAt' | 'deadlineAt' | 'isBookmarked'
 >;
 
 /** 공지 목록 API 요청 파라미터 */
@@ -81,6 +81,12 @@ export interface NoticeListParams {
 /** 공지 검색 API 요청 파라미터 */
 export interface NoticeSearchParams {
   q: string;
+  page: number;
+  size: number;
+}
+
+/** 북마크 공지 목록 API 요청 파라미터 */
+export interface BookmarkedNoticeListParams {
   page: number;
   size: number;
 }


### PR DESCRIPTION
## ❓ 작업을 하게된 배경

북마크 토글 기능은 이미 존재했지만, 사용자가 저장한 공지만 모아 조회하는 화면과 API가 없어 북마크 사용 흐름이 완성되지 않은 상태였다.

홈/검색/상세에서 북마크 상태를 변경해도 저장한 공지를 한 곳에서 확인할 수 없었고, 북마크 기능의 실제 사용성이 제한됨.

기존 공지 목록/상세 응답에는 `isBookmarked`가 이미 포함되어 있어, 기존 구조를 재사용해 북마크 목록 조회 기능을 최소 범위로 추가.

---

## 🔍 변경 범위

- [x] api (컨트롤러/엔드포인트)
- [x] application (서비스/유스케이스)
- [ ] model (도메인 엔티티/VO)
- [x] infra (외부 연동/포트 구현체)
- [x] etc config (기타/설정 파일)

---

## 🎯 결정 사항

### 결정 1

- **옵션:** Bottom Tab 추가 / Header 액션 추가
- **근거:** 하단 Navigation은 `HOME | SEARCH | SETTINGS` 구조를 유지
- **선택:** 공용 `MainHeader` 우측에 북마크 아이콘 추가

### 결정 2

- **옵션:** 북마크 목록 전용 DTO 신설 / 기존 피드 DTO 재사용
- **근거:** 기존 `NoticeFeedResponse`, `NoticeFeedItem`이 공지 카드 렌더링에 필요한 필드를 이미 포함함
- **선택:** 기존 피드 응답 DTO 재사용

### 결정 3

- **옵션:** 전역 북마크 상태 Store 추가 / TanStack Query 캐시 동기화
- **근거:** 기존 공지 조회와 북마크 토글이 TanStack Query 기반으로 동작함
- **선택:** `useToggleBookmark`에서 홈/검색/상세/북마크 목록 캐시 동기화

---

## ⏳ 미정 사항

- 없음

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작하는가
- [x] 관련 테스트가 모두 통과하는가
- [x] 이번 PR에서 발생한 결정 사항이 위 `결정 사항` / 의사결정 문서에 반영됐는가
- [x] 배포 후 문제 발생 시 이 변경을 되돌릴 수 있는가

**되돌릴 수 없는 경우 사유:** 없음

---

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인 / 대응 필요 사항 |
| --- | --- | --- |
| 공지 검색 API | 검색 응답에 `isBookmarked` 필드 추가 | 검색 결과에서도 북마크 상태 표시 및 토글 가능 |
| 공지 상세 API 라우팅 | `/{noticeId}`를 숫자 ID 패턴으로 제한 | `/api/notices/bookmarks`가 상세 라우트로 잘못 매칭되지 않도록 방지 |

---

## 🔗 연관 이슈

- closed #165 

---

## 🧪 테스트 결과

- `npm run lint` 통과
  - 기존 warning 5개 유지
- `npx tsc --noEmit` 통과
- 관련 백엔드 테스트 통과
  - `BookmarkIntegrationTest`
  - `NoticeFeedIntegrationTest`
  - `NoticeDetailIntegrationTest`
  - `NoticeSearchIntegrationTest`
- 실제 앱에서 북마크 목록 진입 및 조회 정상 동작 확인