### PR TITLE
refactor(Notice): notice 패키지 데이터 모델 네이밍/주석 정리

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/application/AiPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/AiPort.java
@@ -1,8 +1,6 @@
 package org.cathori.backend.notice.application;
 
 
-import org.cathori.backend.notice.infra.summarization.AiSummaryResult;
-
 import java.util.List;
 
 public interface AiPort {

--- a/backend/src/main/java/org/cathori/backend/notice/application/AiSummaryResult.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/AiSummaryResult.java
@@ -1,4 +1,4 @@
-package org.cathori.backend.notice.infra.summarization;
+package org.cathori.backend.notice.application;
 
 import java.util.List;
 

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/CrawledNotice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/CrawledNotice.java
@@ -1,29 +1,37 @@
 package org.cathori.backend.notice.application.crawling;
 
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.List;
 
-
 /**
- * 크롤러가 수집한 공지 데이터를 담는 DTO
+ * 크롤러가 수집한 공지 데이터를 담는 모델.
  *
- * JsoupCrawler 학교 사이트에서 파싱한 결과를 담아 반환한다.
- * NoticeService 에서 Notice 엔티티로 변환된다.
+ * <p>JsoupCrawler가 학교 사이트에서 파싱한 결과를 담아 반환하며,
+ * NoticeService에서 Notice 엔티티로 변환된다.
+ *
+ * @param articleNo  원본 게시판에서 공지를 식별하는 게시글 번호
+ * @param category   공지 분류(목록 표시용 카테고리)
+ * @param title      공지 제목
+ * @param department 작성 부서/학과명
+ * @param postedAt   원본 사이트에 표시된 게시일 문자열
+ * @param url        공지 상세 페이지의 원문 URL
+ * @param bodyText   본문 텍스트(HTML 태그 제거된 순수 텍스트)
+ * @param imageUrls  본문에 포함된 이미지의 절대 URL 목록
+ * @param sourceType 공지 출처 유형 (예: "MAIN", "DEPARTMENT")
+ * @param sourceId   학과 공지의 경우 학과 코드, 메인 공지는 null
  */
-@Getter
 @Builder
-public class CrawledNotice {
-
-    private String articleNo;
-    private String category;
-    private String title;
-    private String department;
-    private String postedAt;
-    private String url;
-    private String bodyText;
-    private List<String> imageUrls;
-    private String sourceType;
-    private String sourceId;
+public record CrawledNotice(
+        String articleNo,
+        String category,
+        String title,
+        String department,
+        String postedAt,
+        String url,
+        String bodyText,
+        List<String> imageUrls,
+        String sourceType,
+        String sourceId
+) {
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/CrawlerPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/CrawlerPort.java
@@ -4,17 +4,19 @@ import java.util.List;
 
 
 /**
- * 가톨릭대 공지사항 크롤러 인터페이스
- *
+ * 가톨릭대 공지사항 크롤러 인터페이스.
  * 크롤러 구현체(CatholicNoticeCrawler)와 서비스(NoticeService) 사이의 계약을 정의한다.
- * NoticeService는 이 인터페이스만 바라보기 때문에,
- * 나중에 크롤러 구현체를 교체하거나 추가해도 NoticeService 코드는 건드리지 않아도 된다.
  *
- * 목록 조회(listCandidates)와 상세 조회(crawlDetail)를 분리한 이유:
- * articleNo는 게시 순서/최신성과 무관한 값이라 크기 비교로 "신규 여부"나
- * "더 볼 필요가 있는지"를 판단할 수 없다. 그래서 크롤러는 목록 페이지에서
- * 후보만 모두 모아 반환하고, 신규 여부 판별(DB 존재 여부 대조)은
- * NoticeService가 담당한 뒤 신규 후보에 한해서만 상세 페이지를 크롤링한다.
+ * <p>NoticeService는 이 인터페이스에 의존하므로,
+ * 계약을 유지하는 범위에서 구현체를 교체해도 서비스 코드를 변경할 필요가 없다.
+ *
+ * <p>목록 조회(listCandidates)와 상세 조회(crawlDetail)를 분리한 이유:
+ * articleNo는 게시 순서나 최신성과 무관하므로,
+ * 크기 비교로 신규 여부나 탐색 종료 시점을 판단할 수 없다.
+ *
+ * <p>크롤러는 목록 페이지에서 후보를 모두 모아 반환한다.
+ * NoticeService가 DB 존재 여부를 대조해 신규 후보를 판별하고,
+ * 신규 후보에 한해서만 상세 페이지를 크롤링한다.
  */
 public interface CrawlerPort {
 

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/CrawlerPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/CrawlerPort.java
@@ -28,7 +28,7 @@ public interface CrawlerPort {
      * @param sourceId   학과 공지의 경우 학과 코드, 메인 공지는 null
      * @return 목록 페이지에서 수집한 공지 후보 목록
      */
-    List<NoticeCandidate> listCandidates(String sourceType, String sourceId);
+    List<NewNoticeCandidate> listCandidates(String sourceType, String sourceId);
 
     /**
      * 신규로 판별된 후보 하나의 상세 페이지를 크롤링해 본문/이미지를 채운다.
@@ -38,5 +38,5 @@ public interface CrawlerPort {
      * @param candidate  상세 크롤링 대상 후보
      * @return 상세 정보가 채워진 공지
      */
-    CrawledNotice crawlDetail(String sourceType, String sourceId, NoticeCandidate candidate);
+    CrawledNotice crawlDetail(String sourceType, String sourceId, NewNoticeCandidate candidate);
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NewNoticeCandidate.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NewNoticeCandidate.java
@@ -16,7 +16,7 @@ import lombok.Builder;
  * @param detailUrl  상세 크롤링(CrawlerPort.crawlDetail) 호출 시 사용할 상세 페이지 URL
  */
 @Builder
-public record NoticeCandidate(
+public record NewNoticeCandidate(
         String articleNo,
         String category,
         String title,

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeCandidate.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeCandidate.java
@@ -6,17 +6,23 @@ import lombok.Getter;
 /**
  * 목록 페이지 크롤링만으로 얻어지는, 상세 크롤링 이전 단계의 공지 후보.
  *
- * NoticeService가 이 후보의 articleNo를 DB와 대조해 신규 여부를 판별한 뒤,
+ * <p>NoticeService가 이 후보의 articleNo를 DB와 대조해 신규 여부를 판별한 뒤,
  * 신규인 것만 CrawlerPort.crawlDetail()로 넘겨 상세 페이지를 크롤링한다.
  */
 @Getter
 @Builder
 public class NoticeCandidate {
 
+    /** 원본 게시판에서 공지를 식별하는 게시글 번호 */
     private String articleNo;
+    /** 공지 분류(목록 표시용 카테고리) */
     private String category;
+    /** 공지 제목 */
     private String title;
+    /** 작성 부서/학과명 */
     private String department;
+    /** 원본 사이트에 표시된 게시일 문자열 */
     private String postedAt;
+    /** 상세 크롤링(CrawlerPort.crawlDetail) 호출 시 사용할 상세 페이지 URL */
     private String detailUrl;
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeCandidate.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeCandidate.java
@@ -1,28 +1,27 @@
 package org.cathori.backend.notice.application.crawling;
 
 import lombok.Builder;
-import lombok.Getter;
 
 /**
  * 목록 페이지 크롤링만으로 얻어지는, 상세 크롤링 이전 단계의 공지 후보.
  *
  * <p>NoticeService가 이 후보의 articleNo를 DB와 대조해 신규 여부를 판별한 뒤,
  * 신규인 것만 CrawlerPort.crawlDetail()로 넘겨 상세 페이지를 크롤링한다.
+ *
+ * @param articleNo  원본 게시판에서 공지를 식별하는 게시글 번호
+ * @param category   공지 분류(목록 표시용 카테고리)
+ * @param title      공지 제목
+ * @param department 작성 부서/학과명
+ * @param postedAt   원본 사이트에 표시된 게시일 문자열
+ * @param detailUrl  상세 크롤링(CrawlerPort.crawlDetail) 호출 시 사용할 상세 페이지 URL
  */
-@Getter
 @Builder
-public class NoticeCandidate {
-
-    /** 원본 게시판에서 공지를 식별하는 게시글 번호 */
-    private String articleNo;
-    /** 공지 분류(목록 표시용 카테고리) */
-    private String category;
-    /** 공지 제목 */
-    private String title;
-    /** 작성 부서/학과명 */
-    private String department;
-    /** 원본 사이트에 표시된 게시일 문자열 */
-    private String postedAt;
-    /** 상세 크롤링(CrawlerPort.crawlDetail) 호출 시 사용할 상세 페이지 URL */
-    private String detailUrl;
+public record NoticeCandidate(
+        String articleNo,
+        String category,
+        String title,
+        String department,
+        String postedAt,
+        String detailUrl
+) {
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cathori.backend.notice.application.AiPort;
 import org.cathori.backend.notice.infra.summarization.NoticeSummaryUpdater;
-import org.cathori.backend.notice.infra.summarization.AiSummaryResult;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.springframework.data.domain.PageRequest;

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
@@ -25,11 +25,11 @@ public class NoticeService {
     private final NoticeSummaryUpdater noticeSummaryUpdater;
 
     public List<CrawledNotice> crawl(String sourceType, String sourceId) {
-        List<NoticeCandidate> candidates = crawlerPort.listCandidates(sourceType, sourceId);
+        List<NewNoticeCandidate> candidates = crawlerPort.listCandidates(sourceType, sourceId);
         if (candidates.isEmpty()) return List.of();
 
         List<String> articleNos = candidates.stream()
-                .map(NoticeCandidate::articleNo)
+                .map(NewNoticeCandidate::articleNo)
                 .toList();
         Set<String> existingArticleNos = noticeRepository.findExistingArticleNos(sourceType, sourceId, articleNos);
 

--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
@@ -29,12 +29,12 @@ public class NoticeService {
         if (candidates.isEmpty()) return List.of();
 
         List<String> articleNos = candidates.stream()
-                .map(NoticeCandidate::getArticleNo)
+                .map(NoticeCandidate::articleNo)
                 .toList();
         Set<String> existingArticleNos = noticeRepository.findExistingArticleNos(sourceType, sourceId, articleNos);
 
         return candidates.stream()
-                .filter(candidate -> !existingArticleNos.contains(candidate.getArticleNo()))
+                .filter(candidate -> !existingArticleNos.contains(candidate.articleNo()))
                 .map(candidate -> crawlerPort.crawlDetail(sourceType, sourceId, candidate))
                 .toList();
     }

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/BookmarkedNoticeQuery.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/BookmarkedNoticeQuery.java
@@ -2,6 +2,10 @@ package org.cathori.backend.notice.application.query;
 
 /**
  * 로그인 사용자의 북마크 공지 목록 조회 조건.
+ *
+ * @param userId 조회 요청자(로그인 사용자) ID
+ * @param page   0부터 시작하는 페이지 번호
+ * @param size   페이지당 조회 건수
  */
 public record BookmarkedNoticeQuery(
         Long userId,

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedPort.java
@@ -7,7 +7,7 @@ import java.util.List;
  * 각 쿼리의 size보다 1건 더({@code size + 1}) 조회해서 반환해야 한다.
  */
 public interface NoticeFeedPort {
-    List<NoticeRow> findFeed(NoticeFeedQuery query);
-    List<NoticeRow> findBookmarked(BookmarkedNoticeQuery query);
-    List<NoticeSearchRow> findSearch(NoticeSearchQuery query);
+    List<NoticeQueryResult> findFeed(NoticeFeedQuery query);
+    List<NoticeQueryResult> findBookmarked(BookmarkedNoticeQuery query);
+    List<NoticeSearchQueryResult> findSearch(NoticeSearchQuery query);
 }

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedPort.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedPort.java
@@ -2,6 +2,10 @@ package org.cathori.backend.notice.application.query;
 
 import java.util.List;
 
+/**
+ * 공지 피드/북마크/검색 조회를 위한 포트. 구현체는 hasNext 판정을 호출부에서 할 수 있도록
+ * 각 쿼리의 size보다 1건 더({@code size + 1}) 조회해서 반환해야 한다.
+ */
 public interface NoticeFeedPort {
     List<NoticeRow> findFeed(NoticeFeedQuery query);
     List<NoticeRow> findBookmarked(BookmarkedNoticeQuery query);

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedQuery.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedQuery.java
@@ -6,6 +6,15 @@ import java.util.List;
 /**
  * 공지 피드 조회 조건을 담는 쿼리 객체. 사용자의 전공·복수전공·관심 태그를 기반으로
  * 개인화된 공지를 필터링하며, category가 null이면 전체 카테고리를 대상으로 조회한다.
+ *
+ * @param userId      조회 요청자(로그인 사용자) ID
+ * @param major       사용자의 제1전공 학과 코드
+ * @param secondMajor 사용자의 복수전공 학과 코드. "전공심화"이면 별도 학과 필터로 취급하지 않고
+ *                    제외되며(제1전공 범위만 적용), 복수전공이 없으면 null
+ * @param category    필터링할 공지 분류, null이면 전체 카테고리 대상
+ * @param tags        사용자 관심 태그 목록, 제목에 포함된 태그만 응답에 매칭시키는 용도로 쓰임
+ * @param page        0부터 시작하는 페이지 번호
+ * @param size        페이지당 조회 건수
  */
 public record NoticeFeedQuery(
         Long userId,

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeFeedService.java
@@ -62,11 +62,11 @@ public class NoticeFeedService {
                 category, tagList, page, size
         );
 
-        List<NoticeRow> rows = noticeFeedPort.findFeed(query);
+        List<NoticeQueryResult> rows = noticeFeedPort.findFeed(query);
 
         // 4. hasNext 판정
         boolean hasNext = rows.size() > size;
-        List<NoticeRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+        List<NoticeQueryResult> pageRows = hasNext ? rows.subList(0, size) : rows;
 
 
         // 5. DTO 매핑 + 반환
@@ -85,12 +85,12 @@ public class NoticeFeedService {
         List<String> userTags = tagRepository.findAllByUserId(user.getId()).stream()
                 .map(Tag::getName)
                 .toList();
-        List<NoticeRow> rows = noticeFeedPort.findBookmarked(
+        List<NoticeQueryResult> rows = noticeFeedPort.findBookmarked(
                 new BookmarkedNoticeQuery(user.getId(), page, size)
         );
 
         boolean hasNext = rows.size() > size;
-        List<NoticeRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+        List<NoticeQueryResult> pageRows = hasNext ? rows.subList(0, size) : rows;
 
         List<NoticeFeedItem> content = pageRows.stream()
                 .map(r -> toItem(r, userTags))
@@ -109,10 +109,10 @@ public class NoticeFeedService {
                 userId, keyword, majorCode, resolveSecondMajorCode(user.getSecondMajor()), page, size
         );
 
-        List<NoticeSearchRow> rows = noticeFeedPort.findSearch(query);
+        List<NoticeSearchQueryResult> rows = noticeFeedPort.findSearch(query);
 
         boolean hasNext = rows.size() > size;
-        List<NoticeSearchRow> pageRows = hasNext ? rows.subList(0, size) : rows;
+        List<NoticeSearchQueryResult> pageRows = hasNext ? rows.subList(0, size) : rows;
 
         List<NoticeSearchItem> content = pageRows.stream()
                 .map(this::toSearchItem)
@@ -121,7 +121,7 @@ public class NoticeFeedService {
         return new NoticeSearchResponse(content, page, size, hasNext);
     }
 
-    private NoticeSearchItem toSearchItem(NoticeSearchRow row) {
+    private NoticeSearchItem toSearchItem(NoticeSearchQueryResult row) {
         String deadlineAt = row.deadlineAt() != null ? row.deadlineAt().toString() : null;
         return new NoticeSearchItem(
                 String.valueOf(row.id()), row.category(), row.title(), row.department(), row.postedAt(), deadlineAt,
@@ -164,7 +164,7 @@ public class NoticeFeedService {
         return DepartmentSource.findEnumNameByDisplayName(secondMajor);
     }
 
-    private NoticeFeedItem toItem(NoticeRow row, List<String> queryTags) {
+    private NoticeFeedItem toItem(NoticeQueryResult row, List<String> queryTags) {
         String category = "DEPARTMENT".equals(row.sourceType()) ? null : row.category();
         String deadlineAt = row.deadlineAt() != null ? row.deadlineAt().toString() : null;
         List<String> tags = queryTags.stream()

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeQueryResult.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeQueryResult.java
@@ -18,7 +18,7 @@ import java.time.LocalDate;
  * @param viewCount       조회수
  * @param isBookmarked    조회 요청자가 이 공지를 북마크했는지 여부
  */
-public record NoticeRow(
+public record NoticeQueryResult(
         Long id,
         String sourceType,
         String category,

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeRow.java
@@ -3,7 +3,20 @@ package org.cathori.backend.notice.application.query;
 import java.time.LocalDate;
 
 /**
- * Raw notice feed row from the database.
+ * 공지 피드/북마크 조회 결과 한 건을 담는 DB 조회 row.
+ *
+ * @param id              공지 ID
+ * @param sourceType      공지 출처 유형 (예: "MAIN", "DEPARTMENT")
+ * @param category        공지 분류(목록 표시용 카테고리)
+ * @param title           공지 제목
+ * @param department      작성 부서/학과명
+ * @param postedAt        게시일
+ * @param deadlineAt      공지에서 추출된 마감일, 없으면 null
+ * @param aiSummary       AI 요약 본문, aiSummaryStatus가 SUCCESS일 때만 값이 채워짐(PENDING/FAILED면 null)
+ * @param aiSummaryStatus AI 요약 처리 상태 (PENDING / SUCCESS / FAILED)
+ * @param url             공지 상세 페이지의 원문 URL
+ * @param viewCount       조회수
+ * @param isBookmarked    조회 요청자가 이 공지를 북마크했는지 여부
  */
 public record NoticeRow(
         Long id,

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeSearchQuery.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeSearchQuery.java
@@ -3,9 +3,17 @@ package org.cathori.backend.notice.application.query;
 /**
  * 공지 키워드 검색 유스케이스의 입력 파라미터.
  *
- * 사용자가 입력한 keyword로 공지 제목을 검색하되,
+ * <p>사용자가 입력한 keyword로 공지 제목을 검색하되,
  * major·secondMajor를 기준으로 전체공지(MAIN)와 해당 학과 공지(DEPARTMENT)를 함께 탐색해
  * 본인과 관련 있는 공지만 결과에 포함시킨다.
+ *
+ * @param userId      조회 요청자(로그인 사용자) ID
+ * @param keyword     공지 제목 검색어
+ * @param major       사용자의 제1전공 학과 코드
+ * @param secondMajor 사용자의 복수전공 학과 코드. "전공심화"이면 별도 학과 필터로 취급하지 않고
+ *                    제외되며(제1전공 범위만 적용), 복수전공이 없으면 null
+ * @param page        0부터 시작하는 페이지 번호
+ * @param size        페이지당 조회 건수
  */
 public record NoticeSearchQuery(
         Long userId,

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeSearchQueryResult.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeSearchQueryResult.java
@@ -13,7 +13,7 @@ import java.time.LocalDate;
  * @param deadlineAt   공지에서 추출된 마감일, 없으면 null
  * @param isBookmarked 조회 요청자가 이 공지를 북마크했는지 여부
  */
-public record NoticeSearchRow(
+public record NoticeSearchQueryResult(
         Long id,
         String category,
         String title,

--- a/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeSearchRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/query/NoticeSearchRow.java
@@ -3,7 +3,15 @@ package org.cathori.backend.notice.application.query;
 import java.time.LocalDate;
 
 /**
- * Raw notice search row from the database.
+ * 공지 검색 결과 한 건을 담는 DB 조회 row.
+ *
+ * @param id           공지 ID
+ * @param category     공지 분류(목록 표시용 카테고리)
+ * @param title        공지 제목
+ * @param department   작성 부서/학과명
+ * @param postedAt     게시일
+ * @param deadlineAt   공지에서 추출된 마감일, 없으면 null
+ * @param isBookmarked 조회 요청자가 이 공지를 북마크했는지 여부
  */
 public record NoticeSearchRow(
         Long id,

--- a/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/NoticeFeedAdapter.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.cathori.backend.notice.application.query.BookmarkedNoticeQuery;
 import org.cathori.backend.notice.application.query.NoticeFeedPort;
 import org.cathori.backend.notice.application.query.NoticeFeedQuery;
-import org.cathori.backend.notice.application.query.NoticeRow;
+import org.cathori.backend.notice.application.query.NoticeQueryResult;
 import org.cathori.backend.notice.application.query.NoticeSearchQuery;
-import org.cathori.backend.notice.application.query.NoticeSearchRow;
+import org.cathori.backend.notice.application.query.NoticeSearchQueryResult;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -23,7 +23,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
     private final JdbcTemplate jdbcTemplate;
 
     // DB컬럼 -> 자바객체로 전환
-    private static final RowMapper<NoticeRow> ROW_MAPPER = (rs, rowNum) -> new NoticeRow(
+    private static final RowMapper<NoticeQueryResult> ROW_MAPPER = (rs, rowNum) -> new NoticeQueryResult(
             rs.getLong("id"),
             rs.getString("source_type"),
             rs.getString("category"),
@@ -39,7 +39,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
     );
 
     @Override
-    public List<NoticeRow> findFeed(NoticeFeedQuery q) {
+    public List<NoticeQueryResult> findFeed(NoticeFeedQuery q) {
         boolean hasCategory = q.category() != null && !q.category().isBlank();
         boolean hasTags = !q.tags().isEmpty();
 
@@ -59,7 +59,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
     }
 
     @Override
-    public List<NoticeRow> findBookmarked(BookmarkedNoticeQuery q) {
+    public List<NoticeQueryResult> findBookmarked(BookmarkedNoticeQuery q) {
         List<Object> params = new ArrayList<>();
         params.add(q.userId());
         params.add(q.size() + 1);
@@ -208,7 +208,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
     }
 
     @Override
-    public List<NoticeSearchRow> findSearch(NoticeSearchQuery q) {
+    public List<NoticeSearchQueryResult> findSearch(NoticeSearchQuery q) {
         List<Object> params = new ArrayList<>();
 
         StringBuilder sql = new StringBuilder(
@@ -234,7 +234,7 @@ public class NoticeFeedAdapter implements NoticeFeedPort {
         params.add(q.size() + 1);
         params.add((long) q.page() * q.size());
 
-        RowMapper<NoticeSearchRow> mapper = (rs, rowNum) -> new NoticeSearchRow(
+        RowMapper<NoticeSearchQueryResult> mapper = (rs, rowNum) -> new NoticeSearchQueryResult(
                 rs.getLong("id"),
                 rs.getString("category"),
                 rs.getString("title"),

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawling/CatholicNoticeCrawler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawling/CatholicNoticeCrawler.java
@@ -3,7 +3,7 @@ package org.cathori.backend.notice.infra.crawling;
 import lombok.extern.slf4j.Slf4j;
 import org.cathori.backend.notice.application.crawling.CrawledNotice;
 import org.cathori.backend.notice.application.crawling.CrawlerPort;
-import org.cathori.backend.notice.application.crawling.NoticeCandidate;
+import org.cathori.backend.notice.application.crawling.NewNoticeCandidate;
 import org.cathori.backend.notice.infra.crawling.model.NoticeDetails;
 import org.cathori.backend.notice.infra.crawling.model.NoticeRow;
 import org.cathori.backend.notice.infra.crawling.source.DepartmentSource;
@@ -40,9 +40,9 @@ public class CatholicNoticeCrawler implements CrawlerPort {
      * @return 목록 페이지에서 수집한 공지 후보 목록 (중복 articleNo 제거됨)
      */
     @Override
-    public List<NoticeCandidate> listCandidates(String sourceType, String sourceId) {
+    public List<NewNoticeCandidate> listCandidates(String sourceType, String sourceId) {
         String targetUrl = getCrawlTargetUrl(sourceType, sourceId);
-        List<NoticeCandidate> result = new ArrayList<>();
+        List<NewNoticeCandidate> result = new ArrayList<>();
         Set<String> seenArticleNo = new HashSet<>();
 
         for (int page = 1; page <= MAX_LIST_PAGES; page++) {
@@ -65,7 +65,7 @@ public class CatholicNoticeCrawler implements CrawlerPort {
      * @return 상세 정보가 채워진 공지
      */
     @Override
-    public CrawledNotice crawlDetail(String sourceType, String sourceId, NoticeCandidate candidate) {
+    public CrawledNotice crawlDetail(String sourceType, String sourceId, NewNoticeCandidate candidate) {
         NoticeDetails detail = crawlNoticeDetail(candidate.detailUrl());
 
         log.debug("본문 수집 - articleNo: {}, 본문길이: {}, 이미지수: {}",
@@ -126,14 +126,14 @@ public class CatholicNoticeCrawler implements CrawlerPort {
      * 이미 같은 크롤링 실행 안에서 본 articleNo(예: 상단 고정 공지 중복 노출)는 건너뛴다.
      */
     private void collectCandidatesFromRows(Elements rows, String targetUrl, String pageUrl,
-                                            Set<String> seenArticleNo, List<NoticeCandidate> result) {
+                                            Set<String> seenArticleNo, List<NewNoticeCandidate> result) {
         for (Element row : rows) {
             try {
                 NoticeRow parsed = parseNoticeRow(row, targetUrl);
                 if (parsed == null) continue;
                 if (!seenArticleNo.add(parsed.articleNo())) continue;
 
-                result.add(NoticeCandidate.builder()
+                result.add(NewNoticeCandidate.builder()
                         .articleNo(parsed.articleNo())
                         .category(parsed.category())
                         .title(parsed.title())

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawling/CatholicNoticeCrawler.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawling/CatholicNoticeCrawler.java
@@ -66,18 +66,18 @@ public class CatholicNoticeCrawler implements CrawlerPort {
      */
     @Override
     public CrawledNotice crawlDetail(String sourceType, String sourceId, NoticeCandidate candidate) {
-        NoticeDetails detail = crawlNoticeDetail(candidate.getDetailUrl());
+        NoticeDetails detail = crawlNoticeDetail(candidate.detailUrl());
 
         log.debug("본문 수집 - articleNo: {}, 본문길이: {}, 이미지수: {}",
-                candidate.getArticleNo(), detail.bodyText().length(), detail.imageUrls().size());
+                candidate.articleNo(), detail.bodyText().length(), detail.imageUrls().size());
 
         return CrawledNotice.builder()
-                .articleNo(candidate.getArticleNo())
-                .category(candidate.getCategory())
-                .title(candidate.getTitle())
-                .department(candidate.getDepartment())
-                .postedAt(candidate.getPostedAt())
-                .url(candidate.getDetailUrl())
+                .articleNo(candidate.articleNo())
+                .category(candidate.category())
+                .title(candidate.title())
+                .department(candidate.department())
+                .postedAt(candidate.postedAt())
+                .url(candidate.detailUrl())
                 .bodyText(detail.bodyText())
                 .imageUrls(detail.imageUrls())
                 .sourceType(sourceType)

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawling/model/NoticeDetails.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawling/model/NoticeDetails.java
@@ -2,5 +2,11 @@ package org.cathori.backend.notice.infra.crawling.model;
 
 import java.util.List;
 
+/**
+ * 공지 상세 페이지를 파싱한 결과.
+ *
+ * @param bodyText  본문 텍스트(HTML 태그 제거된 순수 텍스트)
+ * @param imageUrls 본문에 포함된 이미지의 절대 URL 목록(본문 내 등장 순서)
+ */
 public record NoticeDetails(String bodyText, List<String> imageUrls) {
 }

--- a/backend/src/main/java/org/cathori/backend/notice/infra/crawling/model/NoticeRow.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/crawling/model/NoticeRow.java
@@ -1,16 +1,15 @@
 package org.cathori.backend.notice.infra.crawling.model;
 
-/***
- * 공지 목록 페이지에서
+/**
+ * 공지 목록 페이지의 행(row) 하나를 파싱한 결과.
  *
- * @param articleNo
- * @param category
- * @param title
- * @param department
- * @param postedAt
- * @param noticeDetailsUrl
+ * @param articleNo        원본 게시판에서 공지를 식별하는 게시글 번호
+ * @param category         목록에 표시된 분류(칸막이 텍스트), 없으면 null
+ * @param title            공지 제목
+ * @param department       작성 부서/학과명
+ * @param postedAt         원본 사이트에 표시된 게시일 문자열(파싱 전 원본 그대로)
+ * @param noticeDetailsUrl 상세 페이지로 이동하는 절대 URL
  */
-
 public record NoticeRow(
         String articleNo,
         String category,

--- a/backend/src/main/java/org/cathori/backend/notice/infra/summarization/GeminiAiAdapter.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/summarization/GeminiAiAdapter.java
@@ -1,6 +1,7 @@
 package org.cathori.backend.notice.infra.summarization;
 
 import org.cathori.backend.notice.application.AiPort;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;

--- a/backend/src/main/java/org/cathori/backend/notice/infra/summarization/NoticeSummaryUpdater.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/summarization/NoticeSummaryUpdater.java
@@ -1,6 +1,7 @@
 package org.cathori.backend.notice.infra.summarization;
 
 import lombok.RequiredArgsConstructor;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.springframework.stereotype.Component;

--- a/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
@@ -113,17 +113,17 @@ public class Notice {
 
     public static Notice from(CrawledNotice crawled) {
         Notice notice = new Notice();
-        notice.articleNo = crawled.getArticleNo();
-        notice.sourceType = crawled.getSourceType();
-        notice.sourceId = crawled.getSourceId();
-        notice.category = crawled.getCategory();
-        notice.title = crawled.getTitle();
-        notice.department = crawled.getDepartment();
-        notice.postedAt = LocalDate.parse(crawled.getPostedAt());
-        notice.url = crawled.getUrl();
-        notice.bodyText = crawled.getBodyText();
+        notice.articleNo = crawled.articleNo();
+        notice.sourceType = crawled.sourceType();
+        notice.sourceId = crawled.sourceId();
+        notice.category = crawled.category();
+        notice.title = crawled.title();
+        notice.department = crawled.department();
+        notice.postedAt = LocalDate.parse(crawled.postedAt());
+        notice.url = crawled.url();
+        notice.bodyText = crawled.bodyText();
         try {
-            notice.imageUrlsJson = MAPPER.writeValueAsString(crawled.getImageUrls());
+            notice.imageUrlsJson = MAPPER.writeValueAsString(crawled.imageUrls());
         } catch (JacksonException e) {
             notice.imageUrlsJson = "[]";
         }

--- a/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cathori.backend.notice.application.crawling.CrawledNotice;
-import org.cathori.backend.notice.infra.summarization.AiSummaryResult;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeDetailIntegrationTest.java
@@ -4,7 +4,7 @@ import org.cathori.backend.IntegrationTestBase;
 import org.cathori.backend.bookmark.domain.Bookmark;
 import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
 import org.cathori.backend.notice.application.crawling.CrawledNotice;
-import org.cathori.backend.notice.infra.summarization.AiSummaryResult;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.security.JwtUtil;

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeFeedIntegrationTest.java
@@ -4,7 +4,7 @@ import org.cathori.backend.IntegrationTestBase;
 import org.cathori.backend.bookmark.domain.Bookmark;
 import org.cathori.backend.bookmark.infra.BookmarkJpaRepository;
 import org.cathori.backend.notice.application.crawling.CrawledNotice;
-import org.cathori.backend.notice.infra.summarization.AiSummaryResult;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.security.JwtUtil;

--- a/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/api/NoticeSearchIntegrationTest.java
@@ -2,7 +2,7 @@ package org.cathori.backend.notice.api;
 
 import org.cathori.backend.IntegrationTestBase;
 import org.cathori.backend.notice.application.crawling.CrawledNotice;
-import org.cathori.backend.notice.infra.summarization.AiSummaryResult;
+import org.cathori.backend.notice.application.AiSummaryResult;
 import org.cathori.backend.notice.model.Notice;
 import org.cathori.backend.notice.model.NoticeRepository;
 import org.cathori.backend.security.JwtUtil;


### PR DESCRIPTION
## 🔧 리팩터링 대상

1. `notice/application/crawling` — `CrawledNotice`, `NoticeCandidate`
2. `notice/application/query` — `NoticeRow`, `NoticeSearchRow`
3. `notice/infra/crawling/model` — `NoticeRow`, `NoticeDetails` (주석)
4. `notice/application` — `AiPort` ↔ `AiSummaryResult`

문제였던 지점:
- `CrawledNotice`/`NoticeCandidate`만 `@Getter @Builder` 클래스라, 같은 패키지의 다른 데이터 모델(`NoticeRow`, `NoticeDetails` 등)이 전부 `record`인 것과 스타일이 어긋났음
- `application/query`의 `NoticeRow`/`NoticeSearchRow`는 JDBC `ResultSet`의 "row" 개념을 그대로 드러내는 이름이라 애플리케이션 계층에 부적합
- `AiPort`(application)가 `AiSummaryResult`를 `infra.summarization` 패키지에서 직접 import해서 반환 타입으로 사용 — "Port 인터페이스 통해 접근" 의존 방향 규칙 위반

## 📐 As-Is → To-Be

**As-Is**
- `CrawledNotice`, `NoticeCandidate`: `@Getter @Builder` 클래스, 필드별 설명 주석 없음
- `NoticeRow`, `NoticeSearchRow`(application/query): DB row를 뜻하는 이름 그대로 사용
- `AiPort` → `infra.summarization.AiSummaryResult` 직접 참조

**To-Be**
- `CrawledNotice`, `NoticeCandidate`(→`NewNoticeCandidate`)를 `record` + `@Builder`로 전환, 다른 record 데이터 모델과 동일하게 `@param` Javadoc 정리
- `NoticeRow` → `NoticeQueryResult`, `NoticeSearchRow` → `NoticeSearchQueryResult`로 리네임해 인프라 용어 제거
- `AiSummaryResult`를 `application` 패키지로 이동, `AiPort`는 이제 application 내부 타입만 참조

## 🎯 결정 사항


## ⚠️ 동작 불변 검증

- [x] 기존 테스트가 모두 그대로 통과하는가 (수정 없이) — 필드 구성은 그대로 두고 타입명/접근자만 변경, `compileJava`/`compileTestJava`로 컴파일 확인
- [x] 테스트 코드를 수정했다면, "동작 변경"이 아니라 "구조 변경으로 인한 갱신"인지 확인 — import 경로 변경만 있고 로직/기댓값 변경 없음

## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| `BookmarkedNoticeQuery`가 `Notice+목적+Query` 어순 패턴과 다름 (`목적+Notice+Query`) | 동작에 영향 없는 사소한 어순 차이로 판단 | 다음 네이밍 정리 작업 시 |
| `NoticeQueryResult`/`NoticeSearchQueryResult` Javadoc에 "DB 조회 row" 표현이 남아있음 | 클래스명만 우선 정리, 문서 표현 갱신은 후속으로 미룸 | 다음 주석 정리 작업 시 |

## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| bookmark, notification, user 도메인 통합 테스트 | `CrawledNotice`/`AiSummaryResult` import 경로 변경으로 인한 수정 | 없음 (컴파일 확인 완료) |

## 🔗 연관 이슈
closes #191