### PR TITLE
feat(notification): 알림 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notification/api/NotificationController.java
+++ b/backend/src/main/java/org/cathori/backend/notification/api/NotificationController.java
@@ -34,4 +34,14 @@ public class NotificationController {
         notificationService.markRead(userDetails.getUserId(), alertHistoryId);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/{alertHistoryId}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long alertHistoryId
+    ) {
+        notificationService.deleteNotification(userDetails.getUserId(), alertHistoryId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/backend/src/main/java/org/cathori/backend/notification/application/inbox/NotificationService.java
+++ b/backend/src/main/java/org/cathori/backend/notification/application/inbox/NotificationService.java
@@ -50,4 +50,11 @@ public class NotificationService {
         alertHistory.markRead();
         alertHistoryRepository.save(alertHistory);
     }
+
+    @Transactional
+    public void deleteNotification(Long userId, Long alertHistoryId) {
+        AlertHistory alertHistory = alertHistoryRepository.findByIdAndUserId(alertHistoryId, userId)
+                .orElseThrow(() -> new BusinessException(AlertErrorCode.ALERT_NOT_FOUND));
+        alertHistoryRepository.delete(alertHistory);
+    }
 }

--- a/backend/src/main/java/org/cathori/backend/notification/domain/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notification/domain/AlertHistoryRepository.java
@@ -23,5 +23,7 @@ public interface AlertHistoryRepository {
 
     Optional<AlertHistory> findByIdAndUserId(Long id, Long userId);
 
+    void delete(AlertHistory alertHistory);
+
     void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryRepositoryImpl.java
@@ -65,6 +65,11 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     }
 
     @Override
+    public void delete(AlertHistory alertHistory) {
+        jpaRepository.delete(alertHistory);
+    }
+
+    @Override
     public void deleteByUserId(Long userId) {
         jpaRepository.deleteByUserId(userId);
     }

--- a/backend/src/test/java/org/cathori/backend/notification/api/NotificationIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notification/api/NotificationIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -166,6 +167,60 @@ class NotificationIntegrationTest extends IntegrationTestBase {
     @DisplayName("NI-8: PATCH JWT 없음 → 401")
     void markRead_withoutJwt_returns401() throws Exception {
         mockMvc.perform(patch("/api/notifications/1/read"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("NI-9: DELETE /{id} → 204 No Content")
+    void deleteNotification_validAlert_returns204() throws Exception {
+        Notice notice = saveNotice();
+        Long historyId = insertAlertHistory(userAId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(delete("/api/notifications/" + historyId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("NI-10: DELETE /{id} → 내 알림 삭제")
+    void deleteNotification_validAlert_deletesAlert() throws Exception {
+        Notice notice = saveNotice();
+        Long historyId = insertAlertHistory(userAId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(delete("/api/notifications/" + historyId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/notifications")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts").isEmpty());
+    }
+
+    @Test
+    @DisplayName("NI-11: DELETE /{없는id} → 404 + ALERT_NOT_FOUND")
+    void deleteNotification_notExistingId_returns404() throws Exception {
+        mockMvc.perform(delete("/api/notifications/99999")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("ALERT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("NI-12: DELETE /{타인id} → 404")
+    void deleteNotification_othersAlert_returns404() throws Exception {
+        Notice notice = saveNotice();
+        Long historyId = insertAlertHistory(userBId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(delete("/api/notifications/" + historyId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("NI-13: DELETE JWT 없음 → 401")
+    void deleteNotification_withoutJwt_returns401() throws Exception {
+        mockMvc.perform(delete("/api/notifications/1"))
                 .andExpect(status().isUnauthorized());
     }
 

--- a/backend/src/test/java/org/cathori/backend/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/org/cathori/backend/notification/application/NotificationServiceTest.java
@@ -174,6 +174,40 @@ class NotificationServiceTest extends IntegrationTestBase {
                         .isEqualTo(AlertErrorCode.ALERT_NOT_FOUND));
     }
 
+    // --- deleteNotification ---
+
+    @Test
+    @DisplayName("NS-11: 내 알림 삭제 → 이력 삭제")
+    void deleteNotification_myAlert_deletesAlert() {
+        Notice notice = saveNotice("공지");
+        Long historyId = insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", null);
+
+        notificationService.deleteNotification(USER_ID, historyId);
+
+        assertThat(alertHistoryJpaRepository.findById(historyId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("NS-12: 존재하지 않는 alertHistoryId 삭제 → ALERT_NOT_FOUND 예외")
+    void deleteNotification_notExistingId_throwsAlertNotFound() {
+        assertThatThrownBy(() -> notificationService.deleteNotification(USER_ID, 99999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AlertErrorCode.ALERT_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("NS-13: 타인 알림 삭제 → ALERT_NOT_FOUND 예외")
+    void deleteNotification_othersAlert_throwsAlertNotFound() {
+        Notice notice = saveNotice("공지");
+        Long historyId = insertAlertHistory(OTHER_USER_ID, notice.getId(), "SUCCESS", null);
+
+        assertThatThrownBy(() -> notificationService.deleteNotification(USER_ID, historyId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(AlertErrorCode.ALERT_NOT_FOUND));
+    }
+
     private Notice saveNotice(String title) {
         return noticeRepository.save(Notice.from(CrawledNotice.builder()
                 .articleNo("NS-" + title.hashCode())

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -117,44 +118,46 @@ function RootLayoutNav() {
   // 트리 상단에 Provider가 없으면 useSafeAreaInsets() - SafeAreaView가 inset을 0으로
   // 계산하여 갤럭시(Android)의 OS 네비바 영역을 침범한다.
   return (
-    <SafeAreaProvider>
-      <QueryClientProvider client={queryClient}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          {/* 공지 상세 화면 */}
-          <Stack.Screen
-            name="notice/[id]"
-            options={{ headerShown: false, animation: 'slide_from_right' }}
-          />
-          {/* 알림 리스트 화면 */}
-          <Stack.Screen
-            name="notification/index"
-            options={{ headerShown: false, animation: 'slide_from_right' }}
-          />
-          {/* 북마크 목록 화면 */}
-          <Stack.Screen
-            name="bookmark/index"
-            options={{ headerShown: false, animation: 'slide_from_right' }}
-          />
-          {/* 인증 화면 — 로그인 */}
-          <Stack.Screen
-            name="login"
-            options={{ headerShown: false, animation: 'fade' }}
-          />
-          {/* 인증 화면 — 회원가입 */}
-          <Stack.Screen
-            name="register"
-            options={{ headerShown: false, animation: 'slide_from_right' }}
-          />
-          {/* 설정 — 관심 키워드 화면 */}
-          <Stack.Screen
-            name="settings/keywords"
-            options={{ headerShown: false, animation: 'slide_from_right' }}
-          />
-        </Stack>
-        {/* Android only: 상태바 스타일 */}
-        <StatusBar style="light" backgroundColor="transparent" translucent />
-      </QueryClientProvider>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <QueryClientProvider client={queryClient}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            {/* 공지 상세 화면 */}
+            <Stack.Screen
+              name="notice/[id]"
+              options={{ headerShown: false, animation: 'slide_from_right' }}
+            />
+            {/* 알림 리스트 화면 */}
+            <Stack.Screen
+              name="notification/index"
+              options={{ headerShown: false, animation: 'slide_from_right' }}
+            />
+            {/* 북마크 목록 화면 */}
+            <Stack.Screen
+              name="bookmark/index"
+              options={{ headerShown: false, animation: 'slide_from_right' }}
+            />
+            {/* 인증 화면 — 로그인 */}
+            <Stack.Screen
+              name="login"
+              options={{ headerShown: false, animation: 'fade' }}
+            />
+            {/* 인증 화면 — 회원가입 */}
+            <Stack.Screen
+              name="register"
+              options={{ headerShown: false, animation: 'slide_from_right' }}
+            />
+            {/* 설정 — 관심 키워드 화면 */}
+            <Stack.Screen
+              name="settings/keywords"
+              options={{ headerShown: false, animation: 'slide_from_right' }}
+            />
+          </Stack>
+          {/* Android only: 상태바 스타일 */}
+          <StatusBar style="light" backgroundColor="transparent" translucent />
+        </QueryClientProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -109,11 +109,6 @@ export default function RootLayout() {
 }
 
 function RootLayoutNav() {
-  // 인증 상태 기반 라우팅 가드 활성화
-  useProtectedRoute();
-  // 푸시 토큰 동기화(로그인 시 등록) + 알림 탭 → 공지 상세 네비게이션
-  usePushNotifications();
-
   // SafeAreaProvider — react-native-safe-area-context의 inset 컨텍스트를 트리에 주입.
   // 트리 상단에 Provider가 없으면 useSafeAreaInsets() - SafeAreaView가 inset을 0으로
   // 계산하여 갤럭시(Android)의 OS 네비바 영역을 침범한다.
@@ -121,43 +116,56 @@ function RootLayoutNav() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <QueryClientProvider client={queryClient}>
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            {/* 공지 상세 화면 */}
-            <Stack.Screen
-              name="notice/[id]"
-              options={{ headerShown: false, animation: 'slide_from_right' }}
-            />
-            {/* 알림 리스트 화면 */}
-            <Stack.Screen
-              name="notification/index"
-              options={{ headerShown: false, animation: 'slide_from_right' }}
-            />
-            {/* 북마크 목록 화면 */}
-            <Stack.Screen
-              name="bookmark/index"
-              options={{ headerShown: false, animation: 'slide_from_right' }}
-            />
-            {/* 인증 화면 — 로그인 */}
-            <Stack.Screen
-              name="login"
-              options={{ headerShown: false, animation: 'fade' }}
-            />
-            {/* 인증 화면 — 회원가입 */}
-            <Stack.Screen
-              name="register"
-              options={{ headerShown: false, animation: 'slide_from_right' }}
-            />
-            {/* 설정 — 관심 키워드 화면 */}
-            <Stack.Screen
-              name="settings/keywords"
-              options={{ headerShown: false, animation: 'slide_from_right' }}
-            />
-          </Stack>
-          {/* Android only: 상태바 스타일 */}
-          <StatusBar style="light" backgroundColor="transparent" translucent />
+          <AppNavigator />
         </QueryClientProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>
+  );
+}
+
+function AppNavigator() {
+  // 인증 상태 기반 라우팅 가드 활성화
+  useProtectedRoute();
+  // 푸시 토큰 동기화(로그인 시 등록) + 알림 탭 → 공지 상세 네비게이션
+  usePushNotifications();
+
+  return (
+    <>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        {/* 공지 상세 화면 */}
+        <Stack.Screen
+          name="notice/[id]"
+          options={{ headerShown: false, animation: 'slide_from_right' }}
+        />
+        {/* 알림 리스트 화면 */}
+        <Stack.Screen
+          name="notification/index"
+          options={{ headerShown: false, animation: 'slide_from_right' }}
+        />
+        {/* 북마크 목록 화면 */}
+        <Stack.Screen
+          name="bookmark/index"
+          options={{ headerShown: false, animation: 'slide_from_right' }}
+        />
+        {/* 인증 화면 — 로그인 */}
+        <Stack.Screen
+          name="login"
+          options={{ headerShown: false, animation: 'fade' }}
+        />
+        {/* 인증 화면 — 회원가입 */}
+        <Stack.Screen
+          name="register"
+          options={{ headerShown: false, animation: 'slide_from_right' }}
+        />
+        {/* 설정 — 관심 키워드 화면 */}
+        <Stack.Screen
+          name="settings/keywords"
+          options={{ headerShown: false, animation: 'slide_from_right' }}
+        />
+      </Stack>
+      {/* Android only: 상태바 스타일 */}
+      <StatusBar style="light" backgroundColor="transparent" translucent />
+    </>
   );
 }

--- a/frontend/app/notification/index.tsx
+++ b/frontend/app/notification/index.tsx
@@ -18,12 +18,17 @@
  */
 
 import React from 'react';
-import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Alert, FlatList, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
-import { NotificationItem, useNotifications } from '@/src/features/notifications';
+import {
+  NotificationItem,
+  useDeleteNotification,
+  useNotifications,
+} from '@/src/features/notifications';
 import { EmptyState, SubHeader } from '@/src/shared/components';
+import type { NotificationListItem } from '@/src/types/notifications';
 
 export default function NotificationScreen() {
   const insets = useSafeAreaInsets();
@@ -37,6 +42,7 @@ export default function NotificationScreen() {
     hasNextPage,
     isFetchingNextPage,
   } = useNotifications();
+  const deleteNotificationMutation = useDeleteNotification();
 
   // 커서 페이지네이션 응답(pages)을 단일 목록으로 평탄화
   const notifications = data?.pages.flatMap((page) => page.alerts) ?? [];
@@ -50,6 +56,32 @@ export default function NotificationScreen() {
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
+  };
+
+  const handleDeleteNotification = (notification: NotificationListItem) => {
+    if (deleteNotificationMutation.isPending) return;
+
+    Alert.alert(
+      '알림 삭제',
+      '이 알림을 삭제할까요?',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: () => {
+            deleteNotificationMutation.mutate(notification.alertHistoryId, {
+              onError: () => {
+                Alert.alert(
+                  '삭제 실패',
+                  '알림 삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+                );
+              },
+            });
+          },
+        },
+      ],
+    );
   };
 
   return (
@@ -71,7 +103,16 @@ export default function NotificationScreen() {
         <FlatList
           data={notifications}
           keyExtractor={(item) => String(item.alertHistoryId)}
-          renderItem={({ item }) => <NotificationItem notification={item} />}
+          renderItem={({ item }) => (
+            <NotificationItem
+              notification={item}
+              onDelete={handleDeleteNotification}
+              isDeleteDisabled={
+                deleteNotificationMutation.isPending &&
+                deleteNotificationMutation.variables === item.alertHistoryId
+              }
+            />
+          )}
           contentContainerStyle={[styles.listContent, contentPadding]}
           ItemSeparatorComponent={() => <View style={styles.separator} />}
           showsVerticalScrollIndicator={false}

--- a/frontend/src/features/notifications/components/NotificationItem.tsx
+++ b/frontend/src/features/notifications/components/NotificationItem.tsx
@@ -12,9 +12,14 @@
  * - deadlineAt이 있을 때만 date.ts로 D-day를 연산해 뱃지 표시
  */
 
+import { Feather } from '@expo/vector-icons';
 import { useRouter, type Href } from 'expo-router';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { SharedValue } from 'react-native-reanimated';
 
 import { Colors } from '@/src/constants/colors';
 import {
@@ -27,9 +32,15 @@ import type { NotificationListItem } from '@/src/types/notifications';
 
 interface NotificationItemProps {
   notification: NotificationListItem;
+  onDelete?: (notification: NotificationListItem) => void;
+  isDeleteDisabled?: boolean;
 }
 
-function NotificationItemComponent({ notification }: NotificationItemProps) {
+function NotificationItemComponent({
+  notification,
+  onDelete,
+  isDeleteDisabled = false,
+}: NotificationItemProps) {
   const router = useRouter();
 
   // 카드 탭 → 공지 상세로 이동 (NoticeCard와 동일 패턴)
@@ -43,62 +54,119 @@ function NotificationItemComponent({ notification }: NotificationItemProps) {
       : null;
   const urgent = dday != null && isDdayUrgent(dday);
 
+  const renderRightActions = (
+    _progress: SharedValue<number>,
+    _translation: SharedValue<number>,
+    swipeableMethods: SwipeableMethods,
+  ) => (
+    <View style={styles.deleteActionWrapper}>
+      <TouchableOpacity
+        style={[
+          styles.deleteAction,
+          isDeleteDisabled && styles.deleteActionDisabled,
+        ]}
+        onPress={() => {
+          swipeableMethods.close();
+          onDelete?.(notification);
+        }}
+        activeOpacity={0.8}
+        disabled={isDeleteDisabled}
+      >
+        <Feather name="trash-2" size={18} color="#FFFFFF" />
+        <Text style={styles.deleteActionText}>삭제</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
   return (
-    <TouchableOpacity
-      style={styles.container}
-      onPress={handlePress}
-      activeOpacity={0.7}
+    <ReanimatedSwipeable
+      containerStyle={styles.swipeableContainer}
+      renderRightActions={renderRightActions}
+      rightThreshold={36}
+      friction={2}
+      overshootRight={false}
     >
-      {/* 상단: 매칭 태그 칩 + D-day 뱃지 */}
-      <View style={styles.topRow}>
-        {notification.matchedTag ? (
-          <View style={styles.tagChip}>
-            <Text style={styles.tagChipText} numberOfLines={1}>
-              #{notification.matchedTag}
-            </Text>
-          </View>
-        ) : (
-          // 태그가 없는 경우에도 space-between 정렬 유지를 위한 빈 자리
-          <View />
-        )}
-        {dday != null && (
-          <View
-            style={[
-              styles.ddayBadge,
-              urgent ? styles.ddayUrgent : styles.ddayNormal,
-            ]}
-          >
-            <Text
+      <TouchableOpacity
+        style={styles.container}
+        onPress={handlePress}
+        activeOpacity={0.7}
+      >
+        {/* 상단: 매칭 태그 칩 + D-day 뱃지 */}
+        <View style={styles.topRow}>
+          {notification.matchedTag ? (
+            <View style={styles.tagChip}>
+              <Text style={styles.tagChipText} numberOfLines={1}>
+                #{notification.matchedTag}
+              </Text>
+            </View>
+          ) : (
+            // 태그가 없는 경우에도 space-between 정렬 유지를 위한 빈 자리
+            <View />
+          )}
+          {dday != null && (
+            <View
               style={[
-                styles.ddayText,
-                urgent ? styles.ddayTextUrgent : styles.ddayTextNormal,
+                styles.ddayBadge,
+                urgent ? styles.ddayUrgent : styles.ddayNormal,
               ]}
             >
-              {formatDday(dday)}
-            </Text>
-          </View>
-        )}
-      </View>
+              <Text
+                style={[
+                  styles.ddayText,
+                  urgent ? styles.ddayTextUrgent : styles.ddayTextNormal,
+                ]}
+              >
+                {formatDday(dday)}
+              </Text>
+            </View>
+          )}
+        </View>
 
-      {/* 제목 */}
-      <Text style={styles.title} numberOfLines={2}>
-        {notification.title}
-      </Text>
+        {/* 제목 */}
+        <Text style={styles.title} numberOfLines={2}>
+          {notification.title}
+        </Text>
 
-      {/* 발송 시각 */}
-      <Text style={styles.date}>{formatDate(notification.createdAt)}</Text>
-    </TouchableOpacity>
+        {/* 발송 시각 */}
+        <Text style={styles.date}>{formatDate(notification.createdAt)}</Text>
+      </TouchableOpacity>
+    </ReanimatedSwipeable>
   );
 }
 
 export const NotificationItem = NotificationItemComponent;
 
 const styles = StyleSheet.create({
+  swipeableContainer: {
+    borderRadius: 12,
+  },
   container: {
     backgroundColor: Colors.cardBg,
     borderRadius: 12,
     padding: 20,
     gap: 8,
+  },
+  deleteActionWrapper: {
+    width: 88,
+    marginLeft: 8,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  deleteAction: {
+    flex: 1,
+    backgroundColor: '#D92D20',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 4,
+  },
+  deleteActionDisabled: {
+    backgroundColor: '#F97066',
+  },
+  deleteActionText: {
+    fontFamily: 'Pretendard',
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#FFFFFF',
   },
   topRow: {
     flexDirection: 'row',

--- a/frontend/src/features/notifications/hooks/index.ts
+++ b/frontend/src/features/notifications/hooks/index.ts
@@ -1,2 +1,6 @@
-export { useNotifications } from './useNotifications';
+export {
+  useDeleteNotification,
+  useHasNotifications,
+  useNotifications,
+} from './useNotifications';
 export { usePushNotifications } from './usePushNotifications';

--- a/frontend/src/features/notifications/hooks/useNotifications.ts
+++ b/frontend/src/features/notifications/hooks/useNotifications.ts
@@ -6,10 +6,52 @@
  * 화면에서는 data.pages.flatMap(p => p.alerts)로 평탄화해 사용한다.
  */
 
-import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
 
-import { fetchNotifications } from '@/src/services/notifications';
+import {
+  deleteNotification,
+  fetchNotifications,
+} from '@/src/services/notifications';
 import type { NotificationPage } from '@/src/types/notifications';
+
+interface DeleteNotificationContext {
+  previousNotificationQueries: {
+    queryKey: readonly unknown[];
+    data: InfiniteData<NotificationPage> | undefined;
+  }[];
+}
+
+function isNotificationInfiniteData(
+  data: unknown,
+): data is InfiniteData<NotificationPage> {
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    'pages' in data &&
+    Array.isArray((data as InfiniteData<NotificationPage>).pages)
+  );
+}
+
+function removeNotificationFromPages(
+  data: InfiniteData<NotificationPage>,
+  alertHistoryId: number,
+): InfiniteData<NotificationPage> {
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      alerts: page.alerts.filter(
+        (notification) => notification.alertHistoryId !== alertHistoryId,
+      ),
+    })),
+  };
+}
 
 export function useNotifications() {
   return useInfiniteQuery<NotificationPage>({
@@ -21,5 +63,58 @@ export function useNotifications() {
     // hasNext가 false거나 nextCursor가 null이면 undefined를 반환해 페이징 종료
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? lastPage.nextCursor ?? undefined : undefined,
+  });
+}
+
+export function useHasNotifications() {
+  return useQuery({
+    queryKey: ['notifications', 'hasAny'],
+    queryFn: () => fetchNotifications({ size: 1 }),
+    select: (page) => page.alerts.length > 0,
+  });
+}
+
+export function useDeleteNotification() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteNotification,
+
+    onMutate: async (alertHistoryId): Promise<DeleteNotificationContext> => {
+      await queryClient.cancelQueries({ queryKey: ['notifications'] });
+
+      const notificationQueries = queryClient
+        .getQueriesData<unknown>({ queryKey: ['notifications'] })
+        .filter(
+          (query): query is [readonly unknown[], InfiniteData<NotificationPage>] =>
+            isNotificationInfiniteData(query[1]),
+        );
+
+      const previousNotificationQueries = notificationQueries.map(
+        ([queryKey, data]) => ({ queryKey, data }),
+      );
+
+      notificationQueries.forEach(([queryKey, data]) => {
+        if (!data) return;
+        queryClient.setQueryData<InfiniteData<NotificationPage>>(
+          queryKey,
+          removeNotificationFromPages(data, alertHistoryId),
+        );
+      });
+
+      return { previousNotificationQueries };
+    },
+
+    onError: (_error, _alertHistoryId, context) => {
+      if (!context) return;
+
+      context.previousNotificationQueries.forEach(({ queryKey, data }) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
   });
 }

--- a/frontend/src/features/notifications/hooks/usePushNotifications.ts
+++ b/frontend/src/features/notifications/hooks/usePushNotifications.ts
@@ -11,8 +11,10 @@
  */
 
 import * as Notifications from 'expo-notifications';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter, type Href } from 'expo-router';
 import { useEffect, useRef } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
 
 import { getDevicePushToken, requestNotificationPermission } from '@/src/services/notification';
 import { registerDeviceToken } from '@/src/services/pushToken';
@@ -30,8 +32,10 @@ function navigateToNotice(router: ReturnType<typeof useRouter>, data: unknown) {
 
 export function usePushNotifications() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const accessToken = useAuthStore((state) => state.accessToken);
   const registeredRef = useRef(false); // 등록여부 확인 플래그
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
 
   // 1) 로그인 직후 디바이스 토큰 등록
   useEffect(() => {
@@ -58,24 +62,51 @@ export function usePushNotifications() {
     })();
   }, [accessToken]);
 
-  // 2) 알림 탭 → 공지 상세 이동 (포그라운드/백그라운드)
+  // 2) 포그라운드 푸시 수신 → 알림 목록/헤더 상태 갱신
+  useEffect(() => {
+    const sub = Notifications.addNotificationReceivedListener(() => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    });
+    return () => sub.remove();
+  }, [queryClient]);
+
+  // 3) 백그라운드에서 돌아오면 알림 목록/헤더 상태 갱신
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (nextAppState) => {
+      const previousAppState = appStateRef.current;
+      appStateRef.current = nextAppState;
+
+      if (
+        previousAppState.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        queryClient.invalidateQueries({ queryKey: ['notifications'] });
+      }
+    });
+
+    return () => sub.remove();
+  }, [queryClient]);
+
+  // 4) 알림 탭 → 공지 상세 이동 (포그라운드/백그라운드)
   useEffect(() => {
     const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
       navigateToNotice(router, response.notification.request.content.data);
     });
     return () => sub.remove();
-  }, [router]);
+  }, [queryClient, router]);
 
-  // 2-b) cold start: 종료 상태에서 알림 탭으로 진입한 경우
+  // 4-b) cold start: 종료 상태에서 알림 탭으로 진입한 경우
   useEffect(() => {
     let cancelled = false;
     Notifications.getLastNotificationResponseAsync().then((response) => {
       if (!cancelled && response) {
+        queryClient.invalidateQueries({ queryKey: ['notifications'] });
         navigateToNotice(router, response.notification.request.content.data);
       }
     });
     return () => {
       cancelled = true;
     };
-  }, [router]);
+  }, [queryClient, router]);
 }

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -4,6 +4,8 @@
  * 백엔드 API 명세(정본: personal_docs/api/API_알림이력조회.md):
  *  - GET /api/notifications?cursor={마지막 alert_history.id}&size={개수}
  *    → { alerts, nextCursor, hasNext } (커서 페이지네이션, 최신순)
+ *  - DELETE /api/notifications/{alertHistoryId}
+ *    → 204 No Content
  *
  * ⚠️ 백엔드 GET /api/notifications가 아직 미구현이라 현재는 mock으로 동작한다.
  *    실제 연동 시 아래 USE_MOCK 플래그만 false로 바꾸면 된다. (호출부 수정 불필요)
@@ -47,4 +49,12 @@ export async function fetchNotifications(
   params: FetchNotificationsParams = {},
 ): Promise<NotificationPage> {
   return USE_MOCK ? fetchNotificationsMock(params) : fetchNotificationsReal(params);
+}
+
+/**
+ * 인증 사용자의 특정 알림 삭제
+ * DELETE /api/notifications/{alertHistoryId}
+ */
+export async function deleteNotification(alertHistoryId: number): Promise<void> {
+  await apiClient.delete(`/api/notifications/${alertHistoryId}`);
 }

--- a/frontend/src/shared/components/MainHeader.tsx
+++ b/frontend/src/shared/components/MainHeader.tsx
@@ -21,6 +21,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/src/constants/colors';
+import { useHasNotifications } from '@/src/features/notifications';
 
 interface MainHeaderProps {
   /** 필요 시 특정 화면에서만 북마크 목록 진입 버튼을 숨긴다. */
@@ -30,6 +31,7 @@ interface MainHeaderProps {
 function MainHeaderComponent({ showBookmark = true }: MainHeaderProps) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const { data: hasNotifications = false } = useHasNotifications();
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
@@ -62,7 +64,7 @@ function MainHeaderComponent({ showBookmark = true }: MainHeaderProps) {
           >
             <Feather name="bell" size={20} color="#FFFFFF" />
             {/* 알림 dot — #FCC006, 10x10, border #00288C 2px */}
-            <View style={styles.notificationDot} />
+            {hasNotifications && <View style={styles.notificationDot} />}
           </TouchableOpacity>
         </View>
       </View>


### PR DESCRIPTION
## ❓ 작업을 하게 된 배경

알림 이력 조회 기능 이후, 사용자가 더 이상 필요하지 않은 알림을 직접 정리할 수 있는 삭제 기능이 필요.

기존에는 알림 목록 조회와 읽음 처리만 가능했고, 특정 알림을 사용자 단위로 제거하는 API와 UI가 없음.

또한 알림 존재 여부에 따라 헤더 아이콘 상태를 다르게 보여줘야 했지만, 백그라운드 수신 후 앱 복귀 시 캐시가 갱신되지 않는 문제가 있었음
-> 백그라운드에서 포그라운드로 넘어갈 시 usePushNotifications.ts에 AppState 리스너 추가로 해결 완료.

이 범위를 처리하지 않으면 알림 삭제 UX와 헤더 알림 상태 표시가 완성되지 않는 상태.

---

## 🔍 변경 범위

- [x] `api` (컨트롤러/엔드포인트)
- [x] `application` (서비스/유스케이스)
- [ ] `model` (도메인 엔티티/VO)
- [x] `infra` (외부 연동/포트 구현체)
- [x] `etc/config` (기타/설정 파일)

### 처리 흐름

```text
DELETE /api/notifications/{alertHistoryId}
→ 로그인 사용자 소유 알림 조회
→ 해당 alert_history 삭제
→ 프론트 알림 목록 캐시 갱신
```

---

## 🎯 결정 사항

### 결정 1. 알림 삭제 방식

- **옵션**
  - `alert_history` 직접 삭제
  - Soft Delete 필드 추가

- **근거**
  - 현재 알림 이력에는 삭제 상태 필드가 없음
  - 사용자별 알림 이력 Row가 독립적으로 관리됨

- **선택**
  - 로그인 사용자 소유의 `alert_history` Row를 직접 삭제

### 결정 2. 알림 삭제 UI

- **옵션**
  - 삭제 버튼을 별도로 항상 노출
  - 스와이프 액션으로 삭제 버튼 제공

- **근거**
  - 알림 목록의 주요 액션은 상세 진입
  - 삭제는 보조 액션이므로 항상 노출하면 목록 밀도가 높아짐

- **선택**
  - `ReanimatedSwipeable` 기반으로 왼쪽 스와이프 시 삭제 버튼 노출

### 결정 3. 알림 존재 여부 확인 방식

- **옵션**
  - 전체 알림 목록을 조회하여 존재 여부 판단
  - `size=1` 조회를 통해 존재 여부 판단

- **근거**
  - 헤더 아이콘은 알림의 상세 데이터가 아닌 존재 여부만 필요함
  - 전체 알림 목록을 조회하는 것은 불필요함

- **선택**
  - `GET /api/notifications?size=1` 기반 `useHasNotifications` 훅 추가

---

## ⏳ 미정 사항

없음

---

## ✅ 체크리스트

- [x] 로컬에서 정상 동작하는가
- [x] 관련 테스트가 모두 통과하는가
- [x] 이번 PR에서 발생한 결정 사항이 위 `결정 사항` / 의사결정 문서에 반영됐는가
- [x] 배포 후 문제 발생 시 이 변경을 되돌릴 수 있는가

**되돌릴 수 없는 경우 사유:** 없음

---

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
| --- | --- | --- |
| 알림 이력 API | 로그인 사용자의 특정 알림 삭제 엔드포인트 추가 | 프론트 삭제 호출 경로와 `204 No Content` 응답 처리 확인 |
| 푸시 알림 / 헤더 상태 | 푸시 수신 및 앱 복귀 시 알림 캐시 갱신 | 백그라운드 복귀 시 헤더 점 표시 확인 |

---

## 🧪 테스트

### Backend

```bash
./gradlew test \
  --tests org.cathori.backend.notification.application.NotificationServiceTest \
  --tests org.cathori.backend.notification.api.NotificationIntegrationTest
```

### Frontend Type Check

```bash
npx tsc --noEmit
```

### Frontend Lint

```bash
npm run lint
```
---

## 🔗 연관 이슈

closes #167 