### PR TITLE
chore: Android 개발용 앱과 운영용 앱 설정 분리

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -18,6 +18,7 @@ expo-env.d.ts
 *.key
 *.mobileprovision
 google-services.json
+google-services.dev.json
 GoogleService-Info.plist
 
 # Metro

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,6 +1,8 @@
+const isDev = process.env.APP_VARIANT === "development";
+
 export default {
   expo: {
-    name: "cathori",
+    name: isDev ? "cathori Dev" : "cathori",
     slug: "cathori",
     version: "1.0.0",
     orientation: "portrait",
@@ -27,8 +29,12 @@ export default {
       },
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
-      package: "site.cathori.cathoriapp",
-      googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
+      package: isDev
+          ? "site.cathori.cathoriapp.dev"
+          : "site.cathori.cathoriapp",
+      googleServicesFile: isDev
+          ? "./google-services.dev.json"
+          : process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
       versionCode: 1
     },
     web: {

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -6,7 +6,10 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "APP_VARIANT": "development"
+      }
     },
     "preview": {
       "distribution": "internal",


### PR DESCRIPTION
## 작업 배경
비공개 테스트 앱을 유지하면서 로컬 개발과 FCM 테스트를 진행할 수 있도록 Android 개발용 앱을 분리

## 변경 사항
- 개발용 앱 이름을 `cathori Dev`, 패키지명을 `site.cathori.cathoriapp.dev`로 분리
- 개발용 Firebase 설정 파일 분기
- EAS development 프로필에 `APP_VARIANT` 환경변수 추가

## 테스트
- [x] 개발용 APK 빌드 및 기존 앱과 함께 설치 확인
- [x] Metro 연결 및 로컬 백엔드 API 연동 확인
- [x] FCM 알림 수신 확인

## 관련 이슈
Closes #195 

아직 chore쪽은 PR템플릿없어서 일단 이렇게 작성