### PR TITLE
chore: cathori 앱 버전 1.0.0->1.0.1로 수정

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -4,7 +4,7 @@ export default {
   expo: {
     name: isDev ? "cathori Dev" : "cathori",
     slug: "cathori",
-    version: "1.0.0",
+    version: "1.0.1",
     orientation: "portrait",
     icon: "./assets/images/cathori-icon.png",
     scheme: "cathori",


### PR DESCRIPTION
## 변경 사항
- app.config.js의 expo.version을 1.0.0 → 1.0.1로 변경
- Android·iOS 신규 빌드에 공통 적용

## 작업 목적
최신 변경 사항을 포함한 앱의 스토어 심사 제출 준비

## 관련 이슈
Closes #189