### PR TITLE
refactor: backend 컨테이너 재시작 시 스케줄링 1회 실행

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.cathori.backend.notice.application.CrawledNotice;
 import org.cathori.backend.notice.application.NoticeService;
 import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +19,12 @@ import lombok.extern.slf4j.Slf4j;
 public class CrawlingScheduler {
 
     private final NoticeService noticeService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onStartup() {
+        log.info("컨테이너 기동 감지, 크롤링 1회 실행");
+        scheduleCrawling();
+    }
 
     @Scheduled(cron = "${crawler.dispatch.cron}")
     public void scheduleCrawling() {


### PR DESCRIPTION
## 🔧 리팩터링 대상

1. `backend/src/main/java/org/cathori/backend/notice/infra/crawler/CrawlingScheduler.java`
2. 기존에는 `@Scheduled(cron = "${crawler.dispatch.cron}")`로만 크롤링이 트리거되어(prod 기준 하루 2회, 0시/12시), 컨테이너가 재시작되면 다음 스케줄 시각까지 크롤링 공백이 발생함. 재시작 직후 즉시 최신화할 트리거가 없었음.

## 📐 As-Is → To-Be

**As-Is**
```java
@Scheduled(cron = "${crawler.dispatch.cron}")
public void scheduleCrawling() { ... }
```
- cron 트리거만 존재 → 컨테이너 재시작 후 최대 12시간 크롤링 공백 발생 가능

**To-Be**
```java
@EventListener(ApplicationReadyEvent.class)
public void onStartup() {
    log.info("컨테이너 기동 감지, 크롤링 1회 실행");
    scheduleCrawling();
}

@Scheduled(cron = "${crawler.dispatch.cron}")
public void scheduleCrawling() { ... }
```
- 애플리케이션 기동 완료(`ApplicationReadyEvent`) 시 `scheduleCrawling()`을 1회 호출하는 리스너 추가
- 기존 cron 스케줄은 그대로 유지 (구조 변경 없음)

## 🎯 결정 사항

### 결정 1
- 옵션: (a) `@PostConstruct`로 기동 시 실행, (b) `ApplicationReadyEvent` 리스너로 실행
- 근거: `@PostConstruct`는 빈 초기화 시점(다른 인프라 준비 이전)에 실행되어 외부 크롤링 요청 시 애플리케이션 컨텍스트가 완전히 준비되지 않았을 위험이 있음. `ApplicationReadyEvent`는 컨텍스트 초기화가 모두 끝난 뒤 발행되어 더 안전함.
- 선택: `ApplicationReadyEvent` 리스너 방식

## ⚠️ 동작 불변 검증

- [x] 기존 테스트가 모두 그대로 통과하는가 (수정 없이)
- [x] 테스트 자체를 수정했다면, 그 이유가 "동작 변경"이 아니라 "구조 변경으로 인한 테스트 코드 갱신"임을 확인했는가 (테스트 코드 수정 없음)

## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| 테스트 환경(`crawler.dispatch.cron=-`)에서 `ApplicationReadyEvent`로 인해 컨텍스트 로딩 시마다 크롤링이 실행될 수 있음 | 현재 크롤링 대상 소스가 실제 네트워크 호출을 포함하는지 등 영향 범위 추가 확인 필요 | 테스트 실행 시 외부 호출/부작용 확인 후 필요 시 `@Profile("prod")` 등으로 제한 |

## 🌐 연관 도메인 영향

해당 없음

## 🔗 연관 이슈
closes #179