### PR TITLE
fix(notification): 미읽음 알림 기준으로 아이콘 상태 갱신

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notification/api/NotificationController.java
+++ b/backend/src/main/java/org/cathori/backend/notification/api/NotificationController.java
@@ -2,6 +2,7 @@ package org.cathori.backend.notification.api;
 
 import lombok.RequiredArgsConstructor;
 import org.cathori.backend.notification.api.dto.NotificationListResponse;
+import org.cathori.backend.notification.api.dto.UnreadNotificationStatusResponse;
 import org.cathori.backend.notification.application.inbox.NotificationService;
 import org.cathori.backend.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,14 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
     private final NotificationService notificationService;
+
+    @GetMapping("/unread-exists")
+    public ResponseEntity<UnreadNotificationStatusResponse> hasUnread(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        boolean hasUnread = notificationService.hasUnreadNotifications(userDetails.getUserId());
+        return ResponseEntity.ok(new UnreadNotificationStatusResponse(hasUnread));
+    }
 
     @GetMapping
     public ResponseEntity<NotificationListResponse> list(

--- a/backend/src/main/java/org/cathori/backend/notification/api/dto/UnreadNotificationStatusResponse.java
+++ b/backend/src/main/java/org/cathori/backend/notification/api/dto/UnreadNotificationStatusResponse.java
@@ -1,0 +1,5 @@
+package org.cathori.backend.notification.api.dto;
+
+public record UnreadNotificationStatusResponse(
+        boolean hasUnread
+) {}

--- a/backend/src/main/java/org/cathori/backend/notification/application/inbox/NotificationService.java
+++ b/backend/src/main/java/org/cathori/backend/notification/application/inbox/NotificationService.java
@@ -43,6 +43,10 @@ public class NotificationService {
         return new NotificationListResponse(items, nextCursor, hasNext);
     }
 
+    public boolean hasUnreadNotifications(Long userId) {
+        return alertHistoryRepository.existsUnreadSuccessByUserId(userId);
+    }
+
     @Transactional
     public void markRead(Long userId, Long alertHistoryId) {
         AlertHistory alertHistory = alertHistoryRepository.findByIdAndUserId(alertHistoryId, userId)

--- a/backend/src/main/java/org/cathori/backend/notification/domain/AlertHistoryRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notification/domain/AlertHistoryRepository.java
@@ -23,6 +23,8 @@ public interface AlertHistoryRepository {
 
     Optional<AlertHistory> findByIdAndUserId(Long id, Long userId);
 
+    boolean existsUnreadSuccessByUserId(Long userId);
+
     void delete(AlertHistory alertHistory);
 
     void deleteByUserId(Long userId);

--- a/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryJpaRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryJpaRepository.java
@@ -34,5 +34,7 @@ public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, L
 
     Optional<AlertHistory> findByIdAndUserId(Long id, Long userId);
 
+    boolean existsByUserIdAndAlarmStatusAndIsReadFalse(Long userId, String alarmStatus);
+
     void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryRepositoryImpl.java
+++ b/backend/src/main/java/org/cathori/backend/notification/infra/AlertHistoryRepositoryImpl.java
@@ -65,6 +65,11 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     }
 
     @Override
+    public boolean existsUnreadSuccessByUserId(Long userId) {
+        return jpaRepository.existsByUserIdAndAlarmStatusAndIsReadFalse(userId, "SUCCESS");
+    }
+
+    @Override
     public void delete(AlertHistory alertHistory) {
         jpaRepository.delete(alertHistory);
     }

--- a/backend/src/test/java/org/cathori/backend/notification/api/NotificationIntegrationTest.java
+++ b/backend/src/test/java/org/cathori/backend/notification/api/NotificationIntegrationTest.java
@@ -118,6 +118,37 @@ class NotificationIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    @DisplayName("NI-3-1: GET /api/notifications/unread-exists → 미읽음 성공 알림 존재 시 true")
+    void hasUnread_withUnreadSuccessAlert_returnsTrue() throws Exception {
+        Notice notice = saveNotice();
+        insertAlertHistory(userAId, notice.getId(), "SUCCESS", null);
+
+        mockMvc.perform(get("/api/notifications/unread-exists")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasUnread").value(true));
+    }
+
+    @Test
+    @DisplayName("NI-3-2: GET /api/notifications/unread-exists → 모두 읽음이면 false")
+    void hasUnread_withOnlyReadAlerts_returnsFalse() throws Exception {
+        Notice notice = saveNotice();
+        insertAlertHistory(userAId, notice.getId(), "SUCCESS", null, true);
+
+        mockMvc.perform(get("/api/notifications/unread-exists")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasUnread").value(false));
+    }
+
+    @Test
+    @DisplayName("NI-3-3: GET /api/notifications/unread-exists JWT 없음 → 401")
+    void hasUnread_withoutJwt_returns401() throws Exception {
+        mockMvc.perform(get("/api/notifications/unread-exists"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     @DisplayName("NI-4: PATCH /{id}/read → 204 No Content")
     void markRead_validAlert_returns204() throws Exception {
         Notice notice = saveNotice();
@@ -235,9 +266,13 @@ class NotificationIntegrationTest extends IntegrationTestBase {
     }
 
     private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag) {
+        return insertAlertHistory(userId, noticeId, status, matchedTag, false);
+    }
+
+    private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag, boolean isRead) {
         return jdbcTemplate.queryForObject(
                 "INSERT INTO alert_history (user_id, notice_id, alarm_status, is_read, retry_count, created_at, matched_tag) " +
-                "VALUES (?, ?, ?, false, 0, now(), ?) RETURNING id",
-                Long.class, userId, noticeId, status, matchedTag);
+                "VALUES (?, ?, ?, ?, 0, now(), ?) RETURNING id",
+                Long.class, userId, noticeId, status, isRead, matchedTag);
     }
 }

--- a/backend/src/test/java/org/cathori/backend/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/org/cathori/backend/notification/application/NotificationServiceTest.java
@@ -126,6 +126,32 @@ class NotificationServiceTest extends IntegrationTestBase {
                 .isEqualTo(ZoneOffset.ofHours(9));
     }
 
+    @Test
+    @DisplayName("NS-6-1: 미읽음 SUCCESS 알림 존재 → true")
+    void hasUnreadNotifications_withUnreadSuccessAlert_returnsTrue() {
+        Notice notice = saveNotice("공지");
+        insertAlertHistory(USER_ID, notice.getId(), "SUCCESS", null);
+
+        boolean hasUnread = notificationService.hasUnreadNotifications(USER_ID);
+
+        assertThat(hasUnread).isTrue();
+    }
+
+    @Test
+    @DisplayName("NS-6-2: 읽음/실패/타인 알림만 존재 → false")
+    void hasUnreadNotifications_withoutUnreadSuccessAlert_returnsFalse() {
+        Notice readNotice = saveNotice("읽은 공지");
+        Notice failedNotice = saveNotice("실패 공지");
+        Notice otherNotice = saveNotice("타인 공지");
+        insertAlertHistory(USER_ID, readNotice.getId(), "SUCCESS", null, true);
+        insertAlertHistory(USER_ID, failedNotice.getId(), "FAILED", null);
+        insertAlertHistory(OTHER_USER_ID, otherNotice.getId(), "SUCCESS", null);
+
+        boolean hasUnread = notificationService.hasUnreadNotifications(USER_ID);
+
+        assertThat(hasUnread).isFalse();
+    }
+
     // --- markRead ---
 
     @Test
@@ -219,9 +245,13 @@ class NotificationServiceTest extends IntegrationTestBase {
     }
 
     private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag) {
+        return insertAlertHistory(userId, noticeId, status, matchedTag, false);
+    }
+
+    private Long insertAlertHistory(Long userId, Long noticeId, String status, String matchedTag, boolean isRead) {
         return jdbcTemplate.queryForObject(
                 "INSERT INTO alert_history (user_id, notice_id, alarm_status, is_read, retry_count, created_at, matched_tag) " +
-                "VALUES (?, ?, ?, false, 0, now(), ?) RETURNING id",
-                Long.class, userId, noticeId, status, matchedTag);
+                "VALUES (?, ?, ?, ?, 0, now(), ?) RETURNING id",
+                Long.class, userId, noticeId, status, isRead, matchedTag);
     }
 }

--- a/frontend/app/notification/index.tsx
+++ b/frontend/app/notification/index.tsx
@@ -20,11 +20,13 @@
 import React from 'react';
 import { ActivityIndicator, Alert, FlatList, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter, type Href } from 'expo-router';
 
 import { Colors } from '@/src/constants/colors';
 import {
   NotificationItem,
   useDeleteNotification,
+  useMarkNotificationRead,
   useNotifications,
 } from '@/src/features/notifications';
 import { EmptyState, SubHeader } from '@/src/shared/components';
@@ -32,6 +34,7 @@ import type { NotificationListItem } from '@/src/types/notifications';
 
 export default function NotificationScreen() {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const {
     data,
     isLoading,
@@ -43,6 +46,7 @@ export default function NotificationScreen() {
     isFetchingNextPage,
   } = useNotifications();
   const deleteNotificationMutation = useDeleteNotification();
+  const markNotificationReadMutation = useMarkNotificationRead();
 
   // 커서 페이지네이션 응답(pages)을 단일 목록으로 평탄화
   const notifications = data?.pages.flatMap((page) => page.alerts) ?? [];
@@ -84,6 +88,13 @@ export default function NotificationScreen() {
     );
   };
 
+  const handlePressNotification = (notification: NotificationListItem) => {
+    if (!notification.isRead) {
+      markNotificationReadMutation.mutate(notification.alertHistoryId);
+    }
+    router.push(`/notice/${notification.noticeId}` as Href);
+  };
+
   return (
     <View style={styles.screen}>
       <SubHeader title="알림" />
@@ -106,6 +117,7 @@ export default function NotificationScreen() {
           renderItem={({ item }) => (
             <NotificationItem
               notification={item}
+              onPress={handlePressNotification}
               onDelete={handleDeleteNotification}
               isDeleteDisabled={
                 deleteNotificationMutation.isPending &&

--- a/frontend/src/features/notifications/components/NotificationItem.tsx
+++ b/frontend/src/features/notifications/components/NotificationItem.tsx
@@ -32,12 +32,14 @@ import type { NotificationListItem } from '@/src/types/notifications';
 
 interface NotificationItemProps {
   notification: NotificationListItem;
+  onPress?: (notification: NotificationListItem) => void;
   onDelete?: (notification: NotificationListItem) => void;
   isDeleteDisabled?: boolean;
 }
 
 function NotificationItemComponent({
   notification,
+  onPress,
   onDelete,
   isDeleteDisabled = false,
 }: NotificationItemProps) {
@@ -45,6 +47,10 @@ function NotificationItemComponent({
 
   // 카드 탭 → 공지 상세로 이동 (NoticeCard와 동일 패턴)
   const handlePress = () => {
+    if (onPress) {
+      onPress(notification);
+      return;
+    }
     router.push(`/notice/${notification.noticeId}` as Href);
   };
 

--- a/frontend/src/features/notifications/hooks/index.ts
+++ b/frontend/src/features/notifications/hooks/index.ts
@@ -1,6 +1,7 @@
 export {
   useDeleteNotification,
   useHasNotifications,
+  useMarkNotificationRead,
   useNotifications,
 } from './useNotifications';
 export { usePushNotifications } from './usePushNotifications';

--- a/frontend/src/features/notifications/hooks/useNotifications.ts
+++ b/frontend/src/features/notifications/hooks/useNotifications.ts
@@ -16,11 +16,20 @@ import type { InfiniteData } from '@tanstack/react-query';
 
 import {
   deleteNotification,
+  fetchUnreadNotificationStatus,
   fetchNotifications,
+  markNotificationRead,
 } from '@/src/services/notifications';
 import type { NotificationPage } from '@/src/types/notifications';
 
 interface DeleteNotificationContext {
+  previousNotificationQueries: {
+    queryKey: readonly unknown[];
+    data: InfiniteData<NotificationPage> | undefined;
+  }[];
+}
+
+interface MarkNotificationReadContext {
   previousNotificationQueries: {
     queryKey: readonly unknown[];
     data: InfiniteData<NotificationPage> | undefined;
@@ -53,6 +62,23 @@ function removeNotificationFromPages(
   };
 }
 
+function markNotificationReadInPages(
+  data: InfiniteData<NotificationPage>,
+  alertHistoryId: number,
+): InfiniteData<NotificationPage> {
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      alerts: page.alerts.map((notification) =>
+        notification.alertHistoryId === alertHistoryId
+          ? { ...notification, isRead: true }
+          : notification,
+      ),
+    })),
+  };
+}
+
 export function useNotifications() {
   return useInfiniteQuery<NotificationPage>({
     queryKey: ['notifications'],
@@ -68,9 +94,54 @@ export function useNotifications() {
 
 export function useHasNotifications() {
   return useQuery({
-    queryKey: ['notifications', 'hasAny'],
-    queryFn: () => fetchNotifications({ size: 1 }),
-    select: (page) => page.alerts.length > 0,
+    queryKey: ['notifications', 'hasUnread'],
+    queryFn: fetchUnreadNotificationStatus,
+    select: (status) => status.hasUnread,
+  });
+}
+
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markNotificationRead,
+
+    onMutate: async (alertHistoryId): Promise<MarkNotificationReadContext> => {
+      await queryClient.cancelQueries({ queryKey: ['notifications'] });
+
+      const notificationQueries = queryClient
+        .getQueriesData<unknown>({ queryKey: ['notifications'] })
+        .filter(
+          (query): query is [readonly unknown[], InfiniteData<NotificationPage>] =>
+            isNotificationInfiniteData(query[1]),
+        );
+
+      const previousNotificationQueries = notificationQueries.map(
+        ([queryKey, data]) => ({ queryKey, data }),
+      );
+
+      notificationQueries.forEach(([queryKey, data]) => {
+        if (!data) return;
+        queryClient.setQueryData<InfiniteData<NotificationPage>>(
+          queryKey,
+          markNotificationReadInPages(data, alertHistoryId),
+        );
+      });
+
+      return { previousNotificationQueries };
+    },
+
+    onError: (_error, _alertHistoryId, context) => {
+      if (!context) return;
+
+      context.previousNotificationQueries.forEach(({ queryKey, data }) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
   });
 }
 

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -4,6 +4,10 @@
  * 백엔드 API 명세(정본: personal_docs/api/API_알림이력조회.md):
  *  - GET /api/notifications?cursor={마지막 alert_history.id}&size={개수}
  *    → { alerts, nextCursor, hasNext } (커서 페이지네이션, 최신순)
+ *  - GET /api/notifications/unread-exists
+ *    → { hasUnread } (읽지 않은 알림 존재 여부)
+ *  - PATCH  /api/notifications/{alertHistoryId}/read
+ *    → 204 No Content
  *  - DELETE /api/notifications/{alertHistoryId}
  *    → 204 No Content
  *
@@ -12,7 +16,10 @@
  */
 
 import { fetchNotificationsMock } from '@/src/mocks/notifications';
-import type { NotificationPage } from '@/src/types/notifications';
+import type {
+  NotificationPage,
+  UnreadNotificationStatus,
+} from '@/src/types/notifications';
 
 import apiClient from './api';
 
@@ -49,6 +56,25 @@ export async function fetchNotifications(
   params: FetchNotificationsParams = {},
 ): Promise<NotificationPage> {
   return USE_MOCK ? fetchNotificationsMock(params) : fetchNotificationsReal(params);
+}
+
+/**
+ * 인증 사용자의 미읽음 알림 존재 여부 조회
+ * GET /api/notifications/unread-exists
+ */
+export async function fetchUnreadNotificationStatus(): Promise<UnreadNotificationStatus> {
+  const { data } = await apiClient.get<UnreadNotificationStatus>(
+    '/api/notifications/unread-exists',
+  );
+  return data;
+}
+
+/**
+ * 인증 사용자의 특정 알림 읽음 처리
+ * PATCH /api/notifications/{alertHistoryId}/read
+ */
+export async function markNotificationRead(alertHistoryId: number): Promise<void> {
+  await apiClient.patch(`/api/notifications/${alertHistoryId}/read`);
 }
 
 /**

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -34,3 +34,8 @@ export interface NotificationPage {
   /** 다음 페이지 존재 여부 */
   hasNext: boolean;
 }
+
+/** 인증 사용자의 미읽음 알림 존재 여부 */
+export interface UnreadNotificationStatus {
+  hasUnread: boolean;
+}


### PR DESCRIPTION
## 🐛 버그 현상

사용자가 알림을 읽었더라도, 알림 이력이 하나라도 남아 있으면 헤더 알림 아이콘에 노란 dot이 계속 표시됐다.

기대 동작:
- 읽지 않은 알림이 있으면 노란 dot 표시
- 모든 알림을 읽으면 기본 알림 아이콘 표시

실제 동작:
- 알림 읽음 여부와 무관하게 알림 이력 존재 여부만으로 노란 dot 표시


## 🔍 원인

프론트의 `useHasNotifications()`가 `GET /api/notifications?size=1` 응답의 `alerts.length > 0`만 확인하고 있었다.

즉, 알림의 `isRead` 값을 보지 않고 “알림 존재 여부”만 기준으로 아이콘 상태를 결정했다.

또한 프론트에서 알림 카드 탭 시 백엔드의 읽음 처리 API(`PATCH /api/notifications/{alertHistoryId}/read`)를 호출하지 않고 상세 화면으로만 이동하고 있었다.


## 🔧 해결 방법

- 알림 카드 탭 시 미읽음 알림이면 읽음 처리 API를 호출하도록 수정
  - `PATCH /api/notifications/{alertHistoryId}/read`
- 프론트 알림 목록 캐시에 해당 알림의 `isRead`를 optimistic update로 반영
- 백엔드에 미읽음 알림 존재 여부 조회 API 추가
  - `GET /api/notifications/unread-exists`
  - 응답: `{ "hasUnread": true | false }`
- 헤더 알림 dot 기준을 “알림 존재 여부”에서 “미읽음 알림 존재 여부”로 변경
- 관련 서비스/API 테스트 추가


## ⏳ 미정 사항

없음


## ✅ 체크리스트

- [x] 로컬에서 재현 후 수정 확인했는가
- [x] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가


## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| 알림 API | `GET /api/notifications/unread-exists` 엔드포인트 추가 | 프론트 헤더 dot 상태 조회에서 사용 |
| 알림 목록 화면 | 알림 카드 탭 시 읽음 처리 API 호출 추가 | 미읽음 상태와 헤더 아이콘 상태 연동 확인 |
| 알림 이력 | `SUCCESS` 상태이면서 `isRead=false`인 알림만 미읽음으로 판단 | 실패/대기 알림은 헤더 dot 기준에서 제외 |


## 🔗 연관 이슈

closes #190 