### PR TITLE
[PR] 알림도메인, 애플리케이션 계층 메소드& 지역변수 네이밍개선

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notification/application/push/PushNotificationPort.java
+++ b/backend/src/main/java/org/cathori/backend/notification/application/push/PushNotificationPort.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface PushNotificationPort {
 
-    List<UserPushResult> sendMulticast(List<UserToken> targets, String title, String body, Long noticeId);
+    List<UserPushResult> send(List<UserToken> recipients, String title, String body, Long noticeId);
 }

--- a/backend/src/main/java/org/cathori/backend/notification/application/push/PushNotificationService.java
+++ b/backend/src/main/java/org/cathori/backend/notification/application/push/PushNotificationService.java
@@ -30,7 +30,7 @@ public class PushNotificationService {
     private final UserRepository userRepository;
     private final PushNotificationPort pushNotificationPort;
 
-    public void dispatchAlerts() {
+    public void sendNoticeNotifications() {
         List<Notice> unsentNotices = noticeRepository.findByAlertDispatchedFalse();
         if (unsentNotices.isEmpty()) {
             log.info("미발송 공지 없음");
@@ -39,11 +39,11 @@ public class PushNotificationService {
         log.info("미발송 공지 {}건 발송 시작", unsentNotices.size());
         for (Notice notice : unsentNotices) {
             log.info("공지id {} 제목 {} 발송 시작", notice.getId(), notice.getTitle());
-            dispatchForNotice(notice);
+            sendNoticeNotification(notice);
         }
     }
 
-    private void dispatchForNotice(Notice notice) {
+    private void sendNoticeNotification(Notice notice) {
         boolean hasRecipients = registerRecipients(notice);
         if (!hasRecipients) return;
         sendToRecipients(notice);
@@ -52,30 +52,29 @@ public class PushNotificationService {
     // 발송 대상을 계산해 AlertHistory PENDING row로 원자적으로 저장한다.
     // 이후 sendToRecipients는 이 결과를 신뢰의 원천으로 삼아 DB에서 다시 읽어 발송한다.
     private boolean registerRecipients(Notice notice) {
-        List<UserToken> targets = buildTargets(notice);
-        log.info("noticeId={} 발송 대상 {}명", notice.getId(), targets.size());
+        List<UserToken> recipients = selectEligibleRecipients(notice);
+        log.info("noticeId={} 발송 대상 {}명", notice.getId(), recipients.size());
 
-        if (targets.isEmpty()) {
+        if (recipients.isEmpty()) {
             notice.markAlertDispatched();
             noticeRepository.save(notice);
             return false;
         }
-        // (user_id, notice_id)는 유니크 제약이므로, 이미 이력이 있는 사용자에게는 새 PENDING row를 INSERT X
-        // 발송 자체는 전체 대상에게 하고, 기존 row는 persistDispatchResult의 UPDATE로 갱신된다.
 
-        // 1. 일단 AlertHistory에 저장된 user_id를 가져옴
-        Set<Long> alreadyLogged = new HashSet<>(alertHistoryRepository.findUserIdsByNoticeId(notice.getId()));
+        // 발송 절차가 중단된 후 재실행되더라도, 이미 커밋된 (회원, 공지) 이력을 중복 INSERT하지 않도록 기존 이력이 있는 사용자를 제외한다.
+        Set<Long> userIdsWithHistory = new HashSet<>(alertHistoryRepository.findUserIdsByNoticeId(notice.getId()));
 
-        // 2. AlertHistory에 저장된 user_id를 제외한 나머지 user_id에 대해서만 AlertHistory를 생성
-        Map<Long, String> matchedTags = userRepository.findFirstMatchedTagsByTitle(notice.getTitle());
-        List<AlertHistory> pendingLogs = targets.stream()
-                .filter(t -> !alreadyLogged.contains(t.userId()))
-                .map(t -> AlertHistory.create(t.userId(), notice.getId(), matchedTags.get(t.userId())))
+        // AlertHistory에 저장된 user_id를 제외한 나머지 user_id에 대해서만 AlertHistory를 생성
+        Map<Long, String> matchedTagsByUserId = userRepository.findFirstMatchedTagsByTitle(notice.getTitle());
+        List<AlertHistory> newPendingHistories = recipients.stream()
+                .filter(recipient -> !userIdsWithHistory.contains(recipient.userId()))
+                .map(recipient -> AlertHistory.create(
+                        recipient.userId(), notice.getId(), matchedTagsByUserId.get(recipient.userId())))
                 .toList();
 
-        // 3. 기존 AlertHistory에 없을 경우 PENDING 로그를 추가
-        if (!pendingLogs.isEmpty()) {
-            alertHistoryRepository.saveAll(pendingLogs);
+        // 기존 AlertHistory에 없을 경우 PENDING 로그를 추가
+        if (!newPendingHistories.isEmpty()) {
+            alertHistoryRepository.saveAll(newPendingHistories);
         }
         return true;
     }
@@ -86,47 +85,47 @@ public class PushNotificationService {
         if (recipients.isEmpty()) return;
 
         // @Transactional 범위 밖에서 FCM HTTP 호출
-        List<UserPushResult> results;
+        List<UserPushResult> pushResults;
         try {
-            results = pushNotificationPort.sendMulticast(recipients, "Cathori 새 공지", notice.getTitle(), notice.getId());
+            pushResults = pushNotificationPort.send(recipients, "Cathori 새 공지", notice.getTitle(), notice.getId());
         } catch (Exception e) {
             log.error("FCM 발송 실패. noticeId={}", notice.getId(), e);
-            List<Long> allUserIds = recipients.stream().map(UserToken::userId).toList();
+            List<Long> recipientIds = recipients.stream().map(UserToken::userId).toList();
 
             // 여기서 발송 실패는 UPDATE 라서 괜찮음
-            notificationResultWriter.persistDispatchFailure(notice, allUserIds);
+            notificationResultWriter.persistDispatchFailure(notice, recipientIds);
             return;
         }
 
         // FCM예외와 무관하게 성공 실패는 한 번에 기록
-        List<Long> successIds = results.stream().filter(UserPushResult::success).map(UserPushResult::userId).toList();
-        List<Long> failedIds = results.stream().filter(r -> !r.success()).map(UserPushResult::userId).toList();
-        notificationResultWriter.persistDispatchResult(notice, successIds, failedIds);
+        List<Long> successfulUserIds = pushResults.stream().filter(UserPushResult::success).map(UserPushResult::userId).toList();
+        List<Long> failedUserIds = pushResults.stream().filter(r -> !r.success()).map(UserPushResult::userId).toList();
+        notificationResultWriter.persistDispatchResult(notice, successfulUserIds, failedUserIds);
 
-        log.info("FCM 발송 완료. noticeId={}, success={}, fail={}", notice.getId(), successIds.size(), failedIds.size());
+        log.info("FCM 발송 완료. noticeId={}, success={}, fail={}", notice.getId(), successfulUserIds.size(), failedUserIds.size());
     }
 
     private List<UserToken> loadPendingRecipients(Long noticeId) {
-        List<Long> recipients = alertHistoryRepository.findPendingUserIdsByNoticeId(noticeId);
-        if (recipients.isEmpty()) return List.of();
+        List<Long> recipientIds = alertHistoryRepository.findPendingUserIdsByNoticeId(noticeId);
+        if (recipientIds.isEmpty()) return List.of();
 
-        Map<Long, String> deviceTokens = userRepository.findDeviceTokensByIds(recipients);
-        return recipients.stream()
-                .filter(deviceTokens::containsKey)
-                .map(id -> new UserToken(id, deviceTokens.get(id)))
+        Map<Long, String> deviceTokensByUserId = userRepository.findDeviceTokensByIds(recipientIds);
+        return recipientIds.stream()
+                .filter(deviceTokensByUserId::containsKey)
+                .map(userId -> new UserToken(userId, deviceTokensByUserId.get(userId)))
                 .toList();
     }
 
-    private List<UserToken> buildTargets(Notice notice) {
+    private List<UserToken> selectEligibleRecipients(Notice notice) {
         return userRepository.findUsersWithTagMatchingTitle(notice.getTitle())
                 .stream()
-                .filter(u -> isEligibleForNotice(u, notice))
-                .filter(u -> u.getDeviceToken() != null)
-                .map(u -> new UserToken(u.getId(), u.getDeviceToken()))
+                .filter(user -> matchesNoticeScope(user, notice))
+                .filter(user -> user.getDeviceToken() != null)
+                .map(user -> new UserToken(user.getId(), user.getDeviceToken()))
                 .toList();
     }
 
-    private boolean isEligibleForNotice(User user, Notice notice) {
+    private boolean matchesNoticeScope(User user, Notice notice) {
         if ("MAIN".equals(notice.getSourceType())) return true;
         String sourceId = notice.getSourceId();
         String majorCode = DepartmentSource.findEnumNameByDisplayName(user.getMajor());
@@ -137,47 +136,47 @@ public class PushNotificationService {
         return sourceId.equals(secondMajorCode);
     }
 
-    public void retryFailedAlerts() {
-        List<AlertHistory> failedLogs = alertHistoryRepository.findFailedForRetry();
-        if (failedLogs.isEmpty()) return;
+    public void retryFailedNotifications() {
+        List<AlertHistory> failedHistories = alertHistoryRepository.findFailedForRetry();
+        if (failedHistories.isEmpty()) return;
 
-        log.info("FCM 재시도 {}건", failedLogs.size());
+        log.info("FCM 재시도 {}건", failedHistories.size());
 
-        Map<Long, List<AlertHistory>> byNotice = failedLogs.stream()
+        Map<Long, List<AlertHistory>> failedHistoriesByNoticeId = failedHistories.stream()
                 .collect(Collectors.groupingBy(AlertHistory::getNoticeId));
 
-        for (Map.Entry<Long, List<AlertHistory>> entry : byNotice.entrySet()) {
-            retryForNotice(entry.getKey(), entry.getValue());
+        for (Map.Entry<Long, List<AlertHistory>> entry : failedHistoriesByNoticeId.entrySet()) {
+            retryNotificationsForNotice(entry.getKey(), entry.getValue());
         }
     }
 
-    private void retryForNotice(Long noticeId, List<AlertHistory> logs) {
+    private void retryNotificationsForNotice(Long noticeId, List<AlertHistory> failedHistories) {
         Notice notice = noticeRepository.findById(noticeId).orElse(null);
         if (notice == null) return;
 
-        List<UserToken> targets = logs.stream()
-                .map(l -> {
-                    User user = userRepository.findById(l.getUserId()).orElse(null);
+        List<UserToken> recipients = failedHistories.stream()
+                .map(history -> {
+                    User user = userRepository.findById(history.getUserId()).orElse(null);
                     if (user == null || user.getDeviceToken() == null) return null;
-                    return new UserToken(l.getUserId(), user.getDeviceToken());
+                    return new UserToken(history.getUserId(), user.getDeviceToken());
                 })
                 .filter(Objects::nonNull)
                 .toList();
 
-        if (targets.isEmpty()) return;
+        if (recipients.isEmpty()) return;
 
-        List<UserPushResult> results;
+        List<UserPushResult> pushResults;
         try {
-            results = pushNotificationPort.sendMulticast(targets, "Cathori 새 공지", notice.getTitle(), noticeId);
+            pushResults = pushNotificationPort.send(recipients, "Cathori 새 공지", notice.getTitle(), noticeId);
         } catch (Exception e) {
             log.error("FCM 재시도 실패. noticeId={}", noticeId, e);
-            List<Long> userIds = targets.stream().map(UserToken::userId).toList();
-            notificationResultWriter.persistRetryFailure(noticeId, userIds);
+            List<Long> recipientIds = recipients.stream().map(UserToken::userId).toList();
+            notificationResultWriter.persistRetryFailure(noticeId, recipientIds);
             return;
         }
 
-        List<Long> successIds = results.stream().filter(UserPushResult::success).map(UserPushResult::userId).toList();
-        List<Long> failedIds = results.stream().filter(r -> !r.success()).map(UserPushResult::userId).toList();
-        notificationResultWriter.persistRetryResult(noticeId, successIds, failedIds);
+        List<Long> successfulUserIds = pushResults.stream().filter(UserPushResult::success).map(UserPushResult::userId).toList();
+        List<Long> failedUserIds = pushResults.stream().filter(r -> !r.success()).map(UserPushResult::userId).toList();
+        notificationResultWriter.persistRetryResult(noticeId, successfulUserIds, failedUserIds);
     }
 }

--- a/backend/src/main/java/org/cathori/backend/notification/infra/FcmAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/FcmAdapter.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class FcmAdapter implements PushNotificationPort {
 
     @Override
-    public List<UserPushResult> sendMulticast(List<UserToken> targets, String title, String body, Long noticeId) {
+    public List<UserPushResult> send(List<UserToken> targets, String title, String body, Long noticeId) {
         List<String> tokens = targets.stream().map(UserToken::token).toList();
 
         MulticastMessage message = MulticastMessage.builder()

--- a/backend/src/main/java/org/cathori/backend/notification/infra/PushNotificationScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/PushNotificationScheduler.java
@@ -29,14 +29,13 @@ public class PushNotificationScheduler {
     @Scheduled(cron = "${alert.dispatch.cron:0 0 11 * * *}")
     public void sendNoticeNotifications() {
         log.info("알림 발송 스케줄러 시작");
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
     }
 
     /** 20분마다 실패한 알림 발송을 재시도합니다. */
     @Scheduled(cron = "0 0/20 * * * *")
-    public void retryFailedAlerts() {
-        pushNotificationService.retryFailedAlerts();
     public void retryFailedNotifications() {
+        pushNotificationService.retryFailedNotifications();
     }
 
 }

--- a/backend/src/main/java/org/cathori/backend/notification/infra/PushNotificationScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/PushNotificationScheduler.java
@@ -27,7 +27,7 @@ public class PushNotificationScheduler {
      * 코드 변경 없이 발송 주기를 짧게 덮어쓸 수 있습니다.
      */
     @Scheduled(cron = "${alert.dispatch.cron:0 0 11 * * *}")
-    public void dispatchAlerts() {
+    public void sendNoticeNotifications() {
         log.info("알림 발송 스케줄러 시작");
         pushNotificationService.dispatchAlerts();
     }
@@ -36,6 +36,7 @@ public class PushNotificationScheduler {
     @Scheduled(cron = "0 0/20 * * * *")
     public void retryFailedAlerts() {
         pushNotificationService.retryFailedAlerts();
+    public void retryFailedNotifications() {
     }
 
 }

--- a/backend/src/test/java/org/cathori/backend/notification/application/AlertServiceTest.java
+++ b/backend/src/test/java/org/cathori/backend/notification/application/AlertServiceTest.java
@@ -53,18 +53,18 @@ class AlertServiceTest extends IntegrationTestBase {
         noticeRepository.deleteAll();
     }
 
-    // --- dispatchAlerts() ---
+    // --- sendNoticeNotifications() ---
 
     @Test
     @DisplayName("DA-1: FCM 성공 → 사용자별 SUCCESS 이력 저장")
-    void dispatchAlerts_fcmSuccess_savesSuccessHistory() {
+    void sendNoticeNotifications_fcmSuccess_savesSuccessHistory() {
         Notice notice = saveNotice("장학금 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
         saveTag(user.getId(), "장학금");
-        given(pushNotificationPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+        given(pushNotificationPort.send(anyList(), anyString(), anyString(), anyLong()))
                 .willReturn(List.of(new UserPushResult(user.getId(), true)));
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
         List<AlertHistory> histories = alertHistoryJpaRepository.findAll();
         assertThat(histories).hasSize(1);
@@ -73,14 +73,14 @@ class AlertServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("DA-2: FCM 실패 → 사용자별 FAILED 이력 저장")
-    void dispatchAlerts_fcmFailure_savesFailedHistory() {
+    void sendNoticeNotifications_fcmFailure_savesFailedHistory() {
         saveNotice("장학금 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
         saveTag(user.getId(), "장학금");
-        given(pushNotificationPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+        given(pushNotificationPort.send(anyList(), anyString(), anyString(), anyLong()))
                 .willReturn(List.of(new UserPushResult(user.getId(), false)));
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
         List<AlertHistory> histories = alertHistoryJpaRepository.findAll();
         assertThat(histories).hasSize(1);
@@ -89,33 +89,33 @@ class AlertServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("DA-4: 태그 미매칭 → FCM 미호출, 이력 미저장")
-    void dispatchAlerts_noTagMatch_doesNotSendOrSave() {
+    void sendNoticeNotifications_noTagMatch_doesNotSendOrSave() {
         saveNotice("장학금 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
         saveTag(user.getId(), "취업");
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
-        verify(pushNotificationPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        verify(pushNotificationPort, never()).send(anyList(), anyString(), anyString(), anyLong());
         assertThat(alertHistoryJpaRepository.findAll()).isEmpty();
     }
 
     @Test
     @DisplayName("DA-5: deviceToken=null → FCM 미호출, 이력 미저장")
-    void dispatchAlerts_nullDeviceToken_doesNotSendOrSave() {
+    void sendNoticeNotifications_nullDeviceToken_doesNotSendOrSave() {
         saveNotice("장학금 안내");
         User user = saveUserWithoutToken("user1@test.com");
         saveTag(user.getId(), "장학금");
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
-        verify(pushNotificationPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        verify(pushNotificationPort, never()).send(anyList(), anyString(), anyString(), anyLong());
         assertThat(alertHistoryJpaRepository.findAll()).isEmpty();
     }
 
     @Test
     @DisplayName("DA-7: alertDispatched=true 공지 → FCM 미호출")
-    void dispatchAlerts_alreadyDispatched_doesNotSend() {
+    void sendNoticeNotifications_alreadyDispatched_doesNotSend() {
         CrawledNotice crawled = CrawledNotice.builder()
                 .articleNo("TEST001")
                 .sourceType("MAIN")
@@ -132,21 +132,21 @@ class AlertServiceTest extends IntegrationTestBase {
         notice.markAlertDispatched();
         noticeRepository.save(notice);
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
-        verify(pushNotificationPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        verify(pushNotificationPort, never()).send(anyList(), anyString(), anyString(), anyLong());
     }
 
     @Test
     @DisplayName("DA-9: 발송 완료 후 notice.alertDispatched=true 변경")
-    void dispatchAlerts_afterDispatch_marksNoticeAsDispatched() {
+    void sendNoticeNotifications_afterDispatch_marksNoticeAsDispatched() {
         Notice notice = saveNotice("장학금 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
         saveTag(user.getId(), "장학금");
-        given(pushNotificationPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+        given(pushNotificationPort.send(anyList(), anyString(), anyString(), anyLong()))
                 .willReturn(List.of(new UserPushResult(user.getId(), true)));
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
         Notice reloaded = noticeRepository.findById(notice.getId()).orElseThrow();
         assertThat(reloaded.isAlertDispatched()).isTrue();
@@ -154,11 +154,11 @@ class AlertServiceTest extends IntegrationTestBase {
 
     @Test
     @DisplayName("DA-10: 매칭 사용자 없어도 notice.alertDispatched=true 변경")
-    void dispatchAlerts_noMatchingUser_stillMarksNoticeAsDispatched() {
+    void sendNoticeNotifications_noMatchingUser_stillMarksNoticeAsDispatched() {
         Notice notice = saveNotice("장학금 안내");
         saveUserWithoutToken("user1@test.com");  // 태그 없는 사용자 (매칭 안 됨)
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
         Notice reloaded = noticeRepository.findById(notice.getId()).orElseThrow();
         assertThat(reloaded.isAlertDispatched()).isTrue();
@@ -167,67 +167,67 @@ class AlertServiceTest extends IntegrationTestBase {
     @Test
     @DisplayName("DA-11: 학과 공지 — 제1전공 일치 사용자에게만 발송")
     @SuppressWarnings("unchecked")
-    void dispatchAlerts_departmentNotice_onlySendsToMatchingMajorUser() {
+    void sendNoticeNotifications_departmentNotice_onlySendsToMatchingMajorUser() {
         String csieCode = DepartmentSource.findEnumNameByDisplayName("컴퓨터정보공학");
         saveDepartmentNotice("장학금 안내", csieCode);
         User matching = saveUserWithToken("csie@test.com", "token-csie");
         saveTag(matching.getId(), "장학금");
         User nonMatching = saveUserWithSecondMajor("biz@test.com", "token-biz", "경영학", null);
         saveTag(nonMatching.getId(), "장학금");
-        given(pushNotificationPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+        given(pushNotificationPort.send(anyList(), anyString(), anyString(), anyLong()))
                 .willReturn(List.of(new UserPushResult(matching.getId(), true)));
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
         ArgumentCaptor<List<UserToken>> captor = ArgumentCaptor.forClass(List.class);
-        verify(pushNotificationPort).sendMulticast(captor.capture(), anyString(), anyString(), anyLong());
+        verify(pushNotificationPort).send(captor.capture(), anyString(), anyString(), anyLong());
         assertThat(captor.getValue()).hasSize(1);
         assertThat(captor.getValue().getFirst().userId()).isEqualTo(matching.getId());
     }
 
     @Test
     @DisplayName("DA-14: 학과 공지 — 제2전공=전공심화 → 제외")
-    void dispatchAlerts_departmentNotice_excludesSecondMajorJeonGongSimhwa() {
+    void sendNoticeNotifications_departmentNotice_excludesSecondMajorJeonGongSimhwa() {
         String csieCode = DepartmentSource.findEnumNameByDisplayName("컴퓨터정보공학");
         saveDepartmentNotice("장학금 안내", csieCode);
         User user = saveUserWithSecondMajor("biz@test.com", "token-biz", "경영학", "전공심화");
         saveTag(user.getId(), "장학금");
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
-        verify(pushNotificationPort, never()).sendMulticast(anyList(), anyString(), anyString(), anyLong());
+        verify(pushNotificationPort, never()).send(anyList(), anyString(), anyString(), anyLong());
     }
 
     @Test
     @DisplayName("DA-3: FCM 발송 시 matched_tag 저장 — 가나다 순 첫 번째 태그")
-    void dispatchAlerts_savesMatchedTagAsMinTagName() {
+    void sendNoticeNotifications_savesMatchedTagAsMinTagName() {
         Notice notice = saveNotice("국가장학금 신청 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
         saveTag(user.getId(), "장학");
         saveTag(user.getId(), "국가장학");
-        given(pushNotificationPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+        given(pushNotificationPort.send(anyList(), anyString(), anyString(), anyLong()))
                 .willReturn(List.of(new UserPushResult(user.getId(), true)));
 
-        pushNotificationService.dispatchAlerts();
+        pushNotificationService.sendNoticeNotifications();
 
         AlertHistory history = alertHistoryJpaRepository.findAll().getFirst();
         assertThat(history.getMatchedTag()).isEqualTo("국가장학");
     }
 
-    // --- retryFailedAlerts() ---
+    // --- retryFailedNotifications() ---
 
     @Test
     @DisplayName("RA-1: 재시도 FCM 성공 → alarmStatus=SUCCESS 변경")
-    void retryFailedAlerts_fcmSuccess_updatesStatusToSuccess() {
+    void retryFailedNotifications_fcmSuccess_updatesStatusToSuccess() {
         Notice notice = saveNotice("장학금 안내");
         User user = saveUserWithToken("user1@test.com", "token-abc");
         AlertHistory failed = AlertHistory.create(user.getId(), notice.getId(), null);
         failed.markFailed();
         AlertHistory saved = alertHistoryJpaRepository.save(failed);
-        given(pushNotificationPort.sendMulticast(anyList(), anyString(), anyString(), anyLong()))
+        given(pushNotificationPort.send(anyList(), anyString(), anyString(), anyLong()))
                 .willReturn(List.of(new UserPushResult(user.getId(), true)));
 
-        pushNotificationService.retryFailedAlerts();
+        pushNotificationService.retryFailedNotifications();
 
         AlertHistory updated = alertHistoryJpaRepository.findById(saved.getId()).orElseThrow();
         assertThat(updated.getAlarmStatus()).isEqualTo("SUCCESS");


### PR DESCRIPTION
## 🔧 리팩터링 대상

<!--
1. 어느 파일/클래스/메서드가 대상인지
2. 코드 레벨로 무엇이 문제였는지 (중복, 책임 과다, 의존성 방향 위반, 테스트 어려움 등)
   - "지저분함" 같은 추상적 표현 금지, 구체적 증상 명시
-->

>알림도메인 애플리케이션 계층의 push관련 비지니스로직의 메소드와 그안의 지역변수들 대상으로 진행


## 📐 As-Is → To-Be

<!-- 구조 변경 전/후를 비교. 다이어그램, 코드 스니펫, 클래스 관계 등 -->

**As-Is**
```
dispatchAlerts()
 └─ dispatchForNotice()
     ├─ buildTargets()
     │   └─ isEligibleForNotice()
     └─ PushNotificationPort.sendMulticast()

retryFailedAlerts()
 └─ retryForNotice()
```

**To-Be**
```
sendNoticeNotifications()
 └─ sendNoticeNotification()
     ├─ selectEligibleRecipients()
     │   └─ matchesNoticeScope()
     └─ PushNotificationPort.send()

retryFailedNotifications()
 └─ retryNotificationsForNotice()
```


## 🎯 결정 사항

###결정 1: 포트에서 구현 세부사항 제거
- 옵션: sendMulticast(), send()
- 근거: 멀티캐스트는 FCM 어댑터의 구현 방식이며 애플리케이션 포트가 알 필요가 없음
- 선택: PushNotificationPort.send()로 변경하고 멀티캐스트 구현은 FcmAdapter 내부에 유지


<!-- 4개 이상이면 요약만 남기고 별도 문서로 분리 -->


## ⚠️ 동작 불변 검증

<!-- 리팩터링은 외부 동작이 바뀌면 안 되므로, 이를 어떻게 보장했는지 -->

- [x] 기존 테스트가 모두 그대로 통과하는가 (수정 없이)
- [x] 테스트 자체를 수정했다면, 그 이유가 "동작 변경"이 아니라 "구조 변경으로 인한 테스트 코드 갱신"임을 확인했는가


## ⏳ 미정 사항

- /infra, /domain, /application/inbox 등에 대한 네이밍 개선은 추후 진행
- 테이블 스키마 변경등 변경사항이 커질까봐 당장은 보류해뒀음.

해당 없으면: 없음


## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| | | |

해당 없으면: 없음


## 🔗 연관 이슈
closes #163 