### PR TITLE
fix(notification): 푸시 알림 백그라운드/종료 상태 소리 미재생 문제 해결

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notification/infra/FcmAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/FcmAdapter.java
@@ -8,6 +8,10 @@ import org.cathori.backend.notification.application.push.UserPushResult;
 import org.cathori.backend.notification.application.push.UserToken;
 import org.springframework.stereotype.Component;
 
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -30,6 +34,17 @@ public class FcmAdapter implements PushNotificationPort {
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
+                        .build())
+                // Android/iOS 모두 sound를 명시하지 않으면 백그라운드·종료 상태에서 무음으로 표시된다.
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setNotification(AndroidNotification.builder()
+                                .setSound("default")
+                                .build())
+                        .build())
+                .setApnsConfig(ApnsConfig.builder()
+                        .setAps(Aps.builder()
+                                .setSound("default")
+                                .build())
                         .build())
                 .putData("noticeId", String.valueOf(noticeId))
                 .build();


### PR DESCRIPTION
## 🐛 버그 현상

1. 기대 동작: Android/iOS 클라이언트가 푸시 알림을 수신하면 소리가 재생되어야 한다.
2. 실제 동작: 앱이 백그라운드 또는 종료 상태일 때 알림은 정상 표시되지만 소리가 재생되지 않는다.
3. 재현 조건: 앱을 백그라운드로 전환하거나 완전히 종료한 상태에서 서버가 공지 알림을 발송했을 때 (포그라운드 상태에서는 정상적으로 소리가 재생됨)


## 🔍 원인

`FcmAdapter.send()`에서 `MulticastMessage`를 구성할 때 `Notification`(title/body)만 설정하고 `AndroidConfig`/`ApnsConfig`에 sound 관련 필드를 지정하지 않았다. FCM은 Android/iOS 모두 sound가 명시되지 않으면, 앱이 백그라운드·종료 상태라 OS가 직접 알림을 표시하는 경우 무음으로 처리한다. 반면 포그라운드 상태에서는 프론트엔드 `notification.ts`의 `Notifications.setNotificationHandler`에 설정된 `shouldPlaySound: true`가 별도로 소리를 재생하므로 그동안 문제가 드러나지 않았다.


## 🔧 해결 방법

`FcmAdapter`의 `MulticastMessage`에 `AndroidConfig.AndroidNotification.setSound("default")`와 `ApnsConfig.Aps.setSound("default")`를 추가했다. `"default"`는 커스텀 사운드 파일 없이 OS 기본 알림음을 재생하도록 지정하는 FCM 표준 값으로, 별도 사운드 리소스를 앱에 번들링할 필요가 없어 이 방법을 택했다.


## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| 커스텀 알림음(사운드 리소스) 적용 여부 | 현재는 OS 기본음으로 충분하다고 판단, 별도 요청 없음 | 디자인/기획 측에서 커스텀 사운드 요구 시 |


## ✅ 체크리스트
- [x] 로컬에서 재현 후 수정 확인했는가
- [ ] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가 (푸시 발송 지점이 `FcmAdapter` 한 곳뿐임을 확인)


## 🌐 연관 도메인 영향

해당 없으면: 없음


## 🔗 연관 이슈
closes #170
