### PR TITLE
fix(notice): 공지 크롤링 데이터 누락/중복 저장 문제 해결 및 페이지 범위 확장

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -47,6 +49,7 @@ public class CatholicNoticeCrawler implements CrawlerPort {
         }
 
         Elements rows = targetPageDoc.select("table tbody tr");
+        Set<String> seenArticleNo = new HashSet<>();
 
         for (Element row : rows) {
             try {
@@ -54,7 +57,8 @@ public class CatholicNoticeCrawler implements CrawlerPort {
                 if (parsed == null) continue;
 
                 int articleNo = Integer.parseInt(parsed.articleNo());
-                if (lastArticleNo > 0 && articleNo <= lastArticleNo) break;
+                if (lastArticleNo > 0 && articleNo <= lastArticleNo) continue;
+                if (!seenArticleNo.add(parsed.articleNo())) continue;
 
                 NoticeDetails detail = crawlNoticeDetail(parsed.noticeDetailsUrl());
                 result.add(CrawledNotice.builder()

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
@@ -25,9 +25,13 @@ import java.util.stream.Collectors;
 @Component
 public class CatholicNoticeCrawler implements CrawlerPort {
 
+    private static final int MAX_LIST_PAGES = 3;
+    private static final int ARTICLES_PER_PAGE = 10;
 
     /**
      * 가톨릭대 공지사항 목록 페이지를 크롤링해 새 공지를 수집한다.
+     * 최신 공지가 1페이지에만 몰려있지 않을 수 있어 최대 {@value #MAX_LIST_PAGES}페이지까지 확인하되,
+     * 한 페이지에 새 공지가 하나도 없으면 이후 페이지는 더 오래된 공지뿐이라고 보고 조회를 중단한다.
      *
      * @param sourceType    공지 출처 유형 (예: "MAIN")
      * @param sourceId      학과 공지의 경우 학과 코드, 메인 공지는 null
@@ -38,18 +42,68 @@ public class CatholicNoticeCrawler implements CrawlerPort {
     public List<CrawledNotice> crawl(String sourceType, String sourceId, int lastArticleNo) {
         String targetUrl = getCrawlTargetUrl(sourceType, sourceId);
         List<CrawledNotice> result = new ArrayList<>();
+        Set<String> seenArticleNo = new HashSet<>();
 
-        Document targetPageDoc;
-        try {
-            targetPageDoc = Jsoup.connect(targetUrl).get();
-            log.info("HTML 수신 성공 - sourceType: {}, sourceId: {}, 길이: {}", sourceType, sourceId, targetPageDoc.html().length());
-        } catch (IOException e) {
-            log.warn("크롤링 연결 실패: {}", e.getMessage());
-            return result;
+        for (int page = 1; page <= MAX_LIST_PAGES; page++) {
+            Elements rows = fetchListRows(targetUrl, sourceType, sourceId, page);
+            if (rows == null) break;
+
+            boolean foundNewArticle = collectNoticesFromRows(
+                    rows, targetUrl, sourceType, sourceId, lastArticleNo, seenArticleNo, result);
+
+            if (lastArticleNo > 0 && !foundNewArticle) break;
         }
 
-        Elements rows = targetPageDoc.select("table tbody tr");
-        Set<String> seenArticleNo = new HashSet<>();
+        return result;
+    }
+
+    /**
+     * 공지 목록 페이지 하나를 요청해 행(tr) 목록을 반환한다.
+     * page가 1이면 기존과 동일하게 targetUrl 그대로 요청하고,
+     * 그 이상이면 article.offset 파라미터를 붙여 다음 페이지를 요청한다.
+     * 요청 실패 시 null 반환.
+     *
+     * @param targetUrl  공지 목록 페이지 기본 URL
+     * @param sourceType 공지 출처 유형
+     * @param sourceId   학과 코드 또는 null
+     * @param page       조회할 페이지 번호 (1부터 시작)
+     * @return tr 요소 목록. 요청 실패 시 null
+     */
+    private Elements fetchListRows(String targetUrl, String sourceType, String sourceId, int page) {
+        String pageUrl = page == 1 ? targetUrl : buildPageUrl(targetUrl, page);
+
+        try {
+            Document targetPageDoc = Jsoup.connect(pageUrl).get();
+            log.info("HTML 수신 성공 - sourceType: {}, sourceId: {}, page: {}, 길이: {}",
+                    sourceType, sourceId, page, targetPageDoc.html().length());
+            return targetPageDoc.select("table tbody tr");
+        } catch (IOException e) {
+            log.warn("크롤링 연결 실패 (page={}): {}", page, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 목록 페이지의 offset 기반 페이지네이션 URL을 만든다.
+     * 예: page=2 -> "...notice.do?mode=list&articleLimit=10&article.offset=10"
+     *
+     * @param targetUrl 공지 목록 페이지 기본 URL
+     * @param page      조회할 페이지 번호 (1부터 시작)
+     * @return 페이지네이션 쿼리가 포함된 URL
+     */
+    private String buildPageUrl(String targetUrl, int page) {
+        int offset = (page - 1) * ARTICLES_PER_PAGE;
+        return targetUrl + "?mode=list&articleLimit=" + ARTICLES_PER_PAGE + "&article.offset=" + offset;
+    }
+
+    /**
+     * 목록 페이지의 tr 행들을 파싱해 새 공지를 result에 추가한다.
+     *
+     * @return 이 페이지에서 lastArticleNo보다 큰(=새로운) 공지를 하나라도 찾았으면 true
+     */
+    private boolean collectNoticesFromRows(Elements rows, String targetUrl, String sourceType, String sourceId,
+                                            int lastArticleNo, Set<String> seenArticleNo, List<CrawledNotice> result) {
+        boolean foundNewArticle = false;
 
         for (Element row : rows) {
             try {
@@ -58,6 +112,7 @@ public class CatholicNoticeCrawler implements CrawlerPort {
 
                 int articleNo = Integer.parseInt(parsed.articleNo());
                 if (lastArticleNo > 0 && articleNo <= lastArticleNo) continue;
+                foundNewArticle = true;
                 if (!seenArticleNo.add(parsed.articleNo())) continue;
 
                 NoticeDetails detail = crawlNoticeDetail(parsed.noticeDetailsUrl());
@@ -81,7 +136,7 @@ public class CatholicNoticeCrawler implements CrawlerPort {
             }
         }
 
-        return result;
+        return foundNewArticle;
     }
     /**
      * tr 한 행을 파싱해 NoticeRow로 변환한다.


### PR DESCRIPTION
## 🐛 버그 현상

>운영 과정에서 일부 공지사항들이 수집되지 않으며 데이터베이스에 저장되는 않는 문제가 발생했음

## 🔍 원인

1. `article_no`가 페이지 내에서 항상 내림차순일 것이라는 잘못된 전제로 구현되어 있었음. 고정 공지가 낮은 `article_no`를 가진 채 목록 앞쪽에 노출되면, `lastArticleNo` 이하를 만나는 즉시 `break`로 순회를 중단해 그 뒤에 있던 신규 공지가 전부 유실됨.

2. 같은 고정 공지가 목록 상단과 원래 순번 위치 두 곳에 중복 노출되는데, 중복 제거 로직이 없어 동일 `article_no`가 두 번 수집·저장됨.

3. 크롤링이 목록 1페이지만 조회하도록 되어 있어, 스케줄 주기 사이에 신규 공지가 10건을 넘게 올라오면 1페이지 밖으로 밀려난 공지는 다음 스케줄 때까지(또는 그 이후로도 계속) 수집 대상에서 벗어나 누락됨.

## 🔧 해결 방법

1. `lastArticleNo` 이하인 행을 만나도 `break` 대신 `continue`로 변경해, 순서를 신뢰하지 않고 페이지의 모든 행을 끝까지 검사하도록 수정.

2. 페이지 내에서 처리한 `article_no`를 `Set`으로 추적해, 동일 공지가 두 번 노출되어도 한 번만 수집되도록 중복 스킵 로직 추가.

3. 목록 조회 범위를 1페이지에서 최대 3페이지로 확장. `article.offset` 쿼리 파라미터로 다음 페이지를 요청하되, 한 페이지에서 신규 공지를 하나도 찾지 못하면 그 이후 페이지는 더 오래된 공지뿐이라고 보고 요청을 조기 종료해 불필요한 호출 증가를 최소화함.

## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| 스케줄 주기 사이 신규 공지가 30건(3페이지)을 초과하는 극단적 상황 | 발생 빈도가 매우 낮고, 발생 시에도 다음 스케줄 때 lastArticleNo 이하로 처리되어 자연 복구됨 | 실제 학과/메인 공지 발행량이 유의미하게 늘어날 경우 |

## ✅ 체크리스트
- [x] 로컬에서 재현 후 수정 확인했는가 (실제 사이트 대상으로 크롤러 직접 실행해 페이지네이션·조기종료·중복스킵 동작 확인)
- [x] 회귀 테스트(재발 방지 테스트)를 추가했는가 (별도 크롤러 유닛 테스트는 없어, 실사이트 대상 수동 검증으로 대체)
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가 (MAIN/DEPARTMENT 소스 모두 동일 크롤러 로직을 공유하므로 별도 추가 확인 불필요)

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| 크롤링 스케줄러 (`CrawlingScheduler`) | 회당 목록 요청 수가 소스당 최대 1건 → 3건으로 증가 (전체 46개 소스 기준 최대 46 → 138건) | 신규 공지가 없으면 조기 종료되어 실질 증가량은 적음. 배포 후 크롤링 소요 시간 모니터링 |
| 공지 저장/요약 파이프라인 (`NoticeService`) | 입력 건수 변화 없음 (중복 제거 후 신규 공지만 저장) | 해당 없음 |

## 🔗 연관 이슈
closes #175
