### PR TITLE
fix(notification): Android 알림 채널 고착으로 인한 포그라운드 무음 문제 해결

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notification/infra/FcmAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/FcmAdapter.java
@@ -36,9 +36,12 @@ public class FcmAdapter implements PushNotificationPort {
                         .setBody(body)
                         .build())
                 // Android/iOS 모두 sound를 명시하지 않으면 백그라운드·종료 상태에서 무음으로 표시된다.
+                // channelId는 프론트(notification.ts)가 생성하는 "notice" 채널과 반드시 일치해야 한다.
+                // 채널 미지정 시 OS/라이브러리가 쓰는 fallback 채널은 기기별로 과거 상태(무음)에 고정돼 있을 수 있다.
                 .setAndroidConfig(AndroidConfig.builder()
                         .setNotification(AndroidNotification.builder()
                                 .setSound("default")
+                                .setChannelId("notice")
                                 .build())
                         .build())
                 .setApnsConfig(ApnsConfig.builder()

--- a/frontend/src/services/notification.ts
+++ b/frontend/src/services/notification.ts
@@ -26,6 +26,22 @@ Notifications.setNotificationHandler({
   }),
 });
 
+/**
+ * Android 8+(API 26+)는 알림 채널이 최초 생성 시점 설정(사운드 포함)으로 고정되며 코드로 재변경할 수 없다.
+ * expo-notifications가 채널 ID 없이 쓰는 fallback 채널에 기대면 과거에 사운드 없이 생성된 채널이
+ * 남아있는 기기에서 계속 무음이 되므로, 우리가 소유하는 채널을 명시적으로 만들어 사운드를 보장한다.
+ * (백엔드 FcmAdapter도 이 채널 ID를 지정해야 실제로 이 채널이 쓰인다.)
+ */
+export const ANDROID_NOTIFICATION_CHANNEL_ID = 'notice';
+
+if (Platform.OS === 'android') {
+  Notifications.setNotificationChannelAsync(ANDROID_NOTIFICATION_CHANNEL_ID, {
+    name: '공지 알림',
+    importance: Notifications.AndroidImportance.HIGH,
+    sound: 'default',
+  });
+}
+
 /** OS 알림 권한을 확인하고, 미허용 시 요청한다. 최종 허용 여부를 반환. */
 export async function requestNotificationPermission(): Promise<boolean> {
   const { status: existing } = await Notifications.getPermissionsAsync();


### PR DESCRIPTION
## 🐛 버그 현상

1. 기대 동작: Android 클라이언트가 포그라운드 상태에서 푸시 알림을 수신하면 소리가 재생되어야 한다.
2. 실제 동작: #171 배포 후 실기기로 확인한 결과, 포그라운드에서 알림은 정상 표시되고 진동은 오지만 소리는 재생되지 않는다. (기기 벨소리 모드는 정상 상태였음을 확인.)
3. 재현 조건: `expo-notifications`를 오래전부터 계속 업데이트해가며 써온 개발 빌드(재설치한 적 없는 기기)에서, 포그라운드로 알림을 수신했을 때


## 🔍 원인

Android 8+(API 26+)는 알림 채널의 사운드 설정이 **채널 최초 생성 시점에 고정**되며, 이후 앱 코드로 재변경할 수 없다(사용자가 시스템 설정에서 직접 바꾸는 것만 가능).

`expo-notifications`는 FCM 메시지에 채널 ID가 지정되어 있지 않으면 자체 fallback 채널(`expo_notifications_fallback_notification_channel`)을 사용하는데(`BaseNotificationBuilder.kt`), 이 채널은 앱을 처음 설치했을 때(사운드 필드를 다루지 않던 과거 코드 시점) 이미 생성되어 있었다. 이후 #171에서 FCM payload에 `AndroidNotification.setSound("default")`를 추가했지만, `ExpoNotificationBuilder.kt`의 주석대로 API 26+에서는 알림별 사운드 설정 호출 자체가 무시되고 오직 채널의 사운드 설정만 적용되므로, 이미 무음으로 고정된 채널에는 영향을 주지 못했다.

(참고로 iOS는 채널 개념이 없고 `Aps.sound` payload가 그대로 적용되므로 #171 수정으로 충분하다. Android도 신규 설치 기기라면 fallback 채널이 사운드 있는 상태로 새로 생성되어 문제가 없었을 것으로 보이나, 검증되지 않은 추정이다.)


## 🔧 해결 방법

fallback 채널에 기대는 대신, 우리가 직접 소유하고 제어하는 새 채널을 만든다.

- `frontend/src/services/notification.ts`: 앱 시작 시 `Notifications.setNotificationChannelAsync('notice', { sound: 'default', importance: HIGH, ... })`로 전용 채널을 명시적으로 생성
- `backend/.../FcmAdapter.java`: `AndroidNotification.setChannelId("notice")`로 FCM 메시지가 이 채널을 타도록 지정

새 채널 ID를 쓰기 때문에 기존에 설치된 앱에서도 재설치 없이(그 채널 ID를 기기가 처음 보는 것이므로) 사운드가 켜진 상태로 채널이 새로 생성된다.


## ⏳ 미정 사항

해당 없으면: 없음


## ✅ 체크리스트
- [ ] 로컬에서 재현 후 수정 확인했는가
- [ ] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가 (푸시 발송 지점은 `FcmAdapter` 한 곳, 채널 생성 지점은 `notification.ts` 한 곳뿐임을 확인)


## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| Android 알림 표시 | 알림이 이제 `notice`라는 이름의 채널로 표시됨(시스템 설정 > 앱 알림에 채널명 "공지 알림" 노출) | 없음 |


## 🔗 연관 이슈
closes #172
