### PR TITLE
fix(Notice): 공지 AI 요약 재시도 횟수 제한

### DIFF
--- a/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
+++ b/backend/src/main/java/org/cathori/backend/notice/application/crawling/NoticeService.java
@@ -19,6 +19,8 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class NoticeService {
 
+    private static final int MAX_SUMMARY_RETRY_COUNT = 3;
+
     private final CrawlerPort crawlerPort;
     private final AiPort aiPort;
     private final NoticeRepository noticeRepository;
@@ -69,11 +71,13 @@ public class NoticeService {
     public void retrySummary() {
         List<Notice> notices = noticeRepository.findTop15ForSummary(
                 List.of("PENDING", "FAILED"),
+                MAX_SUMMARY_RETRY_COUNT,
                 PageRequest.of(0, 15)
         );
 
         for (Notice notice : notices) {
             if (notice.getBodyText() == null) continue;
+            noticeSummaryUpdater.recordRetryAttempt(notice.getId());
             try {
                 AiSummaryResult result = aiPort.summarize(notice.getBodyText(), notice.getImageUrls());
                 noticeSummaryUpdater.applyResult(notice.getId(), result);

--- a/backend/src/main/java/org/cathori/backend/notice/infra/summarization/NoticeSummaryUpdater.java
+++ b/backend/src/main/java/org/cathori/backend/notice/infra/summarization/NoticeSummaryUpdater.java
@@ -24,4 +24,10 @@ public class NoticeSummaryUpdater {
         Notice notice = noticeRepository.findById(noticeId).orElseThrow();
         notice.markSummaryFailed();
     }
+
+    @Transactional
+    public void recordRetryAttempt(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow();
+        notice.recordSummaryRetryAttempt();
+    }
 }

--- a/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/Notice.java
@@ -54,6 +54,9 @@ public class Notice {
     @Column(nullable = false, length = 20)
     private String aiSummaryStatus = "PENDING";
 
+    @Column(nullable = false, columnDefinition = "integer default 0")
+    private int aiSummaryRetryCount = 0;
+
     @Column(nullable = false, length = 30)
     private String department;
 
@@ -109,6 +112,10 @@ public class Notice {
 
     public void markSummaryFailed() {
         this.aiSummaryStatus = "FAILED";
+    }
+
+    public void recordSummaryRetryAttempt() {
+        this.aiSummaryRetryCount++;
     }
 
     public static Notice from(CrawledNotice crawled) {

--- a/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
+++ b/backend/src/main/java/org/cathori/backend/notice/model/NoticeRepository.java
@@ -29,8 +29,11 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
                                         @Param("sourceId") String sourceId,
                                         @Param("articleNos") Collection<String> articleNos);
 
-    @Query("SELECT n FROM Notice n WHERE n.aiSummaryStatus IN :statuses ORDER BY n.id ASC")
-    List<Notice> findTop15ForSummary(@Param("statuses") List<String> statuses, Pageable pageable);
+    @Query("SELECT n FROM Notice n WHERE n.aiSummaryStatus IN :statuses " +
+            "AND n.aiSummaryRetryCount < :maxRetryCount ORDER BY n.id ASC")
+    List<Notice> findTop15ForSummary(@Param("statuses") List<String> statuses,
+                                      @Param("maxRetryCount") int maxRetryCount,
+                                      Pageable pageable);
 
     List<Notice> findByAlertDispatchedFalse();
 }

--- a/backend/src/test/java/org/cathori/backend/notice/application/crawling/NoticeServiceSummaryRetryTest.java
+++ b/backend/src/test/java/org/cathori/backend/notice/application/crawling/NoticeServiceSummaryRetryTest.java
@@ -1,0 +1,124 @@
+package org.cathori.backend.notice.application.crawling;
+
+import org.cathori.backend.IntegrationTestBase;
+import org.cathori.backend.notice.application.AiPort;
+import org.cathori.backend.notice.application.AiSummaryResult;
+import org.cathori.backend.notice.model.Notice;
+import org.cathori.backend.notice.model.NoticeRepository;
+import org.cathori.backend.user.application.NotificationPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("공지 AI 요약 재시도 통합 테스트")
+class NoticeServiceSummaryRetryTest extends IntegrationTestBase {
+
+    @Autowired
+    NoticeService noticeService;
+
+    @Autowired
+    NoticeRepository noticeRepository;
+
+    @MockitoBean
+    AiPort aiPort;
+
+    @MockitoBean
+    NotificationPort notificationPort;
+
+    @AfterEach
+    void cleanup() {
+        noticeRepository.deleteAll();
+        reset(aiPort);
+    }
+
+    @Test
+    @DisplayName("SR-1: 최초 요약 실패는 재시도 횟수에 포함하지 않는다")
+    void summarize_initialFailure_doesNotIncreaseRetryCount() {
+        Notice notice = savePendingNotice("최초 실패 공지");
+        given(aiPort.summarize(anyString(), anyList()))
+                .willThrow(new RuntimeException("AI 요약 실패"));
+
+        noticeService.summarize(List.of(notice.getId()));
+
+        Notice reloaded = noticeRepository.findById(notice.getId()).orElseThrow();
+        assertThat(reloaded.getAiSummaryStatus()).isEqualTo("FAILED");
+        assertThat(reloaded.getAiSummaryRetryCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("SR-2: 재시도 수행 시 재시도 횟수를 증가시킨다")
+    void retrySummary_success_increasesRetryCount() {
+        Notice notice = saveFailedNotice("재시도 성공 공지");
+        given(aiPort.summarize(anyString(), anyList()))
+                .willReturn(new AiSummaryResult(List.of("요약 문장"), null));
+
+        noticeService.retrySummary();
+
+        Notice reloaded = noticeRepository.findById(notice.getId()).orElseThrow();
+        assertThat(reloaded.getAiSummaryStatus()).isEqualTo("SUCCESS");
+        assertThat(reloaded.getAiSummaryRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("SR-3: 재시도 3회 실패 후에는 재시도 대상에서 제외한다")
+    void retrySummary_failedThreeTimes_excludesFromNextRetry() {
+        Notice notice = saveFailedNotice("재시도 제한 공지");
+        given(aiPort.summarize(anyString(), anyList()))
+                .willThrow(new RuntimeException("AI 요약 실패"));
+
+        noticeService.retrySummary();
+        noticeService.retrySummary();
+        noticeService.retrySummary();
+
+        Notice reloaded = noticeRepository.findById(notice.getId()).orElseThrow();
+        assertThat(reloaded.getAiSummaryStatus()).isEqualTo("FAILED");
+        assertThat(reloaded.getAiSummaryRetryCount()).isEqualTo(3);
+        verify(aiPort, times(3)).summarize(anyString(), anyList());
+
+        clearInvocations(aiPort);
+        noticeService.retrySummary();
+
+        verify(aiPort, never()).summarize(anyString(), anyList());
+    }
+
+    private Notice saveFailedNotice(String title) {
+        Notice notice = Notice.from(crawledNotice(title));
+        notice.markSummaryFailed();
+        return noticeRepository.save(notice);
+    }
+
+    private Notice savePendingNotice(String title) {
+        return noticeRepository.save(Notice.from(crawledNotice(title)));
+    }
+
+    private CrawledNotice crawledNotice(String title) {
+        return CrawledNotice.builder()
+                .articleNo(UUID.randomUUID().toString().replace("-", "").substring(0, 10))
+                .sourceType("MAIN")
+                .sourceId(null)
+                .category("일반")
+                .title(title)
+                .department("테스트학과")
+                .postedAt(LocalDate.now().toString())
+                .url("https://test.catholic.ac.kr/" + title.hashCode())
+                .bodyText("본문")
+                .imageUrls(List.of())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🐛 버그 현상

AI 요약에 실패한 공지가 `PENDING` 또는 `FAILED` 상태로 남아 있으면 `retrySummary()` 스케줄마다 계속 재시도된다.

이미지 URL 접근 불가처럼 실패 원인이 지속되는 경우에도 재시도 횟수 제한이 없어 동일 공지가 무한 재시도 대상에 포함된다.


## 🔍 원인

`Notice`에 AI 요약 재시도 횟수를 저장하는 필드가 없고, `NoticeRepository.findTop15ForSummary()` 조회 조건도 `aiSummaryStatus`만 기준으로 삼고 있었다.

또한 최초 요약 실패와 재시도 실패를 구분하는 카운트 로직이 없어 재시도 상한을 적용할 수 없었다.


## 🔧 해결 방법

`Notice`에 `aiSummaryRetryCount` 필드를 추가했다.

`retrySummary()`에서 실제 재시도를 수행하기 직전에 재시도 횟수를 증가시키고, 재시도 대상 조회 조건에 `aiSummaryRetryCount < 3`을 추가했다.

최초 요약 시도인 `summarize()` 실패 경로에서는 재시도 횟수를 증가시키지 않아, 최초 실패가 재시도로 집계되지 않도록 했다.

3회 재시도 후에도 실패한 공지는 `FAILED` 상태로 유지되며, 이후 재시도 조회 조건에서 제외된다.


## ⏳ 미정 사항

| 보류 항목 | 보류 이유 | 재검토 시점 |
|---|---|---|
| 운영 DB 컬럼 반영 방식 | `Notice` 엔티티 컬럼이 추가되어 운영 DB에 `ai_summary_retry_count` 컬럼 반영 필요 | 배포 전 `JPA_DDL_AUTO` 설정 확인 시 |


## ✅ 체크리스트
- [x] 로컬에서 재현 후 수정 확인했는가
- [x] 회귀 테스트(재발 방지 테스트)를 추가했는가
- [x] 동일 원인으로 인한 다른 버그 가능성을 확인했는가


## 🌐 연관 도메인 영향

| 영향 받는 대상 | 영향 내용 | 추가 확인/대응 필요 사항 |
|---|---|---|
| Notice | AI 요약 재시도 횟수 컬럼 추가 | 운영 DB 컬럼 반영 필요 |
| AI Summary Scheduler | 3회 이상 실패한 공지는 재시도 대상에서 제외 | 스케줄 동작 확인 필요 |


## 🔗 연관 이슈
closes #193