### PR TITLE
fix(notice): article_no 순서 가정으로 인한 공지 크롤링 누락 문제 해결

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/application/CrawlerPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/CrawlerPort.java
@@ -6,16 +6,35 @@ import java.util.List;
 /**
  * 가톨릭대 공지사항 크롤러 인터페이스
  *
- * 크롤러 구현체(JsoupCrawler)와 서비스(NoticeService) 사이의 계약을 정의한다.
+ * 크롤러 구현체(CatholicNoticeCrawler)와 서비스(NoticeService) 사이의 계약을 정의한다.
  * NoticeService는 이 인터페이스만 바라보기 때문에,
  * 나중에 크롤러 구현체를 교체하거나 추가해도 NoticeService 코드는 건드리지 않아도 된다.
  *
- * @param sourceType 출처 유형 (예: "MAIN")
- * @param sourceId   학과 공지의 경우 학과 코드, 메인 공지는 null
- * @param lastArticleNo DB에 저장된 가장 최신 articleNo. 이 값 이하의 공지는 수집하지 않는다.
- *                      0이면 중단 조건 없이 전체 수집 (최초 실행 시)
- * @return 새로 수집된 공지 목록 (이미 저장된 공지 제외)
+ * 목록 조회(listCandidates)와 상세 조회(crawlDetail)를 분리한 이유:
+ * articleNo는 게시 순서/최신성과 무관한 값이라 크기 비교로 "신규 여부"나
+ * "더 볼 필요가 있는지"를 판단할 수 없다. 그래서 크롤러는 목록 페이지에서
+ * 후보만 모두 모아 반환하고, 신규 여부 판별(DB 존재 여부 대조)은
+ * NoticeService가 담당한 뒤 신규 후보에 한해서만 상세 페이지를 크롤링한다.
  */
 public interface CrawlerPort {
-    List<CrawledNotice> crawl(String sourceType, String sourceId, int lastArticleNo);
+
+    /**
+     * 공지 목록 페이지(최대 N페이지)를 순회해 후보를 모두 수집한다.
+     * DB와의 대조는 하지 않으며, 상세 본문도 크롤링하지 않는다.
+     *
+     * @param sourceType 출처 유형 (예: "MAIN", "DEPARTMENT")
+     * @param sourceId   학과 공지의 경우 학과 코드, 메인 공지는 null
+     * @return 목록 페이지에서 수집한 공지 후보 목록
+     */
+    List<NoticeCandidate> listCandidates(String sourceType, String sourceId);
+
+    /**
+     * 신규로 판별된 후보 하나의 상세 페이지를 크롤링해 본문/이미지를 채운다.
+     *
+     * @param sourceType 출처 유형
+     * @param sourceId   학과 코드 또는 null
+     * @param candidate  상세 크롤링 대상 후보
+     * @return 상세 정보가 채워진 공지
+     */
+    CrawledNotice crawlDetail(String sourceType, String sourceId, NoticeCandidate candidate);
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeCandidate.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeCandidate.java
@@ -1,0 +1,22 @@
+package org.cathori.backend.notice.application;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 목록 페이지 크롤링만으로 얻어지는, 상세 크롤링 이전 단계의 공지 후보.
+ *
+ * NoticeService가 이 후보의 articleNo를 DB와 대조해 신규 여부를 판별한 뒤,
+ * 신규인 것만 CrawlerPort.crawlDetail()로 넘겨 상세 페이지를 크롤링한다.
+ */
+@Getter
+@Builder
+public class NoticeCandidate {
+
+    private String articleNo;
+    private String category;
+    private String title;
+    private String department;
+    private String postedAt;
+    private String detailUrl;
+}

--- a/backend/src/main/java/org/cathori/backend/notice/application/NoticeService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/NoticeService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -23,10 +24,18 @@ public class NoticeService {
     private final NoticeSummaryUpdater noticeSummaryUpdater;
 
     public List<CrawledNotice> crawl(String sourceType, String sourceId) {
-        int lastArticleNo = noticeRepository.findMaxArticleNo(sourceType, sourceId)
-                .orElse(0);
+        List<NoticeCandidate> candidates = crawlerPort.listCandidates(sourceType, sourceId);
+        if (candidates.isEmpty()) return List.of();
 
-        return crawlerPort.crawl(sourceType, sourceId, lastArticleNo);
+        List<String> articleNos = candidates.stream()
+                .map(NoticeCandidate::getArticleNo)
+                .toList();
+        Set<String> existingArticleNos = noticeRepository.findExistingArticleNos(sourceType, sourceId, articleNos);
+
+        return candidates.stream()
+                .filter(candidate -> !existingArticleNos.contains(candidate.getArticleNo()))
+                .map(candidate -> crawlerPort.crawlDetail(sourceType, sourceId, candidate))
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawler/CatholicNoticeCrawler.java
@@ -3,6 +3,7 @@ package org.cathori.backend.notice.infra.crawler;
 import lombok.extern.slf4j.Slf4j;
 import org.cathori.backend.notice.application.CrawledNotice;
 import org.cathori.backend.notice.application.CrawlerPort;
+import org.cathori.backend.notice.application.NoticeCandidate;
 import org.cathori.backend.notice.infra.crawler.format.NoticeDetails;
 import org.cathori.backend.notice.infra.crawler.format.NoticeRow;
 import org.cathori.backend.notice.infra.crawler.source.DepartmentSource;
@@ -29,32 +30,58 @@ public class CatholicNoticeCrawler implements CrawlerPort {
     private static final int ARTICLES_PER_PAGE = 10;
 
     /**
-     * 가톨릭대 공지사항 목록 페이지를 크롤링해 새 공지를 수집한다.
-     * 최신 공지가 1페이지에만 몰려있지 않을 수 있어 최대 {@value #MAX_LIST_PAGES}페이지까지 확인하되,
-     * 한 페이지에 새 공지가 하나도 없으면 이후 페이지는 더 오래된 공지뿐이라고 보고 조회를 중단한다.
+     * 가톨릭대 공지사항 목록 페이지를 크롤링해 공지 후보를 모두 수집한다.
+     * articleNo는 게시 순서/최신성과 무관한 값이라 크기 비교로 신규 여부나
+     * 조기 종료 여부를 판단할 수 없으므로, 매번 최대 {@value #MAX_LIST_PAGES}페이지를
+     * 전부 순회해 후보를 모은다. 신규 여부 판별은 NoticeService가 DB와 대조해 담당한다.
      *
-     * @param sourceType    공지 출처 유형 (예: "MAIN")
-     * @param sourceId      학과 공지의 경우 학과 코드, 메인 공지는 null
-     * @param lastArticleNo DB에 저장된 가장 최신 articleNo. 이 값 이하의 공지는 수집하지 않는다.
-     * @return 새로 수집된 공지 목록
+     * @param sourceType 공지 출처 유형 (예: "MAIN")
+     * @param sourceId   학과 공지의 경우 학과 코드, 메인 공지는 null
+     * @return 목록 페이지에서 수집한 공지 후보 목록 (중복 articleNo 제거됨)
      */
     @Override
-    public List<CrawledNotice> crawl(String sourceType, String sourceId, int lastArticleNo) {
+    public List<NoticeCandidate> listCandidates(String sourceType, String sourceId) {
         String targetUrl = getCrawlTargetUrl(sourceType, sourceId);
-        List<CrawledNotice> result = new ArrayList<>();
+        List<NoticeCandidate> result = new ArrayList<>();
         Set<String> seenArticleNo = new HashSet<>();
 
         for (int page = 1; page <= MAX_LIST_PAGES; page++) {
             Elements rows = fetchListRows(targetUrl, sourceType, sourceId, page);
             if (rows == null) break;
 
-            boolean foundNewArticle = collectNoticesFromRows(
-                    rows, targetUrl, sourceType, sourceId, lastArticleNo, seenArticleNo, result);
-
-            if (lastArticleNo > 0 && !foundNewArticle) break;
+            collectCandidatesFromRows(rows, targetUrl, seenArticleNo, result);
         }
 
         return result;
+    }
+
+    /**
+     * 신규로 판별된 후보 하나의 상세 페이지를 크롤링해 본문/이미지를 채운다.
+     *
+     * @param sourceType 공지 출처 유형
+     * @param sourceId   학과 코드 또는 null
+     * @param candidate  상세 크롤링 대상 후보
+     * @return 상세 정보가 채워진 공지
+     */
+    @Override
+    public CrawledNotice crawlDetail(String sourceType, String sourceId, NoticeCandidate candidate) {
+        NoticeDetails detail = crawlNoticeDetail(candidate.getDetailUrl());
+
+        log.debug("본문 수집 - articleNo: {}, 본문길이: {}, 이미지수: {}",
+                candidate.getArticleNo(), detail.bodyText().length(), detail.imageUrls().size());
+
+        return CrawledNotice.builder()
+                .articleNo(candidate.getArticleNo())
+                .category(candidate.getCategory())
+                .title(candidate.getTitle())
+                .department(candidate.getDepartment())
+                .postedAt(candidate.getPostedAt())
+                .url(candidate.getDetailUrl())
+                .bodyText(detail.bodyText())
+                .imageUrls(detail.imageUrls())
+                .sourceType(sourceType)
+                .sourceId(sourceId)
+                .build();
     }
 
     /**
@@ -97,46 +124,29 @@ public class CatholicNoticeCrawler implements CrawlerPort {
     }
 
     /**
-     * 목록 페이지의 tr 행들을 파싱해 새 공지를 result에 추가한다.
-     *
-     * @return 이 페이지에서 lastArticleNo보다 큰(=새로운) 공지를 하나라도 찾았으면 true
+     * 목록 페이지의 tr 행들을 파싱해 공지 후보를 result에 추가한다.
+     * 이미 같은 크롤링 실행 안에서 본 articleNo(예: 상단 고정 공지 중복 노출)는 건너뛴다.
      */
-    private boolean collectNoticesFromRows(Elements rows, String targetUrl, String sourceType, String sourceId,
-                                            int lastArticleNo, Set<String> seenArticleNo, List<CrawledNotice> result) {
-        boolean foundNewArticle = false;
-
+    private void collectCandidatesFromRows(Elements rows, String targetUrl,
+                                            Set<String> seenArticleNo, List<NoticeCandidate> result) {
         for (Element row : rows) {
             try {
                 NoticeRow parsed = parseNoticeRow(row, targetUrl);
                 if (parsed == null) continue;
-
-                int articleNo = Integer.parseInt(parsed.articleNo());
-                if (lastArticleNo > 0 && articleNo <= lastArticleNo) continue;
-                foundNewArticle = true;
                 if (!seenArticleNo.add(parsed.articleNo())) continue;
 
-                NoticeDetails detail = crawlNoticeDetail(parsed.noticeDetailsUrl());
-                result.add(CrawledNotice.builder()
+                result.add(NoticeCandidate.builder()
                         .articleNo(parsed.articleNo())
                         .category(parsed.category())
                         .title(parsed.title())
                         .department(parsed.department())
                         .postedAt(parsed.postedAt())
-                        .url(parsed.noticeDetailsUrl())
-                        .bodyText(detail.bodyText())
-                        .imageUrls(detail.imageUrls())
-                        .sourceType(sourceType)
-                        .sourceId(sourceId)
+                        .detailUrl(parsed.noticeDetailsUrl())
                         .build());
-
-                log.debug("본문 수집 - articleNo: {}, 본문길이: {}, 이미지수: {}",
-                        parsed.articleNo(), detail.bodyText().length(), detail.imageUrls().size());
             } catch (Exception e) {
                 log.warn("공지 파싱 실패 (스킵): {}", e.getMessage());
             }
         }
-
-        return foundNewArticle;
     }
     /**
      * tr 한 행을 파싱해 NoticeRow로 변환한다.

--- a/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
@@ -6,21 +6,28 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-
-    boolean existsByArticleNo(String articleNo);
 
     @Modifying
     @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :id")
     void incrementViewCount(@Param("id") Long id);
 
-    @Query(value = "SELECT MAX(CAST(article_no AS INTEGER)) FROM notices" +
-            " WHERE source_type = :sourceType AND (source_id = :sourceId OR source_id IS NULL)",
-            nativeQuery = true)
-    Optional<Integer> findMaxArticleNo(@Param("sourceType") String sourceType, @Param("sourceId") String sourceId);
+    /**
+     * 주어진 articleNo 후보들 중 이미 DB에 저장된 것만 골라 반환한다.
+     * sourceType/sourceId까지 함께 대조해, 학과별로 별도인 articleNo 체계가
+     * 다른 학과 게시판과 우연히 같은 값을 가져도 오탐하지 않도록 한다.
+     * sourceId가 null인 소스(MAIN)도 정상 비교되도록 null-safe 조건을 사용한다.
+     */
+    @Query("SELECT n.articleNo FROM Notice n WHERE n.sourceType = :sourceType " +
+            "AND ((:sourceId IS NULL AND n.sourceId IS NULL) OR n.sourceId = :sourceId) " +
+            "AND n.articleNo IN :articleNos")
+    Set<String> findExistingArticleNos(@Param("sourceType") String sourceType,
+                                        @Param("sourceId") String sourceId,
+                                        @Param("articleNos") Collection<String> articleNos);
 
     @Query("SELECT n FROM Notice n WHERE n.aiSummaryStatus IN :statuses ORDER BY n.id ASC")
     List<Notice> findTop15ForSummary(@Param("statuses") List<String> statuses, Pageable pageable);


### PR DESCRIPTION
## 🐛 버그 현상

<!--
1. 어떤 동작을 기대했는지
2. 실제로 어떤 동작이 발생했는지
3. 재현 조건 (특정 상태값, 입력값, 순서 등)
-->

**기대: DB에 없는 신규 공지는 사이트 목록 1~3페이지 어디에 있든 다음 크롤링 사이클에서 수집되어야 함.**

**실제: 아래 두 경우 신규 공지가 수집되지 않을 수 있다는 점이 확인됐다.**
1. article_no가 DB에 저장된 해당 소스의 최대값(lastArticleNo)보다 작은 신규 공지는 "이미 수집됨"으로 오판되어 영구 스킵됨.

2. 1페이지에 lastArticleNo보다 큰 article_no가 하나도 없으면 2·3페이지는 요청조차 하지 않고 순회가 조기 종료되어, 실제로 뒤 페이지에 있는 신규 공지를 놓침.

재현 조건: article_no가 게시 순서/최신성과 무관하게 부여되는 경우(상단 고정 공지, 사이트 자체의 번호 체계 등) 언제든 발생 가능.

## 🔍 원인

`CatholicNoticeCrawler.crawl()`이 `articleNo <= lastArticleNo`면 스킵, 한 페이지에서 새 글을 하나도 못 찾으면(`!foundNewArticle`) 이후 페이지 요청을 생략하고 break하는 방식으로 구현되어 있었음(구 `CatholicNoticeCrawler.java:55`, `115`). 
이는 "article_no가 클수록 최신 글"이라는 전제가 있어야만 성립하는데, `NoticeService`가 넘기는 `lastArticleNo`는 DB에 저장된 해당 소스의 최대 article_no 값 하나뿐이라 개별 공지의 실제 DB 존재 여부와 무관하게 대소 비교만으로 신규/기존을 판단하고 있었음. article_no와 게시 순서 사이의 상관관계는 보장되지 않으므로 이 전제 자체가 틀림.

## 🔧 해결 방법

article_no 순서 가정을 제거하고 DB 존재 여부 기반으로 신규를 판별하도록 변경.

- `CrawlerPort.crawl(sourceType, sourceId, lastArticleNo)` → `listCandidates(sourceType, sourceId)` / `crawlDetail(sourceType, sourceId, candidate)`로 분리
- `CatholicNoticeCrawler`는 매 실행마다 1~3페이지를 조건 없이 전부 순회해 후보(article_no 등)만 수집
- `NoticeService.crawl()`이 후보 article_no 전체를 `NoticeRepository.findExistingArticleNos()`로 배치 조회해 DB에 없는 것만 상세 크롤링
- 부수적으로, 소스 구분 없이 전역으로 검사하던 `existsByArticleNo`(미사용 상태였음)를 제거하고, `sourceType`/`sourceId`까지 대조하도록 스코프를 좁혀 학과별로 별도인 article_no 체계가 다른 학과와 우연히 같은 값을 가질 때 오탐할 가능성도 함께 제거

대안으로 article_no 대신 게시일(`postedAt`)을 기준으로 순서를 판단하는 방법도 검토했으나, 날짜만 있고 시분초 정보가 없어 동일 날짜 내 순서를 구분할 수 없고, 상단 고정 공지가 오래된 날짜를 가진 채 최상단에 노출되면 동일한 종류의 조기 종료 오류가 재현되어 채택하지 않음.

## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| 스케줄 주기 사이 신규 공지가 3페이지(30건)를 초과해 올라오는 경우는 여전히 누락 가능 | 페이지 수/한도 확장은 이번 버그(순서 가정 오류)와 별개 사안 | 별도 이슈 등록 후 |

## ✅ 체크리스트
- [x] 로컬에서 재현 후 수정 확인했는가
- [ ] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가


## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| | | |

해당 없으면: 없음

`CrawlerPort`/`NoticeRepository` 시그니처가 바뀌었지만 호출부(`CrawlingScheduler.noticeService.crawl(sourceType, sourceId)`)는 그대로라 다른 도메인에 미치는 영향 없음.

## 🔗 연관 이슈
closes #182